### PR TITLE
Introduce `rustfmt`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jobs:
     - stage: test
       rust: stable
       script: |
+        rustup component add rustfmt-preview &&
+        cargo fmt -- --write-mode=diff &&
         cargo test
     - stage: publish
       # Conditional builds: https://docs.travis-ci.com/user/conditional-builds-stages-jobs/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,6 +107,7 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV
+  - rustup component add rustfmt-preview
 
 ## Build Script ##
 
@@ -118,4 +119,5 @@ build: false
 #directly or perform other testing commands. Rust will automatically be placed in the PATH
 # environment variable.
 test_script:
+  - cargo fmt -- --write-mode=diff
   - cargo test --verbose %cargoflags%

--- a/crates/node-archive/src/lib.rs
+++ b/crates/node-archive/src/lib.rs
@@ -39,18 +39,18 @@ cfg_if! {
     }
 }
 
+extern crate progress_read;
 extern crate reqwest;
 extern crate tee;
-extern crate progress_read;
 
+extern crate failure;
 #[macro_use]
 extern crate failure_derive;
-extern crate failure;
 
 #[derive(Fail, Debug)]
 #[fail(display = "HTTP failure ({})", code)]
 pub(crate) struct HttpError {
-    code: ::reqwest::StatusCode
+    code: ::reqwest::StatusCode,
 }
 
 cfg_if! {
@@ -71,7 +71,11 @@ pub trait Archive {
     fn uncompressed_size(&self) -> Option<u64>;
 
     /// Unpacks the zip archive to the specified destination folder.
-    fn unpack(self: Box<Self>, dest: &Path, progress: &mut FnMut(&(), usize)) -> Result<(), failure::Error>;
+    fn unpack(
+        self: Box<Self>,
+        dest: &Path,
+        progress: &mut FnMut(&(), usize),
+    ) -> Result<(), failure::Error>;
 }
 
 cfg_if! {

--- a/crates/notion-core/src/config.rs
+++ b/crates/notion-core/src/config.rs
@@ -14,15 +14,14 @@ use plugin;
 
 /// Lazily loaded Notion configuration settings.
 pub struct LazyConfig {
-    config: LazyCell<Config>
+    config: LazyCell<Config>,
 }
 
 impl LazyConfig {
-
     /// Constructs a new `LazyConfig` (but does not initialize it).
     pub fn new() -> LazyConfig {
         LazyConfig {
-            config: LazyCell::new()
+            config: LazyCell::new(),
         }
     }
 
@@ -34,7 +33,7 @@ impl LazyConfig {
 
 /// Notion configuration settings.
 pub struct Config {
-    pub node: Option<NodeConfig>
+    pub node: Option<NodeConfig>,
 }
 
 /// Notion configuration settings relating to the Node executable.
@@ -42,18 +41,16 @@ pub struct NodeConfig {
     /// The plugin for resolving Node versions, if any.
     pub resolve: Option<plugin::Resolve>,
     /// The plugin for listing the set of Node versions available on the remote server, if any.
-    pub ls_remote: Option<plugin::LsRemote>
+    pub ls_remote: Option<plugin::LsRemote>,
 }
 
 impl Config {
-
     /// Returns the current configuration settings, loaded from the filesystem.
     fn current() -> Fallible<Config> {
         let path = user_config_file()?;
         let src = touch(&path)?.read_into_string().unknown()?;
         src.parse()
     }
-
 }
 
 impl FromStr for Config {

--- a/crates/notion-core/src/env.rs
+++ b/crates/notion-core/src/env.rs
@@ -13,7 +13,7 @@ use path;
 pub fn path_for(version: &str) -> OsString {
     let current = env::var_os("PATH").unwrap_or(OsString::new());
     let shim_dir = &path::shim_dir().unwrap();
-    let split = env::split_paths(&current).filter(|s| { s != shim_dir });
+    let split = env::split_paths(&current).filter(|s| s != shim_dir);
     let mut path_vec: Vec<PathBuf> = Vec::new();
     path_vec.push(path::node_version_bin_dir(version).unwrap());
     path_vec.extend(split);

--- a/crates/notion-core/src/installer/mod.rs
+++ b/crates/notion-core/src/installer/mod.rs
@@ -9,24 +9,21 @@ pub enum Installed {
     /// Indicates that the given tool was already installed.
     Already(Version),
     /// Indicates that the given tool was not already installed but has now been installed.
-    Now(Version)
+    Now(Version),
 }
 
 impl Installed {
-
     /// Consumes this value and produces the installed version.
     pub fn into_version(self) -> Version {
         match self {
-              Installed::Already(version)
-            | Installed::Now(version) => version
+            Installed::Already(version) | Installed::Now(version) => version,
         }
     }
 
     /// Produces a reference to the installed version.
     pub fn version(&self) -> &Version {
         match self {
-              &Installed::Already(ref version)
-            | &Installed::Now(ref version) => version
+            &Installed::Already(ref version) | &Installed::Now(ref version) => version,
         }
     }
 }

--- a/crates/notion-core/src/installer/node.rs
+++ b/crates/notion-core/src/installer/node.rs
@@ -1,6 +1,6 @@
 //! Provides the `Installer` type, which represents a provisioned Node installer.
 
-use std::fs::{File, rename};
+use std::fs::{rename, File};
 use std::string::ToString;
 
 use path;
@@ -17,11 +17,10 @@ const PUBLIC_NODE_SERVER_ROOT: &'static str = "https://nodejs.org/dist/";
 /// A provisioned Node installer.
 pub struct Installer {
     archive: Box<Archive>,
-    version: Version
+    version: Version,
 }
 
 impl Installer {
-
     /// Provision an `Installer` from the public Node distributor (`https://nodejs.org`).
     pub fn public(version: Version) -> Fallible<Self> {
         let archive_file = path::archive_file(&version.to_string());
@@ -40,7 +39,7 @@ impl Installer {
 
         Ok(Installer {
             archive: node_archive::fetch(url, &cache_file).unknown()?,
-            version: version
+            version: version,
         })
     }
 
@@ -48,7 +47,7 @@ impl Installer {
     pub fn cached(version: Version, file: File) -> Fallible<Self> {
         Ok(Installer {
             archive: node_archive::load(file).unknown()?,
-            version: version
+            version: version,
         })
     }
 
@@ -68,15 +67,22 @@ impl Installer {
         let bar = progress_bar(
             Action::Installing,
             &format!("v{}", self.version),
-            self.archive.uncompressed_size().unwrap_or(self.archive.compressed_size()));
+            self.archive
+                .uncompressed_size()
+                .unwrap_or(self.archive.compressed_size()),
+        );
 
-        self.archive.unpack(&dest, &mut |_, read| {
-            bar.inc(read as u64);
-        }).unknown()?;
+        self.archive
+            .unpack(&dest, &mut |_, read| {
+                bar.inc(read as u64);
+            })
+            .unknown()?;
 
         let version_string = self.version.to_string();
-        rename(dest.join(path::archive_root_dir(&version_string)),
-            path::node_version_dir(&version_string)?).unknown()?;
+        rename(
+            dest.join(path::archive_root_dir(&version_string)),
+            path::node_version_dir(&version_string)?,
+        ).unknown()?;
 
         bar.finish_and_clear();
         Ok(Installed::Now(self.version))

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -2,21 +2,21 @@
 
 #![cfg_attr(feature = "universal-docs", feature(doc_cfg))]
 
+extern crate cmdline_words_parser;
+extern crate console;
 extern crate indicatif;
+extern crate lazycell;
+extern crate node_archive;
+extern crate readext;
+extern crate reqwest;
+extern crate semver;
+extern crate serde_json;
 extern crate term_size;
 extern crate toml;
-extern crate node_archive;
-extern crate serde_json;
-extern crate console;
-extern crate lazycell;
-extern crate readext;
-extern crate semver;
-extern crate cmdline_words_parser;
-extern crate reqwest;
 
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde;
 
 extern crate winfolder;
 
@@ -33,9 +33,9 @@ pub mod serial;
 mod plugin;
 mod installer;
 
+extern crate failure;
 #[macro_use]
 extern crate failure_derive;
-extern crate failure;
 #[macro_use]
 extern crate notion_fail;
 

--- a/crates/notion-core/src/manifest.rs
+++ b/crates/notion-core/src/manifest.rs
@@ -17,16 +17,14 @@ pub struct Manifest {
     /// The requested version of Yarn, under the `notion.yarn` key.
     pub yarn: Option<VersionReq>,
     /// The `dependencies` section.
-    pub dependencies: HashMap<String, String>
+    pub dependencies: HashMap<String, String>,
 }
 
 impl Manifest {
-
     /// Loads and parses a Node manifest for the project rooted at the specified path.
     pub fn for_dir(project_root: &Path) -> Fallible<Option<Manifest>> {
         let file = File::open(project_root.join("package.json")).unknown()?;
         let serial: serial::manifest::Manifest = serde_json::de::from_reader(file).unknown()?;
         serial.into_manifest()
     }
-
 }

--- a/crates/notion-core/src/plugin.rs
+++ b/crates/notion-core/src/plugin.rs
@@ -7,7 +7,7 @@ use std::ffi::OsString;
 use serial;
 use installer::node::Installer;
 
-use notion_fail::{Fallible, FailExt, ResultExt};
+use notion_fail::{FailExt, Fallible, ResultExt};
 use semver::{Version, VersionReq};
 use serde_json;
 use cmdline_words_parser::StrExt;
@@ -20,24 +20,21 @@ pub enum Resolve {
 
     /// Resolves a Node version by passing it to an executable and
     /// receiving the resolution in the process's stdout stream.
-    Bin(String)
+    Bin(String),
 }
 
 #[derive(Fail, Debug)]
 #[fail(display = "Invalid plugin command: '{}'", command)]
 pub struct InvalidCommandError {
-    command: String
+    command: String,
 }
 
 impl Resolve {
-
     /// Performs resolution of a Node version based on the given semantic
     /// versioning requirements.
     pub fn resolve(&self, _matching: &VersionReq) -> Fallible<Installer> {
         match self {
-            &Resolve::Url(_) => {
-                unimplemented!()
-            }
+            &Resolve::Url(_) => unimplemented!(),
 
             &Resolve::Bin(ref bin) => {
                 let mut trimmed = bin.trim().to_string();
@@ -45,26 +42,29 @@ impl Resolve {
                 let cmd = if let Some(word) = words.next() {
                     word
                 } else {
-                    throw!(InvalidCommandError {
-                        command: String::from(bin.trim())
-                    }.unknown());
+                    throw!(
+                        InvalidCommandError {
+                            command: String::from(bin.trim()),
+                        }.unknown()
+                    );
                 };
-                let args: Vec<OsString> = words.map(|s| {
-                    let mut os = OsString::new();
-                    os.push(s);
-                    os
-                }).collect();
+                let args: Vec<OsString> = words
+                    .map(|s| {
+                        let mut os = OsString::new();
+                        os.push(s);
+                        os
+                    })
+                    .collect();
                 let child = Command::new(cmd)
                     .args(&args)
                     .stdin(Stdio::null())
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())
-                    .spawn().unknown()?;
+                    .spawn()
+                    .unknown()?;
                 let response = ResolveResponse::from_reader(child.stdout.unwrap())?;
                 match response {
-                    ResolveResponse::Url { version, url } => {
-                        Installer::remote(version, &url)
-                    }
+                    ResolveResponse::Url { version, url } => Installer::remote(version, &url),
                     ResolveResponse::Stream { version: _version } => {
                         unimplemented!("bin plugin produced a stream")
                     }
@@ -83,21 +83,19 @@ pub enum ResolveResponse {
 
     /// A plugin response indicating that the Node installer for the resolved version
     /// is being delivered via the stderr stream of the plugin process.
-    Stream { version: Version }
+    Stream { version: Version },
 }
 
 impl ResolveResponse {
-
     /// Reads and parses a response from a Node version resolution plugin.
     pub fn from_reader<R: Read>(reader: R) -> Fallible<Self> {
         let serial: serial::plugin::ResolveResponse = serde_json::from_reader(reader).unknown()?;
         Ok(serial.into_resolve_response()?)
     }
-
 }
 
 /// A plugin listing the available versions of Node.
 pub enum LsRemote {
     Url(String),
-    Bin(String)
+    Bin(String),
 }

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -14,7 +14,7 @@ fn is_node_root(dir: &Path) -> bool {
 }
 
 fn is_node_modules(dir: &Path) -> bool {
-   dir.file_name() == Some(OsStr::new("node_modules"))
+    dir.file_name() == Some(OsStr::new("node_modules"))
 }
 
 fn is_dependency(dir: &Path) -> bool {
@@ -27,11 +27,10 @@ fn is_project_root(dir: &Path) -> bool {
 
 /// A Node project tree in the filesystem.
 pub struct Project {
-    manifest: Manifest
+    manifest: Manifest,
 }
 
 impl Project {
-
     /// Returns the Node project containing the current working directory,
     /// if any.
     pub fn for_current_dir() -> Fallible<Option<Project>> {
@@ -40,18 +39,20 @@ impl Project {
         while !is_project_root(dir) {
             dir = match dir.parent() {
                 Some(parent) => parent,
-                None => { return Ok(None); }
+                None => {
+                    return Ok(None);
+                }
             }
         }
 
         let manifest = match Manifest::for_dir(&dir)? {
             Some(manifest) => manifest,
-            None => { return Ok(None); }
+            None => {
+                return Ok(None);
+            }
         };
 
-        Ok(Some(Project {
-            manifest: manifest
-        }))
+        Ok(Some(Project { manifest: manifest }))
     }
 
     /// Returns the project manifest (`package.json`) for this project.

--- a/crates/notion-core/src/serial/catalog.rs
+++ b/crates/notion-core/src/serial/catalog.rs
@@ -7,26 +7,26 @@ use std::default::Default;
 
 use notion_fail::{Fallible, ResultExt};
 
-use semver::{Version, SemVerError};
+use semver::{SemVerError, Version};
 
 #[derive(Serialize, Deserialize)]
 pub struct Catalog {
     #[serde(default)]
-    node: NodeCatalog
+    node: NodeCatalog,
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename = "node")]
 pub struct NodeCatalog {
     activated: Option<String>,
-    versions: Vec<String>
+    versions: Vec<String>,
 }
 
 impl Default for NodeCatalog {
     fn default() -> Self {
         NodeCatalog {
             activated: None,
-            versions: vec![]
+            versions: vec![],
         }
     }
 }
@@ -34,7 +34,7 @@ impl Default for NodeCatalog {
 impl Catalog {
     pub fn into_catalog(self) -> Fallible<catalog::Catalog> {
         Ok(catalog::Catalog {
-            node: self.node.into_node_catalog().unknown()?
+            node: self.node.into_node_catalog().unknown()?,
         })
     }
 }
@@ -43,34 +43,33 @@ impl NodeCatalog {
     fn into_node_catalog(self) -> Fallible<catalog::NodeCatalog> {
         let activated = match self.activated {
             Some(v) => Some(Version::parse(&v[..]).unknown()?),
-            None => None
+            None => None,
         };
 
-        let versions: Result<Vec<Version>, SemVerError> = self.versions.into_iter().map(|s| {
-            Ok(Version::parse(&s[..])?)
-        }).collect();
+        let versions: Result<Vec<Version>, SemVerError> = self.versions
+            .into_iter()
+            .map(|s| Ok(Version::parse(&s[..])?))
+            .collect();
 
         Ok(catalog::NodeCatalog {
             activated: activated,
-            versions: BTreeSet::from_iter(versions.unknown()?)
+            versions: BTreeSet::from_iter(versions.unknown()?),
         })
     }
 }
 
 impl catalog::Catalog {
-
     pub fn to_serial(&self) -> Catalog {
         Catalog {
-            node: self.node.to_serial()
+            node: self.node.to_serial(),
         }
     }
-
 }
 impl catalog::NodeCatalog {
     fn to_serial(&self) -> NodeCatalog {
         NodeCatalog {
             activated: self.activated.clone().map(|v| v.to_string()),
-            versions: self.versions.iter().map(|v| v.to_string()).collect()
+            versions: self.versions.iter().map(|v| v.to_string()).collect(),
         }
     }
 }

--- a/crates/notion-core/src/serial/config.rs
+++ b/crates/notion-core/src/serial/config.rs
@@ -6,7 +6,7 @@ use notion_fail::Fallible;
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
-    pub node: Option<NodeConfig>
+    pub node: Option<NodeConfig>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -15,7 +15,7 @@ pub struct NodeConfig {
     pub resolve: Option<Plugin>,
 
     #[serde(rename = "ls-remote")]
-    pub ls_remote: Option<Plugin>
+    pub ls_remote: Option<Plugin>,
 }
 
 impl Config {
@@ -25,7 +25,7 @@ impl Config {
                 Some(n.into_node_config()?)
             } else {
                 None
-            }
+            },
         })
     }
 }
@@ -42,7 +42,7 @@ impl NodeConfig {
                 Some(p.into_ls_remote()?)
             } else {
                 None
-            }
+            },
         })
     }
 }

--- a/crates/notion-core/src/serial/index.rs
+++ b/crates/notion-core/src/serial/index.rs
@@ -1,6 +1,6 @@
 use super::super::catalog;
 
-use std::collections::{HashSet, BTreeMap};
+use std::collections::{BTreeMap, HashSet};
 use std::iter::FromIterator;
 
 use semver::Version;
@@ -12,7 +12,7 @@ pub struct Index(Vec<Entry>);
 #[derive(Serialize, Deserialize)]
 pub struct Entry {
     pub version: String,
-    pub files: Vec<String>
+    pub files: Vec<String>,
 }
 
 impl Index {
@@ -20,7 +20,7 @@ impl Index {
         let mut entries = BTreeMap::new();
         for entry in self.0 {
             let data = catalog::VersionData {
-                files: HashSet::from_iter(entry.files.into_iter())
+                files: HashSet::from_iter(entry.files.into_iter()),
             };
             let mut version = &entry.version[..];
             version = version.trim();

--- a/crates/notion-core/src/serial/manifest.rs
+++ b/crates/notion-core/src/serial/manifest.rs
@@ -19,13 +19,13 @@ pub struct Manifest {
     #[serde(rename = "devDependencies")]
     pub dev_dependencies: HashMap<String, String>,
 
-    pub notion: Option<NotionManifest>
+    pub notion: Option<NotionManifest>,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct NotionManifest {
     pub node: String,
-    pub yarn: Option<String>
+    pub yarn: Option<String>,
 }
 
 impl Manifest {
@@ -38,7 +38,7 @@ impl Manifest {
                 } else {
                     None
                 },
-                dependencies: self.dependencies
+                dependencies: self.dependencies,
             }));
         }
 

--- a/crates/notion-core/src/serial/mod.rs
+++ b/crates/notion-core/src/serial/mod.rs
@@ -8,7 +8,7 @@ pub mod index;
 pub mod version;
 
 use std::path::Path;
-use std::fs::{File, create_dir_all};
+use std::fs::{create_dir_all, File};
 
 use notion_fail::{Fallible, ResultExt};
 

--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -3,10 +3,12 @@ use notion_fail::{Fallible, ResultExt};
 
 pub fn parse_requirements(src: &str) -> Fallible<VersionReq> {
     let src = src.trim();
-    Ok(if src.len() > 0 && src.chars().next().unwrap().is_digit(10) {
-        let defaulted = format!("={}", src);
-        VersionReq::parse(&defaulted).unknown()?
-    } else {
-        VersionReq::parse(src).unknown()?
-    })
+    Ok(
+        if src.len() > 0 && src.chars().next().unwrap().is_digit(10) {
+            let defaulted = format!("={}", src);
+            VersionReq::parse(&defaulted).unknown()?
+        } else {
+            VersionReq::parse(src).unknown()?
+        },
+    )
 }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -20,17 +20,16 @@ use semver::{Version, VersionReq};
 pub struct Session {
     config: LazyConfig,
     catalog: LazyCatalog,
-    project: Option<Project>
+    project: Option<Project>,
 }
 
 impl Session {
-
     /// Constructs a new `Session`.
     pub fn new() -> Fallible<Session> {
         Ok(Session {
             config: LazyConfig::new(),
             catalog: LazyCatalog::new(),
-            project: Project::for_current_dir()?
+            project: Project::for_current_dir()?,
         })
     }
 

--- a/crates/notion-core/src/style.rs
+++ b/crates/notion-core/src/style.rs
@@ -25,15 +25,21 @@ pub fn display_unknown_error() {
     eprintln!("Notion is still a pre-alpha project, so we expect to run into some bugs,");
     eprintln!("but we'd love to hear about them so we can fix them!");
     eprintln!();
-    eprintln!("Please feel free to reach out to us at {} on Twitter or file an issue at:", style("@notionjs").cyan().bold());
+    eprintln!(
+        "Please feel free to reach out to us at {} on Twitter or file an issue at:",
+        style("@notionjs").cyan().bold()
+    );
     eprintln!();
-    eprintln!("    {}", style("https://github.com/notion-cli/notion/issues").bold());
+    eprintln!(
+        "    {}",
+        style("https://github.com/notion-cli/notion/issues").bold()
+    );
     eprintln!();
 }
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
 pub enum Action {
-    Installing
+    Installing,
 }
 
 impl Action {
@@ -43,7 +49,7 @@ impl Action {
 impl Display for Action {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         let s = match self {
-            &Action::Installing => "Installing"
+            &Action::Installing => "Installing",
         };
         f.write_str(s)
     }
@@ -65,10 +71,20 @@ pub fn progress_bar(action: Action, details: &str, len: u64) -> ProgressBar {
 
     let bar = ProgressBar::new(len);
 
-    bar.set_message(&format!("{: >width$} {}", style(action.to_string()).green().bold(), details, width = Action::MAX_WIDTH));
-    bar.set_style(ProgressStyle::default_bar()
-        .template(&format!("{{msg}}  [{{bar:{}.cyan/blue}}] {{percent:>3}}%", bar_width))
-        .progress_chars("=> "));
+    bar.set_message(&format!(
+        "{: >width$} {}",
+        style(action.to_string()).green().bold(),
+        details,
+        width = Action::MAX_WIDTH
+    ));
+    bar.set_style(
+        ProgressStyle::default_bar()
+            .template(&format!(
+                "{{msg}}  [{{bar:{}.cyan/blue}}] {{percent:>3}}%",
+                bar_width
+            ))
+            .progress_chars("=> "),
+    );
 
     bar
 }
@@ -80,8 +96,7 @@ pub fn progress_spinner(message: &str) -> ProgressBar {
     let spinner = ProgressBar::new_spinner();
 
     spinner.set_message(message);
-    spinner.set_style(ProgressStyle::default_spinner()
-        .template("{spinner} {msg}"));
+    spinner.set_style(ProgressStyle::default_spinner().template("{spinner} {msg}"));
     spinner.enable_steady_tick(20); // tick the spinner every 20ms
 
     spinner

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -2,12 +2,12 @@
 
 use std::env::{args_os, ArgsOs};
 use std::ffi::{OsStr, OsString};
-use std::process::{Command, exit};
+use std::process::{exit, Command};
 use std::path::Path;
 use std::marker::Sized;
 
 use session::Session;
-use notion_fail::{NotionFail, FailExt, Fallible};
+use notion_fail::{FailExt, Fallible, NotionFail};
 use env;
 use style;
 
@@ -82,7 +82,9 @@ impl Tool for Script {
         Script(command)
     }
 
-    fn command(self) -> Command { self.0 }
+    fn command(self) -> Command {
+        self.0
+    }
 }
 
 fn command_for(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Command {
@@ -102,7 +104,9 @@ impl Tool for Script {
         Script(command_for(exe, args, path_var))
     }
 
-    fn command(self) -> Command { self.0 }
+    fn command(self) -> Command {
+        self.0
+    }
 }
 
 impl Tool for Binary {
@@ -114,7 +118,9 @@ impl Tool for Binary {
         Binary(command_for(exe, args, path_var))
     }
 
-    fn command(self) -> Command { self.0 }
+    fn command(self) -> Command {
+        self.0
+    }
 }
 
 #[derive(Fail, Debug)]
@@ -122,10 +128,11 @@ impl Tool for Binary {
 struct NoArg0Error;
 
 fn arg0(args: &mut ArgsOs) -> Fallible<OsString> {
-    let opt = args.next()
-        .and_then(|arg0| Path::new(&arg0)
+    let opt = args.next().and_then(|arg0| {
+        Path::new(&arg0)
             .file_name()
-            .map(|file_name| file_name.to_os_string()));
+            .map(|file_name| file_name.to_os_string())
+    });
     if let Some(file_name) = opt {
         Ok(file_name)
     } else {
@@ -138,8 +145,12 @@ fn arg0(args: &mut ArgsOs) -> Fallible<OsString> {
 struct NoGlobalError;
 
 impl NotionFail for NoGlobalError {
-    fn is_user_friendly(&self) -> bool { true }
-    fn exit_code(&self) -> i32 { 2 }
+    fn is_user_friendly(&self) -> bool {
+        true
+    }
+    fn exit_code(&self) -> i32 {
+        2
+    }
 }
 
 impl Tool for Node {
@@ -160,5 +171,7 @@ impl Tool for Node {
         Node(command_for(exe, args, path_var))
     }
 
-    fn command(self) -> Command { self.0 }
+    fn command(self) -> Command {
+        self.0
+    }
 }

--- a/crates/progress-read/src/lib.rs
+++ b/crates/progress-read/src/lib.rs
@@ -7,11 +7,10 @@ use std::io::{self, Read, Seek, SeekFrom};
 pub struct ProgressRead<R: Read, T, F: FnMut(&T, usize) -> T> {
     source: R,
     accumulator: T,
-    progress: F
+    progress: F,
 }
 
 impl<R: Read, T, F: FnMut(&T, usize) -> T> Read for ProgressRead<R, T, F> {
-
     /// Read some bytes from the underlying reader into the specified buffer,
     /// and report progress to the progress callback. The progress callback is
     /// passed the current value of the accumulator as its first argument and
@@ -27,17 +26,18 @@ impl<R: Read, T, F: FnMut(&T, usize) -> T> Read for ProgressRead<R, T, F> {
         self.accumulator = new_accumulator;
         Ok(len)
     }
-
 }
 
 impl<R: Read, T, F: FnMut(&T, usize) -> T> ProgressRead<R, T, F> {
-
     /// Construct a new progress reader with the specified underlying reader,
     /// initial value for an accumulator, and progress callback.
     pub fn new(source: R, init: T, progress: F) -> ProgressRead<R, T, F> {
-        ProgressRead { source, accumulator: init, progress }
+        ProgressRead {
+            source,
+            accumulator: init,
+            progress,
+        }
     }
-
 }
 
 impl<R: Read + Seek, T, F: FnMut(&T, usize) -> T> Seek for ProgressRead<R, T, F> {

--- a/src/command/help.rs
+++ b/src/command/help.rs
@@ -1,20 +1,19 @@
 use notion_fail::Fallible;
 
-use {Notion, CliParseError};
-use command::{Command, CommandName, Use, Version, Current, Install, Uninstall};
+use {CliParseError, Notion};
+use command::{Command, CommandName, Current, Install, Uninstall, Use, Version};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
-    arg_command: Option<String>
+    arg_command: Option<String>,
 }
 
 pub(crate) enum Help {
     Notion,
-    Command(CommandName)
+    Command(CommandName),
 }
 
 impl Command for Help {
-
     type Args = Args;
 
     const USAGE: &'static str = "
@@ -28,7 +27,9 @@ Options:
     -h, --help     Display this message
 ";
 
-    fn help() -> Self { Help::Command(CommandName::Help) }
+    fn help() -> Self {
+        Help::Command(CommandName::Help)
+    }
 
     fn parse(_: Notion, Args { arg_command }: Args) -> Fallible<Help> {
         Ok(match arg_command {
@@ -39,7 +40,7 @@ Options:
                 } else {
                     throw!(CliParseError {
                         usage: None,
-                        error: format!("no such command: `{}`", command)
+                        error: format!("no such command: `{}`", command),
                     });
                 }
             }
@@ -47,15 +48,18 @@ Options:
     }
 
     fn run(self) -> Fallible<bool> {
-        eprintln!("{}", match self {
-            Help::Notion                          => Notion::USAGE,
-            Help::Command(CommandName::Use)       => Use::USAGE,
-            Help::Command(CommandName::Current)   => Current::USAGE,
-            Help::Command(CommandName::Help)      => Help::USAGE,
-            Help::Command(CommandName::Version)   => Version::USAGE,
-            Help::Command(CommandName::Install)   => Install::USAGE,
-            Help::Command(CommandName::Uninstall) => Uninstall::USAGE
-        });
+        eprintln!(
+            "{}",
+            match self {
+                Help::Notion => Notion::USAGE,
+                Help::Command(CommandName::Use) => Use::USAGE,
+                Help::Command(CommandName::Current) => Current::USAGE,
+                Help::Command(CommandName::Help) => Help::USAGE,
+                Help::Command(CommandName::Version) => Version::USAGE,
+                Help::Command(CommandName::Install) => Install::USAGE,
+                Help::Command(CommandName::Uninstall) => Uninstall::USAGE,
+            }
+        );
         Ok(true)
     }
 }

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -4,17 +4,17 @@ use notion_core::session::Session;
 use notion_core::serial::version::parse_requirements;
 use notion_fail::Fallible;
 
-use ::Notion;
+use Notion;
 use command::{Command, CommandName, Help};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
-    arg_version: String
+    arg_version: String,
 }
 
 pub(crate) enum Install {
     Help,
-    Default(VersionReq)
+    Default(VersionReq),
 }
 
 impl Command for Install {
@@ -31,7 +31,9 @@ Options:
     -h, --help     Display this message
 ";
 
-    fn help() -> Self { Install::Help }
+    fn help() -> Self {
+        Install::Help
+    }
 
     fn parse(_: Notion, Args { arg_version }: Args) -> Fallible<Self> {
         let version = parse_requirements(&arg_version)?;
@@ -40,9 +42,7 @@ Options:
 
     fn run(self) -> Fallible<bool> {
         match self {
-            Install::Help => {
-                Help::Command(CommandName::Install).run()
-            }
+            Install::Help => Help::Command(CommandName::Install).run(),
             Install::Default(version) => {
                 let mut session = Session::new()?;
 

--- a/src/command/uninstall.rs
+++ b/src/command/uninstall.rs
@@ -2,17 +2,17 @@ use notion_core::session::Session;
 use notion_fail::{Fallible, ResultExt};
 use semver::Version;
 
-use ::Notion;
+use Notion;
 use command::{Command, CommandName, Help};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
-    arg_version: String
+    arg_version: String,
 }
 
 pub(crate) enum Uninstall {
     Help,
-    Default(Version)
+    Default(Version),
 }
 
 impl Command for Uninstall {
@@ -29,7 +29,9 @@ Options:
     -h, --help     Display this message
 ";
 
-    fn help() -> Self { Uninstall::Help }
+    fn help() -> Self {
+        Uninstall::Help
+    }
 
     fn parse(_: Notion, Args { arg_version }: Args) -> Fallible<Self> {
         let version = Version::parse(&arg_version).unknown()?;
@@ -38,9 +40,7 @@ Options:
 
     fn run(self) -> Fallible<bool> {
         match self {
-            Uninstall::Help => {
-                Help::Command(CommandName::Uninstall).run()
-            }
+            Uninstall::Help => Help::Command(CommandName::Uninstall).run(),
             Uninstall::Default(version) => {
                 let mut session = Session::new()?;
                 session.catalog_mut()?.uninstall_node(&version)?;
@@ -48,5 +48,4 @@ Options:
             }
         }
     }
-
 }

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -8,7 +8,7 @@ use notion_core::session::Session;
 use notion_core::serial::version::parse_requirements;
 use notion_fail::Fallible;
 
-use ::Notion;
+use Notion;
 use command::{Command, CommandName, Help};
 
 use std::process::exit;
@@ -16,13 +16,13 @@ use std::process::exit;
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
     arg_version: String,
-    flag_global: bool
+    flag_global: bool,
 }
 
 pub(crate) enum Use {
     Help,
     Global(VersionReq),
-    Local(VersionReq)
+    Local(VersionReq),
 }
 
 impl Command for Use {
@@ -40,9 +40,17 @@ Options:
     -g, --global   Activate the toolchain globally
 ";
 
-    fn help() -> Self { Use::Help }
+    fn help() -> Self {
+        Use::Help
+    }
 
-    fn parse(_: Notion, Args { arg_version, flag_global }: Args) -> Fallible<Self> {
+    fn parse(
+        _: Notion,
+        Args {
+            arg_version,
+            flag_global,
+        }: Args,
+    ) -> Fallible<Self> {
         let requirements = parse_requirements(&arg_version)?;
         Ok(if flag_global {
             Use::Global(requirements)

--- a/src/command/version.rs
+++ b/src/command/version.rs
@@ -1,6 +1,6 @@
 use notion_fail::Fallible;
 
-use ::Notion;
+use Notion;
 use command::{Command, CommandName, Help};
 
 #[derive(Debug, Deserialize)]
@@ -8,7 +8,7 @@ pub(crate) struct Args;
 
 pub(crate) enum Version {
     Help,
-    Default
+    Default,
 }
 
 impl Command for Version {
@@ -25,15 +25,17 @@ Options:
     -h, --help     Display this message
 ";
 
-    fn help() -> Self { Version::Help }
+    fn help() -> Self {
+        Version::Help
+    }
 
-    fn parse(_: Notion, _: Args) -> Fallible<Version> { Ok(Version::Default) }
+    fn parse(_: Notion, _: Args) -> Fallible<Version> {
+        Ok(Version::Default)
+    }
 
     fn run(self) -> Fallible<bool> {
         match self {
-            Version::Help => {
-                Help::Command(CommandName::Version).run()
-            }
+            Version::Help => Help::Command(CommandName::Version).run(),
             Version::Default => {
                 println!("{}", ::VERSION);
                 Ok(true)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,12 @@
 use docopt;
 use failure::Context;
-use notion_fail::{NotionFail, NotionError};
+use notion_fail::{NotionError, NotionFail};
 
 #[derive(Fail, Debug)]
 #[fail(display = "{}", error)]
 pub(crate) struct CliParseError {
     pub(crate) usage: Option<String>,
-    pub(crate) error: String
+    pub(crate) error: String,
 }
 
 impl CliParseError {
@@ -14,20 +14,24 @@ impl CliParseError {
         if let &docopt::Error::WithProgramUsage(ref real_error, ref usage) = error {
             CliParseError {
                 usage: Some(usage.clone()),
-                error: real_error.to_string()
+                error: real_error.to_string(),
             }
         } else {
             CliParseError {
                 usage: None,
-                error: error.to_string()
+                error: error.to_string(),
             }
         }
     }
 }
 
 impl NotionFail for CliParseError {
-    fn is_user_friendly(&self) -> bool { true }
-    fn exit_code(&self) -> i32 { 3 }
+    fn is_user_friendly(&self) -> bool {
+        true
+    }
+    fn exit_code(&self) -> i32 {
+        3
+    }
 }
 
 pub(crate) trait DocoptExt {
@@ -40,7 +44,7 @@ impl DocoptExt for docopt::Error {
         match self {
             &docopt::Error::Help => true,
             &docopt::Error::WithProgramUsage(ref error, _) => error.is_help(),
-            _ => false
+            _ => false,
         }
     }
 
@@ -48,7 +52,7 @@ impl DocoptExt for docopt::Error {
         match self {
             &docopt::Error::Version(_) => true,
             &docopt::Error::WithProgramUsage(ref error, _) => error.is_version(),
-            _ => false
+            _ => false,
         }
     }
 }

--- a/src/launchbin.rs
+++ b/src/launchbin.rs
@@ -1,6 +1,6 @@
 extern crate notion_core;
 
-use notion_core::tool::{Tool, Binary};
+use notion_core::tool::{Binary, Tool};
 
 /// The entry point for shims to third-party binary executables.
 pub fn main() {

--- a/src/launchscript.rs
+++ b/src/launchscript.rs
@@ -1,6 +1,6 @@
 extern crate notion_core;
 
-use notion_core::tool::{Tool, Script};
+use notion_core::tool::{Script, Tool};
 
 /// The entry point for shims to third-party scripts.
 pub fn main() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
 extern crate notion_core;
 
-use notion_core::tool::{Tool, Node};
+use notion_core::tool::{Node, Tool};
 
 /// The entry point for the `node` shim.
 pub fn main() {


### PR DESCRIPTION
+ Run `rustfmt` against the code base
+ Add formatting to `.travis.yml`
+ Add formatting to `appveyor.yml`

After this change every CI build will execute `cargo fmt -- --write-mode=diff` command to make sure files are properly formatted.If files aren't formatted appropriately, it will fail and hence the CI build will fail.

By default, `rustfmt` would use Rust Style Guide to format the code. There is [an option to customize
it](https://github.com/rust-lang-nursery/rustfmt#configuring-rustfmt) by creating `.rustfmt.toml` (or `rustfmt.toml`) file.

Useful links:

+ [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt)
+ [Rust Style Guide](https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md)
+ [Add `rustfmt` to Travis CI](http://johannh.me/blog/rustfmt-ci.html)

Apologies for so many changes in one PR.