### PR TITLE
new crate/workspace feature for building cross-platform docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
 name = "node-archive"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,7 +667,6 @@ dependencies = [
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winfolder 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["David Herman <david.herman@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/notion-cli/notion"
 
+[features]
+universal-docs = ["notion-core/universal-docs"]
+
 [[bin]]
 name = "notion"
 path = "src/notion.rs"

--- a/crates/node-archive/Cargo.toml
+++ b/crates/node-archive/Cargo.toml
@@ -3,6 +3,9 @@ name = "node-archive"
 version = "0.1.0"
 authors = ["David Herman <david.herman@gmail.com>"]
 
+[features]
+universal-docs = []
+
 [dependencies]
 flate2 = "1.0"
 tar = "0.4.13"
@@ -12,6 +15,5 @@ tee = "0.1.0"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 progress-read = { path = "../progress-read" }
-
-[target.'cfg(windows)'.dependencies]
 verbatim = "0.1"
+cfg-if = "0.1"

--- a/crates/node-archive/src/lib.rs
+++ b/crates/node-archive/src/lib.rs
@@ -1,19 +1,48 @@
 //! This crate provides types for fetching and unpacking Node distribution
 //! archives, which is a tarball for Unixes and a zipfile for Windows.
+//!
+//! These docs show the top-level exports of this crate as re-exported of
+//! the `tarball` module (due to limitations of rustdoc); the top-level
+//! exports are re-exported from `tarball` on Unix operating systems and
+//! from `zip` on Windows operating systems.
 
-#[cfg(not(windows))]
-extern crate tar;
-#[cfg(not(windows))]
-extern crate flate2;
-#[cfg(not(windows))]
-mod tarball;
+#![cfg_attr(feature = "universal-docs", feature(doc_cfg))]
 
-#[cfg(windows)]
-extern crate zip as zip_rs;
-#[cfg(windows)]
-extern crate verbatim;
-#[cfg(windows)]
-mod zip;
+// This has to be included here before the `tarball` and `zip` modules are added,
+// so that they can use the `define_source_trait!` macro.
+#[macro_use]
+mod source;
+
+#[macro_use]
+extern crate cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "universal-docs")] {
+        extern crate tar;
+        extern crate flate2;
+
+        #[doc(cfg(unix))]
+        mod tarball;
+
+        extern crate zip as zip_rs;
+        extern crate verbatim;
+
+        #[doc(cfg(windows))]
+        mod zip;
+    } else if #[cfg(unix)] {
+        extern crate tar;
+        extern crate flate2;
+
+        mod tarball;
+    } else if #[cfg(windows)] {
+        extern crate zip as zip_rs;
+        extern crate verbatim;
+
+        mod zip;
+    } else {
+        compile_error!("Unsupported OS (expected 'unix' or 'windows').");
+    }
+}
 
 extern crate reqwest;
 extern crate tee;
@@ -29,40 +58,15 @@ pub(crate) struct HttpError {
     code: ::reqwest::StatusCode
 }
 
-use std::io::Read;
-
-#[cfg(windows)]
-use std::io::Seek;
-
-macro_rules! define_source_trait {
-    { $name:ident : $($supertypes:tt)* } => {
-        /// A data source for fetching a Node archive. In Windows, this is required to
-        /// implement `std::io::Seek` (required to be able to traverse the contents of
-        /// zip archives) as well as `std::io::Read`; on other platforms it only needs
-        /// to implement `Read`.
-        pub trait $name: $($supertypes)* {
-            /// Produces the uncompressed size of the archive in bytes, when available.
-            /// In Windows, this is never available and always produces `None`. In other
-            /// platforms, this is always available and always produces a `Some` value.
-            fn uncompressed_size(&self) -> Option<u64>;
-
-            /// Produces the compressed size of the archive in bytes.
-            fn compressed_size(&self) -> u64;
-        }
+cfg_if! {
+    if #[cfg(unix)] {
+        pub use tarball::{Archive, Cached, Remote, Source};
+    } else if #[cfg(windows)] {
+        pub use zip::{Archive, Cached, Remote, Source};
+    } else {
+        compile_error!("Unsupported OS (expected 'unix' or 'windows').");
     }
 }
