### PR TITLE
Show a meaningful error message when node version is not found

### DIFF
--- a/crates/node-archive/src/lib.rs
+++ b/crates/node-archive/src/lib.rs
@@ -63,8 +63,8 @@ cfg_if! {
     }
 }
 
-use std::path::Path;
 use std::fs::File;
+use std::path::Path;
 
 pub trait Archive {
     fn compressed_size(&self) -> u64;

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -12,14 +12,14 @@ use readext::ReadExt;
 use reqwest;
 use toml;
 
-use path::{self, user_catalog_file};
-use serial::touch;
-use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
-use semver::{Version, VersionReq};
+use config::{Config, NodeConfig};
 use installer::Installed;
 use installer::node::Installer;
+use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
+use path::{self, user_catalog_file};
+use semver::{Version, VersionReq};
 use serial;
-use config::{Config, NodeConfig};
+use serial::touch;
 use style::progress_spinner;
 
 /// URL of the index of available Node versions on the public Node server.

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -14,7 +14,7 @@ use toml;
 
 use path::{self, user_catalog_file};
 use serial::touch;
-use notion_fail::{FailExt, Fallible, NotionError, ResultExt};
+use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
 use semver::{Version, VersionReq};
 use installer::Installed;
 use installer::node::Installer;
@@ -139,6 +139,14 @@ impl Catalog {
 struct NoNodeVersionFoundError {
     matching: VersionReq,
 }
+impl NotionFail for NoNodeVersionFoundError {
+    fn is_user_friendly(&self) -> bool {
+        true
+    }
+    fn exit_code(&self) -> i32 {
+        100
+    }
+}
 
 impl NodeCatalog {
     /// Tests whether this Node catalog contains the specified Node version.
@@ -178,11 +186,9 @@ impl NodeCatalog {
         if let Some(version) = version {
             Installer::public(version)
         } else {
-            throw!(
-                NoNodeVersionFoundError {
-                    matching: matching.clone(),
-                }.unknown()
-            );
+            throw!(NoNodeVersionFoundError {
+                matching: matching.clone(),
+            });
         }
     }
 

--- a/crates/notion-core/src/config.rs
+++ b/crates/notion-core/src/config.rs
@@ -2,15 +2,15 @@
 
 use std::str::FromStr;
 
-use toml;
 use lazycell::LazyCell;
+use toml;
 
-use path::user_config_file;
 use notion_fail::{Fallible, NotionError, ResultExt};
-use readext::ReadExt;
-use serial::touch;
-use serial;
+use path::user_config_file;
 use plugin;
+use readext::ReadExt;
+use serial;
+use serial::touch;
 
 /// Lazily loaded Notion configuration settings.
 pub struct LazyConfig {

--- a/crates/notion-core/src/installer/node.rs
+++ b/crates/notion-core/src/installer/node.rs
@@ -3,11 +3,11 @@
 use std::fs::{rename, File};
 use std::string::ToString;
 
-use path;
-use node_archive::{self, Archive};
-use style::{progress_bar, Action};
-use catalog::NodeCatalog;
 use super::Installed;
+use catalog::NodeCatalog;
+use node_archive::{self, Archive};
+use path;
+use style::{progress_bar, Action};
 
 use notion_fail::{Fallible, ResultExt};
 use semver::Version;

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -20,18 +20,18 @@ extern crate serde_derive;
 
 extern crate winfolder;
 
-pub mod path;
-pub mod env;
-pub mod config;
-pub mod tool;
-pub mod project;
-pub mod manifest;
 pub mod catalog;
+pub mod config;
+pub mod env;
+mod installer;
+pub mod manifest;
+pub mod path;
+mod plugin;
+pub mod project;
+pub mod serial;
 pub mod session;
 pub mod style;
-pub mod serial;
-mod plugin;
-mod installer;
+pub mod tool;
 
 extern crate failure;
 #[macro_use]

--- a/crates/notion-core/src/manifest.rs
+++ b/crates/notion-core/src/manifest.rs
@@ -1,12 +1,12 @@
 //! Provides the `Manifest` type, which represents a Node manifest file (`package.json`).
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::fs::File;
+use std::path::Path;
 
-use serde_json;
-use semver::VersionReq;
 use notion_fail::{Fallible, ResultExt};
+use semver::VersionReq;
+use serde_json;
 
 use serial;
 

--- a/crates/notion-core/src/plugin.rs
+++ b/crates/notion-core/src/plugin.rs
@@ -1,16 +1,16 @@
 //! Types representing Notion plugins.
 
+use std::ffi::OsString;
 use std::io::Read;
 use std::process::{Command, Stdio};
-use std::ffi::OsString;
 
-use serial;
 use installer::node::Installer;
+use serial;
 
+use cmdline_words_parser::StrExt;
 use notion_fail::{FailExt, Fallible, ResultExt};
 use semver::{Version, VersionReq};
 use serde_json;
-use cmdline_words_parser::StrExt;
 
 /// A Node version resolution plugin.
 pub enum Resolve {

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -1,9 +1,9 @@
 //! Provides the `Project` type, which represents a Node project tree in
 //! the filesystem.
 
-use std::path::Path;
-use std::ffi::OsStr;
 use std::env;
+use std::ffi::OsStr;
+use std::path::Path;
 
 use notion_fail::{Fallible, ResultExt};
 

--- a/crates/notion-core/src/serial/catalog.rs
+++ b/crates/notion-core/src/serial/catalog.rs
@@ -1,9 +1,9 @@
 use super::super::catalog;
 
-use std::string::ToString;
 use std::collections::BTreeSet;
-use std::iter::FromIterator;
 use std::default::Default;
+use std::iter::FromIterator;
+use std::string::ToString;
 
 use notion_fail::{Fallible, ResultExt};
 

--- a/crates/notion-core/src/serial/index.rs
+++ b/crates/notion-core/src/serial/index.rs
@@ -3,8 +3,8 @@ use super::super::catalog;
 use std::collections::{BTreeMap, HashSet};
 use std::iter::FromIterator;
 
-use semver::Version;
 use notion_fail::{Fallible, ResultExt};
+use semver::Version;
 
 #[derive(Serialize, Deserialize)]
 pub struct Index(Vec<Entry>);

--- a/crates/notion-core/src/serial/mod.rs
+++ b/crates/notion-core/src/serial/mod.rs
@@ -1,14 +1,14 @@
 //! Provides utilities for serializing and deserializing file formats.
 
 pub mod catalog;
-pub mod manifest;
 pub mod config;
-pub mod plugin;
 pub mod index;
+pub mod manifest;
+pub mod plugin;
 pub mod version;
 
-use std::path::Path;
 use std::fs::{create_dir_all, File};
+use std::path::Path;
 
 use notion_fail::{Fallible, ResultExt};
 

--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -1,5 +1,5 @@
-use semver::VersionReq;
 use notion_fail::{Fallible, ResultExt};
+use semver::VersionReq;
 
 pub fn parse_requirements(src: &str) -> Fallible<VersionReq> {
     let src = src.trim();

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -2,10 +2,10 @@
 //! execution of a Notion tool, including their configuration, their current
 //! directory, and the state of the local tool catalog.
 
-use config::{Config, LazyConfig};
 use catalog::{Catalog, LazyCatalog};
-use project::Project;
+use config::{Config, LazyConfig};
 use installer::Installed;
+use project::Project;
 
 use notion_fail::Fallible;
 use semver::{Version, VersionReq};

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -2,13 +2,13 @@
 
 use std::env::{args_os, ArgsOs};
 use std::ffi::{OsStr, OsString};
-use std::process::{exit, Command};
-use std::path::Path;
 use std::marker::Sized;
+use std::path::Path;
+use std::process::{exit, Command};
 
-use session::Session;
-use notion_fail::{FailExt, Fallible, NotionFail};
 use env;
+use notion_fail::{FailExt, Fallible, NotionFail};
+use session::Session;
 use style;
 
 /// Represents a command-line tool that Notion shims delegate to.

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -289,7 +289,7 @@ use failure::{Backtrace, Fail};
 macro_rules! throw {
     ($e:expr) => {
         return Err(::std::convert::Into::into($e));
-    }
+    };
 }
 
 /// The failure trait for all Notion errors.

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -218,7 +218,7 @@
 //! # extern crate failure_derive;
 //! # extern crate failure;
 //! # use notion_fail::{NotionFail, Fallible};
-//! // add `unknown()` and `with_context()` extension methosd to Results
+//! // add `unknown()` and `with_context()` extension methods to Results
 //! use notion_fail::ResultExt;
 //! # use std::fmt::Display;
 //!

--- a/src/command/help.rs
+++ b/src/command/help.rs
@@ -1,7 +1,7 @@
 use notion_fail::Fallible;
 
-use {CliParseError, Notion};
 use command::{Command, CommandName, Current, Install, Uninstall, Use, Version};
+use {CliParseError, Notion};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -1,7 +1,7 @@
 use semver::VersionReq;
 
-use notion_core::session::Session;
 use notion_core::serial::version::parse_requirements;
+use notion_core::session::Session;
 use notion_fail::Fallible;
 
 use Notion;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,15 +1,15 @@
+mod current;
+mod help;
 mod install;
 mod uninstall;
-mod current;
 mod use_;
-mod help;
 mod version;
 
+pub(crate) use self::current::Current;
+pub(crate) use self::help::Help;
 pub(crate) use self::install::Install;
 pub(crate) use self::uninstall::Uninstall;
-pub(crate) use self::current::Current;
 pub(crate) use self::use_::Use;
-pub(crate) use self::help::Help;
 pub(crate) use self::version::Version;
 
 use docopt::Docopt;

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -4,8 +4,8 @@
 
 use semver::VersionReq;
 
-use notion_core::session::Session;
 use notion_core::serial::version::parse_requirements;
+use notion_core::session::Session;
 use notion_fail::Fallible;
 
 use Notion;


### PR DESCRIPTION
I noticed this when working on code for events. The error message when the node version is not found was not being displayed to the user.

This changes the displayed message from this:
```
error: An unknown error has occurred
```

to this:
```
error: No Node version found for = 15.11.1
```

Looks like this fits into https://github.com/notion-cli/notion/issues/70