### PR TITLE
NOTION_DEV env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,6 @@ name = "notion-fail"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -17,7 +17,11 @@ pub trait Tool: Sized {
         match Self::new() {
             Ok(tool) => tool.exec(),
             Err(e) => {
-                style::display_error(&e);
+                if e.is_user_friendly() {
+                    style::display_error(&e);
+                } else {
+                    style::display_unknown_error(&e);
+                }
                 exit(1);
             }
         }

--- a/crates/notion-fail/Cargo.toml
+++ b/crates/notion-fail/Cargo.toml
@@ -5,4 +5,3 @@ authors = ["Dave Herman <david.herman@gmail.com>"]
 
 [dependencies]
 failure = "0.1.1"
-failure_derive = "0.1.1"

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -276,8 +276,6 @@
 //! was being parsed and where it came from (say, the filename and line number).
 
 extern crate failure;
-#[macro_use]
-extern crate failure_derive;
 
 use std::convert::{From, Into};
 use std::fmt::{self, Display};
@@ -302,8 +300,7 @@ pub trait NotionFail: Fail {
 }
 
 /// The `NotionError` type, which can contain any Notion failure.
-#[derive(Fail, Debug)]
-#[fail(display = "{}", error)]
+#[derive(Debug)]
 pub struct NotionError {
     /// The underlying error.
     error: failure::Error,
@@ -313,6 +310,22 @@ pub struct NotionError {
 
     /// The result of `error.exit_code()`.
     exit_code: i32,
+}
+
+impl Fail for NotionError {
+    fn cause(&self) -> Option<&Fail> {
+        Some(self.error.cause())
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        Some(self.error.backtrace())
+    }
+}
+
+impl fmt::Display for NotionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.error, f)
+    }
 }
 
 impl NotionError {
@@ -389,9 +402,20 @@ pub trait ResultExt<T, E> {
 }
 
 /// A wrapper type for unknown errors.
-#[derive(Debug)]
 struct UnknownNotionError {
     error: failure::Error,
+}
+
+// The `Debug` implementation for `failure::Error` prints out a stack
+// trace, which is too much information for many debugging purposes,
+// and doesn't nest properly within the debug string of compound data
+// structures, so just show the debug string for the underlying cause
+// instead.
+
+impl fmt::Debug for UnknownNotionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.error.cause(), f)
+    }
 }
 
 impl Display for UnknownNotionError {

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -185,7 +185,7 @@ pub fn main() {
             if err.is_user_friendly() {
                 display_error(&err);
             } else {
-                display_unknown_error();
+                display_unknown_error(&err);
             }
 
             if let Some(ref usage) = err.usage() {


### PR DESCRIPTION
improved "unknown error" reporting:
- consistent for shims as well as notion executable
- can use `NOTION_DEV` (and `RUST_BACKTRACE`) env vars to get detailed reporting (useful for Notion implementers/maintainers)
