### PR TITLE
Make 'release' the default build target

### DIFF
--- a/support/unix/build.sh
+++ b/support/unix/build.sh
@@ -13,12 +13,13 @@ The output file is saved as $script_dir/install.sh.
 END_USAGE
 }
 
-target_dir='release'
-if [ "$#" -gt 1 ] || ! [[ "$1" =~ (debug|release) ]]; then
+if [ -z "$1" ]; then
+  target_dir='release'
+elif [[ "$1" =~ (debug|release) ]]; then
+  target_dir="$1"
+else
   usage
   exit 1
-elif [ -n "$1" ]; then
-  target_dir="$1"
 fi
 
 encode_base64_sed_command() {


### PR DESCRIPTION
Currently running the build script errors when `release` is not set, even though it claims to be the default. This sets `target_dir` to `release` when it is not specified.