### PR TITLE
Deserialize the "bin" section from package.json

### DIFF
--- a/crates/notion-core/fixtures/basic/node_modules/@namespace/some-dep/package.json
+++ b/crates/notion-core/fixtures/basic/node_modules/@namespace/some-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "some-dep",
+  "version": "1.1.1",
+  "description": "Dependency that doesn't have the 'bin' field",
+  "license": "BSD",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/crates/notion-core/fixtures/basic/node_modules/eslint/package.json
+++ b/crates/notion-core/fixtures/basic/node_modules/eslint/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "eslint-project",
+  "version": "4.8.0",
+  "description": "Mock eslint",
+  "license": "To Ill",
+  "bin": {
+    "eslint": "./bin/eslint.js"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/crates/notion-core/fixtures/basic/node_modules/rsvp/package.json
+++ b/crates/notion-core/fixtures/basic/node_modules/rsvp/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "rsvp",
+  "version": "3.5.0",
+  "description": "Mock rsvp",
+  "license": "MIT",
+  "bin": "./bin/rsvp.js",
+  "dependencies": {}
+}

--- a/crates/notion-core/fixtures/basic/node_modules/typescript/package.json
+++ b/crates/notion-core/fixtures/basic/node_modules/typescript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "typescript",
+  "author": "Microsoft Corp.",
+  "homepage": "http://typescriptlang.org/",
+  "version": "2.8.3",
+  "license": "Apache-2.0",
+  "description": "Mock Typescript package",
+  "bin": {
+    "tsc": "./bin/tsc",
+    "tsserver": "./bin/tsserver"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -28,6 +28,7 @@ mod event;
 mod installer;
 pub mod manifest;
 pub mod monitor;
+mod package_info;
 pub mod path;
 mod plugin;
 pub mod project;

--- a/crates/notion-core/src/package_info.rs
+++ b/crates/notion-core/src/package_info.rs
@@ -1,0 +1,102 @@
+//! Provides the `PackageInfo` type, which contains data for a Node project (from `package.json`).
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+
+use notion_fail::{Fallible, ResultExt};
+use serde_json;
+
+use serial;
+
+/// Info about a Node package
+pub struct PackageInfo {
+    /// The `bin` section, containing a map of binary names to locations
+    pub bin: HashMap<String, String>,
+}
+
+impl PackageInfo {
+    /// Loads and parses package.json for the project located at the specified path.
+    pub fn for_dir(project_dir: &Path) -> Fallible<PackageInfo> {
+        let file = File::open(project_dir.join("package.json")).unknown()?;
+        let serial: serial::package::Info = serde_json::de::from_reader(file).unknown()?;
+        Ok(serial.into_package_info())
+    }
+}
+
+// unit tests
+
+#[cfg(test)]
+pub mod tests {
+
+    use package_info::PackageInfo;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn fixture_path(fixture_dir: &str) -> PathBuf {
+        let mut cargo_manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        cargo_manifest_dir.push("fixtures");
+        cargo_manifest_dir.push(fixture_dir);
+        cargo_manifest_dir
+    }
+
+    #[test]
+    fn gets_bin_map_format() {
+        let project_path = fixture_path("basic/node_modules/eslint");
+        let bin = match PackageInfo::for_dir(&project_path) {
+            Ok(pkg_info) => pkg_info.bin,
+            Err(e) => panic!(
+                "Error: Could not get package info for project {:?}, error: {}",
+                project_path, e
+            ),
+        };
+        let mut expected_bin = HashMap::new();
+        expected_bin.insert("eslint".to_string(), "./bin/eslint.js".to_string());
+        assert_eq!(bin, expected_bin);
+    }
+
+    #[test]
+    fn gets_multiple_bins() {
+        let project_path = fixture_path("basic/node_modules/typescript");
+        let bin = match PackageInfo::for_dir(&project_path) {
+            Ok(pkg_info) => pkg_info.bin,
+            Err(e) => panic!(
+                "Error: Could not get package info for project {:?}, error: {}",
+                project_path, e
+            ),
+        };
+        let mut expected_bin = HashMap::new();
+        expected_bin.insert("tsc".to_string(), "./bin/tsc".to_string());
+        expected_bin.insert("tsserver".to_string(), "./bin/tsserver".to_string());
+        assert_eq!(bin, expected_bin);
+    }
+
+    #[test]
+    fn gets_bin_string_format() {
+        let project_path = fixture_path("basic/node_modules/rsvp");
+        let bin = match PackageInfo::for_dir(&project_path) {
+            Ok(pkg_info) => pkg_info.bin,
+            Err(e) => panic!(
+                "Error: Could not get package info for project {:?}, error: {}",
+                project_path, e
+            ),
+        };
+        let mut expected_bin = HashMap::new();
+        expected_bin.insert("rsvp".to_string(), "./bin/rsvp.js".to_string());
+        assert_eq!(bin, expected_bin);
+    }
+
+    #[test]
+    fn handles_dep_with_no_bin() {
+        let project_path = fixture_path("basic/node_modules/@namespace/some-dep");
+        let bin = match PackageInfo::for_dir(&project_path) {
+            Ok(pkg_info) => pkg_info.bin,
+            Err(e) => panic!(
+                "Error: Could not get package info for project {:?}, error: {}",
+                project_path, e
+            ),
+        };
+        let expected_bin = HashMap::new();
+        assert_eq!(bin, expected_bin);
+    }
+}

--- a/crates/notion-core/src/serial/mod.rs
+++ b/crates/notion-core/src/serial/mod.rs
@@ -4,6 +4,7 @@ pub mod catalog;
 pub mod config;
 pub mod index;
 pub mod manifest;
+pub mod package;
 pub mod plugin;
 pub mod version;
 

--- a/crates/notion-core/src/serial/package.rs
+++ b/crates/notion-core/src/serial/package.rs
@@ -1,0 +1,117 @@
+extern crate serde;
+extern crate serde_json;
+
+use package_info::PackageInfo;
+
+use serde::de::{Deserialize, Deserializer, Error, MapAccess, Visitor};
+
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+// wrapper for HashMap to use with deserialization
+pub struct BinMap<K, V>(HashMap<K, V>);
+
+impl<K, V> Deref for BinMap<K, V> {
+    type Target = HashMap<K, V>;
+
+    fn deref(&self) -> &HashMap<K, V> {
+        &self.0
+    }
+}
+
+impl<K, V> DerefMut for BinMap<K, V> {
+    fn deref_mut(&mut self) -> &mut HashMap<K, V> {
+        &mut self.0
+    }
+}
+
+#[derive(Deserialize)]
+pub struct Info {
+    pub name: String,
+    // the "bin" field can be a map or a string
+    // (see https://docs.npmjs.com/files/package.json#bin)
+    #[serde(default)] // handles Option
+    pub bin: Option<BinMap<String, String>>,
+}
+
+impl Info {
+    pub fn into_package_info(self) -> PackageInfo {
+        let mut map = HashMap::new();
+        if self.bin.is_some() {
+            for (name, path) in self.bin.unwrap().iter() {
+                if name == "" {
+                    // npm uses the package name for the binary in this case
+                    map.insert(self.name.clone(), path.clone());
+                } else {
+                    map.insert(name.clone(), path.clone());
+                }
+            }
+        }
+        return PackageInfo { bin: map };
+    }
+}
+
+// (deserialization adapted from https://serde.rs/deserialize-map.html)
+
+struct BinVisitor<K, V> {
+    marker: PhantomData<fn() -> BinMap<K, V>>,
+}
+
+impl<K, V> BinVisitor<K, V> {
+    fn new() -> Self {
+        BinVisitor {
+            marker: PhantomData,
+        }
+    }
+}
+
+// This trait informs Serde how to deserialize BinMap
+impl<'de> Deserialize<'de> for BinMap<String, String> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bin_visitor: BinVisitor<String, String> = BinVisitor::new();
+        deserializer.deserialize_any(bin_visitor)
+    }
+}
+
+// This trait contains methods to deserialize each type of data
+impl<'de, K, V> Visitor<'de> for BinVisitor<K, V>
+where
+    K: Deserialize<'de> + Hash + Eq,
+    V: Deserialize<'de> + Clone,
+{
+    type Value = BinMap<String, String>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("string or map")
+    }
+
+    // handle maps like { "binary-name": "path/to/bin" }
+    fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut bin_map = BinMap(HashMap::new());
+        while let Some((name, path)) = access.next_entry()? {
+            bin_map.insert(name, path);
+        }
+        Ok(bin_map)
+    }
+
+    // handle strings that are only the path
+    fn visit_str<E>(self, bin_path: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        let mut bin_map = BinMap(HashMap::new());
+        // There will only be one string here, so add it to the map
+        // with "" for the path, since that is unknown here
+        bin_map.insert("".to_string(), bin_path.to_string());
+        Ok(bin_map)
+    }
+}

