### PR TITLE
Run all tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
     - stage: test
       rust: stable
       script: |
-        cargo test
+        cargo test --all
     - stage: publish
       # Conditional builds: https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
       if: (branch = master) AND (type = push)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ name = "notion-fail"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,4 +118,4 @@ build: false
 #directly or perform other testing commands. Rust will automatically be placed in the PATH
 # environment variable.
 test_script:
-  - cargo test --verbose %cargoflags%
+  - cargo test --all --verbose %cargoflags%

--- a/crates/notion-fail/Cargo.toml
+++ b/crates/notion-fail/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Dave Herman <david.herman@gmail.com>"]
 
 [dependencies]
 failure = "0.1.1"
+failure_derive = "0.1.1"

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -50,8 +50,7 @@
 //! for its signature:
 //!
 //! ```
-//! # #[macro_use]
-//! # extern crate notion_fail;
+//! # #[macro_use] extern crate notion_fail;
 //! #
 //! use notion_fail::Fallible;
 //! #
@@ -80,9 +79,9 @@
 //!
 //! ## Example
 //!
-//! ```
-//! # #[macro_use]
-//! # extern crate notion_fail;
+//! ```compile_fail
+//! # #[macro_use] extern crate notion_fail;
+//!
 //! // required for `#[derive(Fail)]` and `#[fail(...)]` attributes
 //! #[macro_use]
 //! extern crate failure_derive;
@@ -113,10 +112,8 @@
 //! ## Example
 //!
 //! ```
-//! # #[macro_use]
-//! # extern crate notion_fail;
-//! # #[macro_use]
-//! # extern crate failure_derive;
+//! # #[macro_use] extern crate notion_fail;
+//! # #[macro_use] extern crate failure_derive;
 //! # extern crate failure;
 //! # use notion_fail::{NotionFail, Fallible};
 //! # #[derive(Fail, Debug)]
@@ -158,10 +155,8 @@
 //! ## Example
 //!
 //! ```
-//! # #[macro_use]
-//! # extern crate notion_fail;
-//! # #[macro_use]
-//! # extern crate failure_derive;
+//! # #[macro_use] extern crate notion_fail;
+//! # #[macro_use] extern crate failure_derive;
 //! # extern crate failure;
 //! # use notion_fail::{NotionFail, Fallible};
 //! // add `unknown()` extension method to Results
@@ -211,11 +206,9 @@
 //!
 //! ## Example
 //!
-//! ```
-//! # #[macro_use]
-//! # extern crate notion_fail;
-//! # #[macro_use]
-//! # extern crate failure_derive;
+//! ```compile_fail
+//! # #[macro_use] extern crate notion_fail;
+//! # #[macro_use] extern crate failure_derive;
 //! # extern crate failure;
 //! # use notion_fail::{NotionFail, Fallible};
 //! // add `unknown()` and `with_context()` extension methods to Results


### PR DESCRIPTION
This changes CI to use `cargo test --all`, which runs tests in src/ and crates/, as well as rustdoc. Currently only tests in src/ are run.

I had to modify some examples in the notion-fail docs to get them to compile. There are a couple that I haven't been able to fix , so just marked as `compile_fail` for now so that the tests pass.


```
$ cargo test --all
   Compiling notion-fail v0.1.0 (file:///Users/mistewar/fpe/notion/notion/crates/notion-fail)
   Compiling notion-core v0.1.0 (file:///Users/mistewar/fpe/notion/notion/crates/notion-core)
   Compiling notion v0.1.0 (file:///Users/mistewar/fpe/notion/notion)
    Finished dev [unoptimized + debuginfo] target(s) in 7.87 secs
     Running target/debug/deps/node_archive-a8af169d88f57520

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/launchbin-6d67578f963dee28

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/launchscript-57a08133f383ab5d

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/node-5d39bfa68a9624e6

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/notion-07fde85640da5e68

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/notion_core-a4e9e97be90fedd4

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/notion_fail-50facad1ac3a0db9

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/progress_read-28b191b7a7b7d10d

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests notion-core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests node-archive

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests progress-read

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests notion-fail

running 6 tests
test src/lib.rs -  (line 209) ... ok
test src/lib.rs -  (line 44) ... ok
test src/lib.rs -  (line 157) ... ok
test src/lib.rs -  (line 114) ... ok
test src/lib.rs -  (line 82) ... ok
test src/lib.rs -  (line 52) ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```