### PR TITLE
Expose dev_dependencies in manifest

### DIFF
--- a/crates/notion-core/fixtures/basic/package.json
+++ b/crates/notion-core/fixtures/basic/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "basic-project",
+  "version": "0.0.7",
+  "description": "Testing that manifest pulls things out of this correctly",
+  "license": "To Kill",
+  "dependencies": {
+    "@namespace/some-dep": "0.2.4",
+    "rsvp": "^3.5.0"
+  },
+  "devDependencies": {
+    "@namespaced/something-else": "^6.3.7",
+    "eslint": "~4.8.0"
+  },
+  "notion": {
+    "node": "6.11.1",
+    "yarn": "1.2",
+    "events_plugin": "./support/unix/test-events --some-arg"
+  }
+}

--- a/crates/notion-core/src/manifest.rs
+++ b/crates/notion-core/src/manifest.rs
@@ -18,6 +18,8 @@ pub struct Manifest {
     pub yarn: Option<VersionReq>,
     /// The `dependencies` section.
     pub dependencies: HashMap<String, String>,
+    /// The `devDependencies` section.
+    pub dev_dependencies: HashMap<String, String>,
     /// The command to run a plugin for events, under the `notion.events_plugin` key.
     pub events_plugin: Option<String>,
 }
@@ -28,5 +30,84 @@ impl Manifest {
         let file = File::open(project_root.join("package.json")).unknown()?;
         let serial: serial::manifest::Manifest = serde_json::de::from_reader(file).unknown()?;
         serial.into_manifest()
+    }
+}
+
+// unit tests
+
+#[cfg(test)]
+pub mod tests {
+
+    use manifest::Manifest;
+    use semver::VersionReq;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn fixture_path(fixture_dir: &str) -> PathBuf {
+        let mut cargo_manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        cargo_manifest_dir.push("fixtures");
+        cargo_manifest_dir.push(fixture_dir);
+        cargo_manifest_dir
+    }
+
+    #[test]
+    fn gets_node_version() {
+        let project_path = fixture_path("basic");
+        let version = match Manifest::for_dir(&project_path) {
+            Ok(manifest) => manifest.unwrap().node,
+            _ => panic!(
+                "Error: Could not get manifest for project {:?}",
+                project_path
+            ),
+        };
+        assert_eq!(version, VersionReq::parse("=6.11.1").unwrap());
+    }
+
+    #[test]
+    fn gets_yarn_version() {
+        let project_path = fixture_path("basic");
+        let version = match Manifest::for_dir(&project_path) {
+            Ok(manifest) => manifest.unwrap().yarn,
+            _ => panic!(
+                "Error: Could not get manifest for project {:?}",
+                project_path
+            ),
+        };
+        assert_eq!(version.unwrap(), VersionReq::parse("=1.2").unwrap());
+    }
+
+    #[test]
+    fn gets_dependencies() {
+        let project_path = fixture_path("basic");
+        let dependencies = match Manifest::for_dir(&project_path) {
+            Ok(manifest) => manifest.unwrap().dependencies,
+            _ => panic!(
+                "Error: Could not get manifest for project {:?}",
+                project_path
+            ),
+        };
+        let mut expected_deps = HashMap::new();
+        expected_deps.insert("@namespace/some-dep".to_string(), "0.2.4".to_string());
+        expected_deps.insert("rsvp".to_string(), "^3.5.0".to_string());
+        assert_eq!(dependencies, expected_deps);
+    }
+
+    #[test]
+    fn gets_dev_dependencies() {
+        let project_path = fixture_path("basic");
+        let dev_dependencies = match Manifest::for_dir(&project_path) {
+            Ok(manifest) => manifest.unwrap().dev_dependencies,
+            _ => panic!(
+                "Error: Could not get manifest for project {:?}",
+                project_path
+            ),
+        };
+        let mut expected_deps = HashMap::new();
+        expected_deps.insert(
+            "@namespaced/something-else".to_string(),
+            "^6.3.7".to_string(),
+        );
+        expected_deps.insert("eslint".to_string(), "~4.8.0".to_string());
+        assert_eq!(dev_dependencies, expected_deps);
     }
 }

--- a/crates/notion-core/src/serial/manifest.rs
+++ b/crates/notion-core/src/serial/manifest.rs
@@ -41,6 +41,7 @@ impl Manifest {
                     None
                 },
                 dependencies: self.dependencies,
+                dev_dependencies: self.dev_dependencies,
                 events_plugin: if let Some(plugin) = notion.events_plugin {
                     Some(plugin)
                 } else {


### PR DESCRIPTION
(Breaking this out as a small change, as part of the 3rd party executables work.)

In the manifest, it already includes some code to get the `devDependencies` - I just added the rest of the code to expose that as `dev_dependencies`.

As a bonus, I added some happy path tests for things that are pulled out of package.json.