-
-#[cfg(not(windows))]
-define_source_trait! { Source: Read }
-
-#[cfg(windows)]
-define_source_trait! { Source: Read + Seek }
-
-#[cfg(not(windows))]
-pub use tarball::{Archive, Cached, Remote};
-
-#[cfg(windows)]
-pub use zip::{Archive, Cached, Remote};
 
 impl Source for Box<Source> {
     fn uncompressed_size(&self) -> Option<u64> {

--- a/crates/node-archive/src/source.rs
+++ b/crates/node-archive/src/source.rs
@@ -1,0 +1,19 @@
+//! Defines a helper macro `define_source_trait!`, for both the `tarball` and `zip`
+//! modules to be able to define their own `Source` trait.
+
+macro_rules! define_source_trait {
+    { $name:ident : $($supertypes:tt)* } => {
+        /// A data source for fetching a Node archive. In Unix operating systems, this
+        /// is required to implement `Read`. In Windows, this trait extends both `Read`
+        /// and `Seek` so as to be able to traverse the contents of zip archives.
+        pub trait $name: $($supertypes)* {
+            /// Produces the uncompressed size of the archive in bytes, when available.
+            /// In Windows, this is never available and always produces `None`. In other
+            /// platforms, this is always available and always produces a `Some` value.
+            fn uncompressed_size(&self) -> Option<u64>;
+
+            /// Produces the compressed size of the archive in bytes.
+            fn compressed_size(&self) -> u64;
+        }
+    }
+}

--- a/crates/node-archive/src/tarball.rs
+++ b/crates/node-archive/src/tarball.rs
@@ -1,4 +1,5 @@
-use super::Source;
+//! Provides types and functions for fetching and unpacking a Node installation
+//! tarball in Unix operating systems.
 
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::Path;
@@ -12,6 +13,8 @@ use tar;
 use tee::TeeReader;
 use progress_read::ProgressRead;
 use failure;
+
+define_source_trait! { Source: Read }
 
 /// A data source for a Node tarball that has been cached to the filesystem.
 pub struct Cached {

--- a/crates/node-archive/src/zip.rs
+++ b/crates/node-archive/src/zip.rs
@@ -1,4 +1,5 @@
-use super::Source;
+//! Provides types and functions for fetching and unpacking a Node installation
+//! zip file in Windows operating systems.
 
 use std::io::{self, Read, Seek, SeekFrom, copy};
 use std::path::Path;
@@ -10,6 +11,8 @@ use zip_rs::ZipArchive;
 use verbatim::PathExt;
 
 use failure;
+
+define_source_trait! { Source: Read + Seek }
 
 /// A data source for a Node zip archive that has been cached to the filesystem.
 pub struct Cached {

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -3,6 +3,9 @@ name = "notion-core"
 version = "0.1.0"
 authors = ["David Herman <david.herman@gmail.com>"]
 
+[features]
+universal-docs = []
+
 [dependencies]
 toml = "0.4"
 term_size = "0.3.0"

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["David Herman <david.herman@gmail.com>"]
 
 [features]
-universal-docs = []
+universal-docs = ["node-archive/universal-docs"]
 
 [dependencies]
 toml = "0.4"
@@ -24,7 +24,4 @@ semver = "0.9.0"
 cmdline_words_parser = "0.0.2"
 reqwest = "0.7.3"
 cfg-if = "0.1"
-
-[target.'cfg(windows)'.dependencies]
-zip = "0.2.6"
 winfolder = "0.1"

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -18,7 +18,6 @@ extern crate reqwest;
 extern crate serde_derive;
 extern crate serde;
 
-#[cfg(windows)]
 extern crate winfolder;
 
 pub mod path;

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -1,5 +1,7 @@
 //! The main implementation crate for the core of Notion.
 
+#![cfg_attr(feature = "universal-docs", feature(doc_cfg))]
+
 extern crate indicatif;
 extern crate term_size;
 extern crate toml;

--- a/crates/notion-core/src/path/mod.rs
+++ b/crates/notion-core/src/path/mod.rs
@@ -1,13 +1,15 @@
 //! Provides functions for determining the paths of files and directories
 //! in a standard Notion layout.
 
-#[cfg(not(windows))]
+#[cfg(any(not(windows), feature = "universal-docs"))]
+#[cfg_attr(feature = "universal-docs", doc(cfg(not(windows))))]
 mod unix;
 
 #[cfg(not(windows))]
 pub use self::unix::*;
 
-#[cfg(windows)]
+#[cfg(any(windows, feature = "universal-docs"))]
+#[cfg_attr(feature = "universal-docs", doc(cfg(windows)))]
 mod windows;
 
 #[cfg(windows)]

--- a/crates/notion-core/src/path/mod.rs
+++ b/crates/notion-core/src/path/mod.rs
@@ -1,19 +1,23 @@
 //! Provides functions for determining the paths of files and directories
 //! in a standard Notion layout.
 
-#[cfg(any(not(windows), feature = "universal-docs"))]
-#[cfg_attr(feature = "universal-docs", doc(cfg(not(windows))))]
-mod unix;
+cfg_if! {
+    if #[cfg(feature = "universal-docs")] {
+        #[doc(cfg(unix))]
+        mod unix;
 
-#[cfg(not(windows))]
-pub use self::unix::*;
+        #[doc(cfg(windows))]
+        mod windows;
 
-#[cfg(any(windows, feature = "universal-docs"))]
-#[cfg_attr(feature = "universal-docs", doc(cfg(windows)))]
-mod windows;
-
-#[cfg(windows)]
-pub use self::windows::*;
+        pub use self::unix::*;
+    } else if #[cfg(unix)] {
+        mod unix;
+        pub use self::unix::*;
+    } else {
+        mod windows;
+        pub use self::windows::*;
+    }
+}
 
 pub fn archive_file(version: &str) -> String {
     format!("{}.{}", archive_root_dir(version), archive_extension())

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 
+#[cfg(windows)]
 use winfolder::Folder;
 
 use notion_fail::Fallible;
@@ -43,7 +44,11 @@ cfg_if! {
 //             launchscript.exe                        launchscript_file
 
 fn program_data_root() -> Fallible<PathBuf> {
-    Ok(Folder::ProgramData.path().join("Notion"))
+    #[cfg(windows)]
+    return Ok(Folder::ProgramData.path().join("Notion"));
+
+    #[cfg(not(windows))]
+    unimplemented!()
 }
 
 pub fn cache_dir() -> Fallible<PathBuf> {
@@ -93,7 +98,11 @@ pub fn launchscript_file() -> Fallible<PathBuf> {
 //                 ...
 
 fn program_files_root() -> Fallible<PathBuf> {
-    Ok(Folder::ProgramFilesX64.path().join("Notion"))
+    #[cfg(windows)]
+    return Ok(Folder::ProgramFilesX64.path().join("Notion"));
+
+    #[cfg(not(windows))]
+    unimplemented!()
 }
 
 pub fn bin_dir() -> Fallible<PathBuf> {
@@ -122,7 +131,11 @@ pub fn shim_file(toolname: &str) -> Fallible<PathBuf> {
 //                         catalog.toml                user_catalog_file
 
 fn local_data_root() -> Fallible<PathBuf> {
-    Ok(Folder::LocalAppData.path().join("Notion"))
+    #[cfg(windows)]
+    return Ok(Folder::LocalAppData.path().join("Notion"));
+
+    #[cfg(not(windows))]
+    unimplemented!()
 }
 
 pub fn user_config_file() -> Fallible<PathBuf> {

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -3,8 +3,7 @@
 
 use std::path::PathBuf;
 
-#[cfg(windows)]
-use winfolder::Folder;
+use winfolder;
 
 use notion_fail::Fallible;
 
@@ -45,9 +44,9 @@ cfg_if! {
 
 fn program_data_root() -> Fallible<PathBuf> {
     #[cfg(windows)]
-    return Ok(Folder::ProgramData.path().join("Notion"));
+    return Ok(winfolder::Folder::ProgramData.path().join("Notion"));
 
-    #[cfg(not(windows))]
+    #[cfg(feature = "universal-docs")]
     unimplemented!()
 }
 
@@ -99,9 +98,9 @@ pub fn launchscript_file() -> Fallible<PathBuf> {
 
 fn program_files_root() -> Fallible<PathBuf> {
     #[cfg(windows)]
-    return Ok(Folder::ProgramFilesX64.path().join("Notion"));
+    return Ok(winfolder::Folder::ProgramFilesX64.path().join("Notion"));
 
-    #[cfg(not(windows))]
+    #[cfg(feature = "universal-docs")]
     unimplemented!()
 }
 
@@ -132,9 +131,9 @@ pub fn shim_file(toolname: &str) -> Fallible<PathBuf> {
 
 fn local_data_root() -> Fallible<PathBuf> {
     #[cfg(windows)]
-    return Ok(Folder::LocalAppData.path().join("Notion"));
+    return Ok(winfolder::Folder::LocalAppData.path().join("Notion"));
 
-    #[cfg(not(windows))]
+    #[cfg(feature = "universal-docs")]
     unimplemented!()
 }
 

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -92,7 +92,7 @@ fn command_for(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Command {
     command
 }
 
-#[cfg(not(windows))]
+#[cfg(unix)]
 impl Tool for Script {
     fn new() -> Fallible<Self> {
         unimplemented!()


### PR DESCRIPTION
new crate/workspace feature for building cross-platform docs: `universal-docs`

command for building the docs: `RUSTDOCFLAGS=--document-private-items cargo doc --features universal-docs --all --no-deps`