### PR TITLE
Adding Yarn support to notion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ support/windows/*.log
 support/windows/Notion.wixobj
 support/windows/Notion.wixpdb
 support/unix/install.sh
+/.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ name = "node"
 path = "src/node.rs"
 
 [[bin]]
+name = "yarn"
+path = "src/yarn.rs"
+
+[[bin]]
 name = "launchbin"
 path = "src/launchbin.rs"
 

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -29,7 +29,7 @@ use serial;
 use serial::touch;
 use style::progress_spinner;
 
-// TODO: Should we move these constants to a config file or even maybe a user config?
+// ISSUE (#86): Move public repository URLs to config file
 /// URL of the index of available Node versions on the public Node server.
 const PUBLIC_NODE_VERSION_INDEX: &'static str = "https://nodejs.org/dist/index.json";
 /// URL of the index of available Yarn versions on the public git repository.
@@ -59,7 +59,7 @@ impl LazyCatalog {
     }
 }
 
-pub struct Collection<I:Install> {
+pub struct Collection<I: Install> {
     /// The currently activated Node version, if any.
     pub activated: Option<Version>,
 
@@ -147,7 +147,7 @@ impl Catalog {
         Ok(())
     }
 
-    // TODO: refactor activate, install and uninstall methods
+    // ISSUE (#87) Abstract Catalog's activate, install and uninstall methods
     // And potentially share code between node and yarn
     /// Activates a Yarn version matching the specified semantic versioning requirements.
     pub fn activate_yarn(&mut self, matching: &VersionReq, config: &Config) -> Fallible<()> {
@@ -228,14 +228,14 @@ impl NotionFail for NoYarnVersionFoundError {
     }
 }
 
-impl<I:Install> Collection<I> {
+impl<I: Install> Collection<I> {
     /// Tests whether this Collection contains the specified Tool version.
     pub fn contains(&self, version: &Version) -> bool {
         self.versions.contains(version)
     }
 }
 
-pub trait Resolve<I:Install> {
+pub trait Resolve<I: Install> {
     /// Resolves the specified semantic versioning requirements from a remote distributor.
     fn resolve_remote(&self, matching: &VersionReq, config: Option<&ToolConfig<I>>) -> Fallible<I> {
         match config {

--- a/crates/notion-core/src/config.rs
+++ b/crates/notion-core/src/config.rs
@@ -34,6 +34,7 @@ impl LazyConfig {
 /// Notion configuration settings.
 pub struct Config {
     pub node: Option<NodeConfig>,
+    pub yarn: Option<NodeConfig>, // TODO: rename NodeConfig to a more generic config?
 }
 
 /// Notion configuration settings relating to the Node executable.

--- a/crates/notion-core/src/config.rs
+++ b/crates/notion-core/src/config.rs
@@ -1,6 +1,7 @@
 //! Provides types for working with Notion configuration files.
 
 use std::str::FromStr;
+use std::marker::PhantomData;
 
 use lazycell::LazyCell;
 use toml;
@@ -11,6 +12,9 @@ use plugin;
 use readext::ReadExt;
 use serial;
 use serial::touch;
+use installer::Install;
+use installer::node::NodeInstaller;
+use installer::yarn::YarnInstaller;
 
 /// Lazily loaded Notion configuration settings.
 pub struct LazyConfig {
@@ -33,16 +37,18 @@ impl LazyConfig {
 
 /// Notion configuration settings.
 pub struct Config {
-    pub node: Option<NodeConfig>,
-    pub yarn: Option<NodeConfig>, // TODO: rename NodeConfig to a more generic config?
+    pub node: Option<ToolConfig<NodeInstaller>>,
+    pub yarn: Option<ToolConfig<YarnInstaller>>,
 }
 
 /// Notion configuration settings relating to the Node executable.
-pub struct NodeConfig {
+pub struct ToolConfig<I:Install> {
     /// The plugin for resolving Node versions, if any.
-    pub resolve: Option<plugin::Resolve>,
+    pub resolve: Option<plugin::ResolvePlugin>,
     /// The plugin for listing the set of Node versions available on the remote server, if any.
     pub ls_remote: Option<plugin::LsRemote>,
+
+    pub phantom: PhantomData<I>
 }
 
 impl Config {

--- a/crates/notion-core/src/config.rs
+++ b/crates/notion-core/src/config.rs
@@ -42,7 +42,7 @@ pub struct Config {
 }
 
 /// Notion configuration settings relating to the Node executable.
-pub struct ToolConfig<I:Install> {
+pub struct ToolConfig<I: Install> {
     /// The plugin for resolving Node versions, if any.
     pub resolve: Option<plugin::ResolvePlugin>,
     /// The plugin for listing the set of Node versions available on the remote server, if any.

--- a/crates/notion-core/src/env.rs
+++ b/crates/notion-core/src/env.rs
@@ -16,6 +16,7 @@ pub fn path_for(version: &str) -> OsString {
     let split = env::split_paths(&current).filter(|s| s != shim_dir);
     let mut path_vec: Vec<PathBuf> = Vec::new();
     path_vec.push(path::node_version_bin_dir(version).unwrap());
+    path_vec.push(path::yarn_version_bin_dir(version).unwrap());
     path_vec.extend(split);
     env::join_paths(path_vec.iter()).unwrap()
 }

--- a/crates/notion-core/src/installer/mod.rs
+++ b/crates/notion-core/src/installer/mod.rs
@@ -1,6 +1,7 @@
 //! Provides types for installing tools into the Notion catalog.
 
 pub mod node;
+pub mod yarn;
 
 use semver::Version;
 

--- a/crates/notion-core/src/installer/mod.rs
+++ b/crates/notion-core/src/installer/mod.rs
@@ -32,7 +32,6 @@ impl Installed {
     }
 }
 
-/// TODO: figure out how to get rid of `Sized`
 pub trait Install:Sized {
     /// Provision an `Installer` from the public distributor (e.g. `https://nodejs.org`).
     fn public(version: Version) -> Fallible<Self>;

--- a/crates/notion-core/src/installer/mod.rs
+++ b/crates/notion-core/src/installer/mod.rs
@@ -3,7 +3,10 @@
 pub mod node;
 pub mod yarn;
 
+use std::fs::{File};
 use semver::Version;
+use notion_fail::{Fallible};
+use catalog::Collection;
 
 /// The result of a requested installation.
 pub enum Installed {
@@ -27,4 +30,23 @@ impl Installed {
             &Installed::Already(ref version) | &Installed::Now(ref version) => version,
         }
     }
+}
+
+/// TODO: figure out how to get rid of `Sized`
+pub trait Install:Sized {
+    /// Provision an `Installer` from the public distributor (e.g. `https://nodejs.org`).
+    fn public(version: Version) -> Fallible<Self>;
+
+    /// Provision an `Installer` from a remote distributor.
+    fn remote(version: Version, url: &str) -> Fallible<Self>;
+
+    /// Provision an `Installer` from the filesystem.
+    fn cached(version: Version, file: File) -> Fallible<Self>;
+
+    /// Produces a reference to this installer's Tool version.
+    fn version(&self) -> &Version;
+
+    /// Installs this version of the Tool. (It is left to the responsibility of the `Collection`
+    /// to update its state after installation succeeds.)
+    fn install(self, catalog: &Collection<Self>) -> Fallible<Installed>;
 }

--- a/crates/notion-core/src/installer/node.rs
+++ b/crates/notion-core/src/installer/node.rs
@@ -3,8 +3,8 @@
 use std::fs::{rename, File};
 use std::string::ToString;
 
-use super::Installed;
-use catalog::NodeCatalog;
+use super::{Installed, Install};
+use catalog::{NodeCollection};
 use node_archive::{self, Archive};
 use path;
 use style::{progress_bar, Action};
@@ -15,51 +15,51 @@ use semver::Version;
 const PUBLIC_NODE_SERVER_ROOT: &'static str = "https://nodejs.org/dist/";
 
 /// A provisioned Node installer.
-pub struct Installer {
+pub struct NodeInstaller  {
     archive: Box<Archive>,
     version: Version,
 }
 
-impl Installer {
+impl Install for NodeInstaller {
     /// Provision an `Installer` from the public Node distributor (`https://nodejs.org`).
-    pub fn public(version: Version) -> Fallible<Self> {
+    fn public(version: Version) -> Fallible<Self> {
         let archive_file = path::node_archive_file(&version.to_string());
         let url = format!("{}v{}/{}", PUBLIC_NODE_SERVER_ROOT, version, &archive_file);
-        Installer::remote(version, &url)
+        NodeInstaller::remote(version, &url)
     }
 
     /// Provision an `Installer` from a remote distributor.
-    pub fn remote(version: Version, url: &str) -> Fallible<Self> {
+    fn remote(version: Version, url: &str) -> Fallible<Self> {
         let archive_file = path::node_archive_file(&version.to_string());
         let cache_file = path::node_cache_dir()?.join(&archive_file);
 
         if cache_file.is_file() {
-            return Installer::cached(version, File::open(cache_file).unknown()?);
+            return NodeInstaller::cached(version, File::open(cache_file).unknown()?);
         }
 
-        Ok(Installer {
+        Ok(NodeInstaller {
             archive: node_archive::fetch(url, &cache_file).unknown()?,
             version: version,
         })
     }
 
     /// Provision an `Installer` from the filesystem.
-    pub fn cached(version: Version, file: File) -> Fallible<Self> {
-        Ok(Installer {
+    fn cached(version: Version, file: File) -> Fallible<Self> {
+        Ok(NodeInstaller {
             archive: node_archive::load(file).unknown()?,
             version: version,
         })
     }
 
     /// Produces a reference to this installer's Node version.
-    pub fn version(&self) -> &Version {
+    fn version(&self) -> &Version {
         &self.version
     }
 
-    /// Installs this version of Node. (It is left to the responsibility of the `NodeCatalog`
+    /// Installs this version of Node. (It is left to the responsibility of the `NodeCollection`
     /// to update its state after installation succeeds.)
-    pub fn install(self, catalog: &NodeCatalog) -> Fallible<Installed> {
-        if catalog.contains(&self.version) {
+    fn install(self, collection: &NodeCollection) -> Fallible<Installed> {
+        if collection.contains(&self.version) {
             return Ok(Installed::Already(self.version));
         }
 

--- a/crates/notion-core/src/installer/yarn.rs
+++ b/crates/notion-core/src/installer/yarn.rs
@@ -3,8 +3,8 @@
 use std::fs::{rename, File};
 use std::string::ToString;
 
-use super::Installed;
-use catalog::YarnCatalog;
+use super::{Installed, Install};
+use catalog::{YarnCollection};
 use node_archive::{self, Archive};
 use path;
 use style::{progress_bar, Action};
@@ -15,51 +15,51 @@ use semver::Version;
 const PUBLIC_YARN_SERVER_ROOT: &'static str = "https://github.com/notion-cli/yarn-releases/raw/master/dist/";
 
 /// A provisioned Yarn installer.
-pub struct Installer {
+pub struct YarnInstaller {
     archive: Box<Archive>,
     version: Version,
 }
 
-impl Installer {
+impl Install for YarnInstaller {
     /// Provision an `Installer` from the public Yarn distributor (`https://yarnpkg.com`).
-    pub fn public(version: Version) -> Fallible<Self> {
+    fn public(version: Version) -> Fallible<Self> {
         let archive_file = path::yarn_archive_file(&version.to_string());
         let url = format!("{}{}", PUBLIC_YARN_SERVER_ROOT, archive_file);
-        Installer::remote(version, &url)
+        YarnInstaller::remote(version, &url)
     }
 
     /// Provision an `Installer` from a remote distributor.
-    pub fn remote(version: Version, url: &str) -> Fallible<Self> {
+    fn remote(version: Version, url: &str) -> Fallible<Self> {
         let archive_file = path::yarn_archive_file(&version.to_string());
         let cache_file = path::yarn_cache_dir()?.join(&archive_file);
 
         if cache_file.is_file() {
-            return Installer::cached(version, File::open(cache_file).unknown()?);
+            return YarnInstaller::cached(version, File::open(cache_file).unknown()?);
         }
 
-        Ok(Installer {
+        Ok(YarnInstaller {
             archive: node_archive::fetch(url, &cache_file).unknown()?,
             version: version,
         })
     }
 
     /// Provision an `Installer` from the filesystem.
-    pub fn cached(version: Version, file: File) -> Fallible<Self> {
-        Ok(Installer {
+    fn cached(version: Version, file: File) -> Fallible<Self> {
+        Ok(YarnInstaller {
             archive: node_archive::load(file).unknown()?,
             version: version,
         })
     }
 
     /// Produces a reference to this installer's Yarn version.
-    pub fn version(&self) -> &Version {
+    fn version(&self) -> &Version {
         &self.version
     }
 
-    /// Installs this version of Yarn. (It is left to the responsibility of the `YarnCatalog`
+    /// Installs this version of Yarn. (It is left to the responsibility of the `YarnCollection`
     /// to update its state after installation succeeds.)
-    pub fn install(self, catalog: &YarnCatalog) -> Fallible<Installed> {
-        if catalog.contains(&self.version) {
+    fn install(self, collection: &YarnCollection) -> Fallible<Installed> {
+        if collection.contains(&self.version) {
             return Ok(Installed::Already(self.version));
         }
 

--- a/crates/notion-core/src/path/mod.rs
+++ b/crates/notion-core/src/path/mod.rs
@@ -19,10 +19,18 @@ cfg_if! {
     }
 }
 
-pub fn archive_file(version: &str) -> String {
-    format!("{}.{}", archive_root_dir(version), archive_extension())
+pub fn node_archive_file(version: &str) -> String {
+    format!("{}.{}", node_archive_root_dir(version), archive_extension())
 }
 
-pub fn archive_root_dir(version: &str) -> String {
+pub fn node_archive_root_dir(version: &str) -> String {
     format!("node-v{}-{}-{}", version, OS, ARCH)
+}
+
+pub fn yarn_archive_file(version: &str) -> String {
+    format!("{}.{}", yarn_archive_root_dir(version), archive_extension())
+}
+
+pub fn yarn_archive_root_dir(version: &str) -> String {
+    format!("yarn-v{}", version)
 }

--- a/crates/notion-core/src/path/unix.rs
+++ b/crates/notion-core/src/path/unix.rs
@@ -82,6 +82,9 @@ pub fn cache_dir() -> Fallible<PathBuf> {
 pub fn node_cache_dir() -> Fallible<PathBuf> {
     Ok(cache_dir()?.join("node"))
 }
+pub fn yarn_cache_dir() -> Fallible<PathBuf> {
+    Ok(cache_dir()?.join("yarn"))
+}
 
 pub fn node_index_file() -> Fallible<PathBuf> {
     Ok(node_cache_dir()?.join("index.json"))
@@ -103,12 +106,24 @@ pub fn node_versions_dir() -> Fallible<PathBuf> {
     Ok(versions_dir()?.join("node"))
 }
 
+pub fn yarn_versions_dir() -> Fallible<PathBuf> {
+    Ok(versions_dir()?.join("yarn"))
+}
+
 pub fn node_version_dir(version: &str) -> Fallible<PathBuf> {
     Ok(node_versions_dir()?.join(version))
 }
 
+pub fn yarn_version_dir(version: &str) -> Fallible<PathBuf> {
+    Ok(yarn_versions_dir()?.join(version))
+}
+
 pub fn node_version_bin_dir(version: &str) -> Fallible<PathBuf> {
     Ok(node_version_dir(version)?.join("bin"))
+}
+
+pub fn yarn_version_bin_dir(version: &str) -> Fallible<PathBuf> {
+    Ok(yarn_version_dir(version)?.join("bin"))
 }
 
 pub fn bin_dir() -> Fallible<PathBuf> {

--- a/crates/notion-core/src/plugin.rs
+++ b/crates/notion-core/src/plugin.rs
@@ -32,7 +32,7 @@ pub struct InvalidCommandError {
 impl ResolvePlugin {
     /// Performs resolution of a Tool version based on the given semantic
     /// versioning requirements.
-    pub fn resolve<I:Install>(&self, _matching: &VersionReq) -> Fallible<I> {
+    pub fn resolve<I: Install>(&self, _matching: &VersionReq) -> Fallible<I> {
         match self {
             &ResolvePlugin::Url(_) => unimplemented!(),
 

--- a/crates/notion-core/src/serial/catalog.rs
+++ b/crates/notion-core/src/serial/catalog.rs
@@ -13,11 +13,20 @@ use semver::{SemVerError, Version};
 pub struct Catalog {
     #[serde(default)]
     node: NodeCatalog,
+    #[serde(default)]
+    yarn: YarnCatalog,
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename = "node")]
 pub struct NodeCatalog {
+    activated: Option<String>,
+    versions: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename = "yarn")]
+pub struct YarnCatalog {
     activated: Option<String>,
     versions: Vec<String>,
 }
@@ -31,10 +40,20 @@ impl Default for NodeCatalog {
     }
 }
 
+impl Default for YarnCatalog {
+    fn default() -> Self {
+        YarnCatalog {
+            activated: None,
+            versions: vec![],
+        }
+    }
+}
+
 impl Catalog {
     pub fn into_catalog(self) -> Fallible<catalog::Catalog> {
         Ok(catalog::Catalog {
             node: self.node.into_node_catalog().unknown()?,
+            yarn: self.yarn.into_yarn_catalog().unknown()?,
         })
     }
 }
@@ -58,16 +77,45 @@ impl NodeCatalog {
     }
 }
 
+impl YarnCatalog {
+    fn into_yarn_catalog(self) -> Fallible<catalog::YarnCatalog> {
+        let activated = match self.activated {
+            Some(v) => Some(Version::parse(&v[..]).unknown()?),
+            None => None,
+        };
+
+        let versions: Result<Vec<Version>, SemVerError> = self.versions
+            .into_iter()
+            .map(|s| Ok(Version::parse(&s[..])?))
+            .collect();
+
+        Ok(catalog::YarnCatalog {
+            activated,
+            versions: BTreeSet::from_iter(versions.unknown()?),
+        })
+    }
+}
+
 impl catalog::Catalog {
     pub fn to_serial(&self) -> Catalog {
         Catalog {
             node: self.node.to_serial(),
+            yarn: self.yarn.to_serial(),
         }
     }
 }
 impl catalog::NodeCatalog {
     fn to_serial(&self) -> NodeCatalog {
         NodeCatalog {
+            activated: self.activated.clone().map(|v| v.to_string()),
+            versions: self.versions.iter().map(|v| v.to_string()).collect(),
+        }
+    }
+}
+
+impl catalog::YarnCatalog {
+    fn to_serial(&self) -> YarnCatalog {
+        YarnCatalog {
             activated: self.activated.clone().map(|v| v.to_string()),
             versions: self.versions.iter().map(|v| v.to_string()).collect(),
         }

--- a/crates/notion-core/src/serial/config.rs
+++ b/crates/notion-core/src/serial/config.rs
@@ -7,6 +7,8 @@ use notion_fail::Fallible;
 #[derive(Serialize, Deserialize)]
 pub struct Config {
     pub node: Option<NodeConfig>,
+    // TODO: Do we need a YarnConfig? or should we change NodeConfig to a generic Config?
+    pub yarn: Option<NodeConfig>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -23,6 +25,11 @@ impl Config {
         Ok(config::Config {
             node: if let Some(n) = self.node {
                 Some(n.into_node_config()?)
+            } else {
+                None
+            },
+            yarn: if let Some(y) = self.yarn {
+                Some(y.into_node_config()?)
             } else {
                 None
             },

--- a/crates/notion-core/src/serial/config.rs
+++ b/crates/notion-core/src/serial/config.rs
@@ -1,35 +1,40 @@
 use super::super::config;
+use std::marker::PhantomData;
 
 use super::plugin::Plugin;
+use installer::Install;
+use installer::node::NodeInstaller;
+use installer::yarn::YarnInstaller;
 
 use notion_fail::Fallible;
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
-    pub node: Option<NodeConfig>,
-    // TODO: Do we need a YarnConfig? or should we change NodeConfig to a generic Config?
-    pub yarn: Option<NodeConfig>,
+    pub node: Option<ToolConfig<NodeInstaller>>,
+    pub yarn: Option<ToolConfig<YarnInstaller>>,
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename = "node")]
-pub struct NodeConfig {
+#[serde(rename = "tool")]
+pub struct ToolConfig<I> {
     pub resolve: Option<Plugin>,
 
     #[serde(rename = "ls-remote")]
     pub ls_remote: Option<Plugin>,
+
+    phantom: PhantomData<I>
 }
 
 impl Config {
     pub fn into_config(self) -> Fallible<config::Config> {
         Ok(config::Config {
             node: if let Some(n) = self.node {
-                Some(n.into_node_config()?)
+                Some(n.into_tool_config()?)
             } else {
                 None
             },
             yarn: if let Some(y) = self.yarn {
-                Some(y.into_node_config()?)
+                Some(y.into_tool_config()?)
             } else {
                 None
             },
@@ -37,9 +42,9 @@ impl Config {
     }
 }
 
-impl NodeConfig {
-    pub fn into_node_config(self) -> Fallible<config::NodeConfig> {
-        Ok(config::NodeConfig {
+impl<I:Install> ToolConfig<I> {
+    pub fn into_tool_config(self) -> Fallible<config::ToolConfig<I>> {
+        Ok(config::ToolConfig {
             resolve: if let Some(p) = self.resolve {
                 Some(p.into_resolve()?)
             } else {
@@ -50,6 +55,7 @@ impl NodeConfig {
             } else {
                 None
             },
+            phantom: PhantomData
         })
     }
 }

--- a/crates/notion-core/src/serial/config.rs
+++ b/crates/notion-core/src/serial/config.rs
@@ -42,7 +42,7 @@ impl Config {
     }
 }
 
-impl<I:Install> ToolConfig<I> {
+impl<I: Install> ToolConfig<I> {
     pub fn into_tool_config(self) -> Fallible<config::ToolConfig<I>> {
         Ok(config::ToolConfig {
             resolve: if let Some(p) = self.resolve {

--- a/crates/notion-core/src/serial/plugin.rs
+++ b/crates/notion-core/src/serial/plugin.rs
@@ -43,8 +43,8 @@ impl Plugin {
         }
     }
 
-    pub fn into_resolve(self) -> Fallible<plugin::Resolve> {
-        self.into_plugin(plugin::Resolve::Url, plugin::Resolve::Bin)
+    pub fn into_resolve(self) -> Fallible<plugin::ResolvePlugin> {
+        self.into_plugin(plugin::ResolvePlugin::Url, plugin::ResolvePlugin::Bin)
     }
 
     pub fn into_ls_remote(self) -> Fallible<plugin::LsRemote> {

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -2,7 +2,7 @@
 //! execution of a Notion tool, including their configuration, their current
 //! directory, and the state of the local tool catalog.
 
-use catalog::{Catalog, LazyCatalog};
+use catalog::{Catalog, LazyCatalog, Resolve};
 use config::{Config, LazyConfig};
 use installer::Installed;
 use project::Project;

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -20,6 +20,7 @@ pub enum ActivityKind {
     Current,
     Use,
     Node,
+    Yarn,
     Notion,
     Tool,
     Help,
@@ -34,6 +35,7 @@ impl Display for ActivityKind {
             &ActivityKind::Current => "current",
             &ActivityKind::Use => "use",
             &ActivityKind::Node => "node",
+            &ActivityKind::Yarn => "yarn",
             &ActivityKind::Notion => "notion",
             &ActivityKind::Tool => "tool",
             &ActivityKind::Help => "help",
@@ -126,6 +128,30 @@ impl Session {
         let catalog = self.catalog.get_mut()?;
         let config = self.config.get()?;
         catalog.activate_node(matching, config)
+    }
+
+    /// Produces the version of Yarn for the current session. If there is an
+    /// active project with Notion settings, this will ensure a compatible
+    /// version of Yarn is installed before returning. If there is no active
+    /// project with Notion settings, this produces the global version, which
+    /// may be `None`.
+    pub fn current_yarn(&mut self) -> Fallible<Option<Version>> {
+        if let Some(ref project) = self.project {
+            let requirements = &project.manifest().yarn.clone().unwrap();
+            let catalog = self.catalog.get_mut()?;
+            let available = catalog.yarn.resolve_local(&requirements);
+
+            if available.is_some() {
+                return Ok(available);
+            }
+
+            let config = self.config.get()?;
+            let installed = catalog.install_yarn(&requirements, config)?;
+
+            return Ok(Some(installed.into_version()));
+        }
+
+        Ok(self.catalog()?.yarn.activated.clone())
     }
 
     pub fn add_event_start(&mut self, activity_kind: ActivityKind) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "notion": {
     "node": "6.11.1",
-    "yarn": "1.2",
+    "yarn": "1.7.0",
     "events_plugin": "./support/unix/test-events --some-arg"
   }
 }

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -1,5 +1,6 @@
 use std::string::ToString;
 
+use notion_core::catalog::Resolve;
 use notion_core::session::{ActivityKind, Session};
 use notion_fail::Fallible;
 

--- a/src/yarn.rs
+++ b/src/yarn.rs
@@ -1,0 +1,8 @@
+extern crate notion_core;
+
+use notion_core::tool::{Yarn, Tool};
+
+/// The entry point for the `yarn` shim.
+pub fn main() {
+    Yarn::launch()
+}

--- a/support/unix/build.sh
+++ b/support/unix/build.sh
@@ -32,11 +32,13 @@ build_dir="$script_dir/../../target/$target_dir"
 
 encode_base64_sed_command notion NOTION "$build_dir/notion"
 encode_base64_sed_command node NODE "$build_dir/node"
+encode_base64_sed_command yarn YARN "$build_dir/yarn"
 encode_base64_sed_command launchbin LAUNCHBIN "$build_dir/launchbin"
 encode_base64_sed_command launchscript LAUNCHSCRIPT "$build_dir/launchscript"
 
 sed -f notion.base64.txt \
     -f node.base64.txt \
+    -f yarn.base64.txt \
     -f launchbin.base64.txt \
     -f launchscript.base64.txt \
     < "$script_dir/install.sh.in" > "$script_dir/install.sh"
@@ -45,5 +47,6 @@ chmod 755 "$script_dir/install.sh"
 
 rm notion.base64.txt \
    node.base64.txt \
+   yarn.base64.txt \
    launchbin.base64.txt \
    launchscript.base64.txt

--- a/support/unix/install.sh.in
+++ b/support/unix/install.sh.in
@@ -14,6 +14,12 @@ notion_unpack_node() {
 END_BINARY_PAYLOAD
 }
 
+notion_unpack_yarn() {
+  base64 --decode <<'END_BINARY_PAYLOAD'
+<PLACEHOLDER_YARN_PAYLOAD>
+END_BINARY_PAYLOAD
+}
+
 notion_unpack_launchbin() {
   base64 --decode <<'END_BINARY_PAYLOAD'
 <PLACEHOLDER_LAUNCHBIN_PAYLOAD>
@@ -47,7 +53,9 @@ notion_create_tree() {
   #         shim/
 
   mkdir -p "${INSTALL_DIR}"/cache/node
+  mkdir -p "${INSTALL_DIR}"/cache/yarn
   mkdir -p "${INSTALL_DIR}"/versions/node
+  mkdir -p "${INSTALL_DIR}"/versions/yarn
   mkdir -p "${INSTALL_DIR}"/bin
   mkdir -p "${INSTALL_DIR}"/shim
 }
@@ -59,12 +67,12 @@ notion_create_binaries() {
 
   notion_unpack_notion       > "${INSTALL_DIR}"/bin/notion
   notion_unpack_node         > "${INSTALL_DIR}"/shim/node
+  notion_unpack_yarn         > "${INSTALL_DIR}"/shim/yarn
   notion_unpack_launchscript > "${INSTALL_DIR}"/launchscript
   notion_unpack_launchbin    > "${INSTALL_DIR}"/launchbin
 
   ln -s "${INSTALL_DIR}"/launchscript "${INSTALL_DIR}"/shim/npm
   ln -s "${INSTALL_DIR}"/launchscript "${INSTALL_DIR}"/shim/npx
-  ln -s "${INSTALL_DIR}"/launchscript "${INSTALL_DIR}"/shim/yarn
 
   chmod 755 "${INSTALL_DIR}/bin"/* "${INSTALL_DIR}/shim"/* "${INSTALL_DIR}"/launch*
 }
@@ -184,7 +192,7 @@ notion_install() {
 }
 
 notion_cleanup() {
-  unset -f notion_unpack_notion notion_unpack_node notion_unpack_launchbin notion_unpack_launchscript \
+  unset -f notion_unpack_notion notion_unpack_node notion_unpack_yarn notion_unpack_launchbin notion_unpack_launchscript \
     notion_install_dir notion_create_tree notion_create_binaries notion_try_profile notion_detect_profile \
     notion_eprintf notion_info notion_error notion_warning \
     notion_exit notion_install notion_cleanup


### PR DESCRIPTION
Enable yarn support as a new tool that follows the same model as node.
Implements yarn version `catalog`, yarn `installer` and `shim`.

Since yarnpkg.com doesn't provide an API for released versions and some limitation with GitHub API to fetch versions and download, we decided to use `notion-cli/yarn-releases` git repo till we figure out a better solution.
Released versions: `https://github.com/notion-cli/yarn-releases/raw/master/index.json`
Download tarball URL: `https://github.com/notion-cli/yarn-releases/raw/master/dist/yarn-v{$version}.tar.gz`


This PR is for the following issues in MVP milestone: #73 #61 #67 