### PR TITLE
Add spinner to indicate fetching the public node registry

### DIFF
--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -20,6 +20,7 @@ use installer::Installed;
 use installer::node::Installer;
 use serial;
 use config::{Config, NodeConfig};
+use style::progress_spinner;
 
 /// URL of the index of available Node versions on the public Node server.
 const PUBLIC_NODE_VERSION_INDEX: &'static str = "https://nodejs.org/dist/index.json";
@@ -163,9 +164,11 @@ impl NodeCatalog {
 
     /// Resolves the specified semantic versioning requirements from the public distributor (`https://nodejs.org`).
     fn resolve_public(&self, matching: &VersionReq) -> Fallible<Installer> {
+        let spinner = progress_spinner(&format!("Fetching public registry: {}", PUBLIC_NODE_VERSION_INDEX));
         let serial: serial::index::Index =
             reqwest::get(PUBLIC_NODE_VERSION_INDEX).unknown()?
                 .json().unknown()?;
+        spinner.finish_and_clear();
         let index = serial.into_index()?;
         let version = index.entries.iter()
             .rev()

--- a/crates/notion-core/src/style.rs
+++ b/crates/notion-core/src/style.rs
@@ -74,3 +74,17 @@ pub fn progress_bar(action: Action, details: &str, len: u64) -> ProgressBar {
 
     bar
 }
+
+/// Constructs a command-line progress spinner with the specified "message"
+/// string. The spinner is ticked by default every 20ms.
+pub fn progress_spinner(message: &str) -> ProgressBar {
+    // ⠋ Fetching public registry: https://nodejs.org/dist/index.json
+    let spinner = ProgressBar::new_spinner();
+
+    spinner.set_message(message);
+    spinner.set_style(ProgressStyle::default_spinner()
+        .template("{spinner} {msg}"));
+    spinner.enable_steady_tick(20); // tick the spinner every 20ms
+
+    spinner
+}


### PR DESCRIPTION
This adds a progress spinner to give an indication of what is happening when we are fetching the public node registry. Otherwise there is a visible pause with no feedback about what is going on.

This closes #33