--- a/crates/notion-core/src/serial/package.rs
+++ b/crates/notion-core/src/serial/package.rs
@@ -40,8 +40,9 @@ pub struct Info {
 impl Info {
     pub fn into_package_info(self) -> PackageInfo {
         let mut map = HashMap::new();
-        if self.bin.is_some() {
-            for (name, path) in self.bin.unwrap().iter() {
+        if let Some(ref bin) = self.bin {
+            for (name, path) in bin.iter() {
+                // handle case where only the path was given and binary name was unknown
                 if name == "" {
                     // npm uses the package name for the binary in this case
                     map.insert(self.name.clone(), path.clone());
@@ -110,7 +111,7 @@ where
     {
         let mut bin_map = BinMap(HashMap::new());
         // There will only be one string here, so add it to the map
-        // with "" for the path, since that is unknown here
+        // with "" for the name, since that is unknown here
         bin_map.insert("".to_string(), bin_path.to_string());
         Ok(bin_map)
     }


### PR DESCRIPTION
This adds a new deserializer to handle the "bin" section in package.json. This can be either a map or string, and serde can't automatically handle that, so it needs a custom deserializer.

This is separate from the deserialization done in notion-core::manifest, because this will operate on project dependencies and should not require the `"notion"` section to be present in package.json.