### PR TITLE
Logic to handle shims for 3rd party executables

### DIFF
--- a/crates/notion-core/fixtures/basic/node_modules/.bin/rsvp
+++ b/crates/notion-core/fixtures/basic/node_modules/.bin/rsvp
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+// for testing
+console.log("running the local rsvp binary...");
+

--- a/crates/notion-core/fixtures/basic/node_modules/@namespaced/something-else/package.json
+++ b/crates/notion-core/fixtures/basic/node_modules/@namespaced/something-else/package.json
@@ -4,15 +4,13 @@
   "description": "Testing that manifest pulls things out of this correctly",
   "license": "To Kill",
   "dependencies": {
-    "@namespace/some-dep": "0.2.4",
     "rsvp": "^3.5.0"
   },
   "devDependencies": {
-    "@namespaced/something-else": "^6.3.7",
     "eslint": "~4.8.0"
   },
-  "notion": {
-    "node": "6.11.1",
-    "yarn": "1.2"
+  "bin": {
+    "bin-1": "./lib/cli.js",
+    "bin-2": "./lib/cli.js"
   }
 }

--- a/crates/notion-core/fixtures/basic/rsvp
+++ b/crates/notion-core/fixtures/basic/rsvp
@@ -1,0 +1,1 @@
+../../../../target/debug/launchbin

--- a/crates/notion-core/src/env.rs
+++ b/crates/notion-core/src/env.rs
@@ -10,7 +10,7 @@ use path;
 /// Produces a modified version of the current `PATH` environment variable that
 /// will find Node.js executables in the installation directory for the given
 /// version of Node instead of in the Notion shim directory.
-pub fn path_for(version: &str) -> OsString {
+pub fn path_for_installed_node(version: &str) -> OsString {
     let current = env::var_os("PATH").unwrap_or(OsString::new());
     let shim_dir = &path::shim_dir().unwrap();
     let split = env::split_paths(&current).filter(|s| s != shim_dir);
@@ -22,8 +22,9 @@ pub fn path_for(version: &str) -> OsString {
 }
 
 /// Produces a modified version of the current `PATH` environment variable that
-/// removes the Notion shims and binaries.
-pub fn path_no_notion() -> OsString {
+/// removes the Notion shims and binaries, to use for running system node and
+/// executables.
+pub fn path_for_system_node() -> OsString {
     let current = env::var_os("PATH").unwrap_or(OsString::new());
     let shim_dir = &path::shim_dir().unwrap();
     let bin_dir = &path::bin_dir().unwrap();

--- a/crates/notion-core/src/env.rs
+++ b/crates/notion-core/src/env.rs
@@ -20,3 +20,14 @@ pub fn path_for(version: &str) -> OsString {
     path_vec.extend(split);
     env::join_paths(path_vec.iter()).unwrap()
 }
+
+/// Produces a modified version of the current `PATH` environment variable that
+/// removes the Notion shims and binaries.
+pub fn path_no_notion() -> OsString {
+    let current = env::var_os("PATH").unwrap_or(OsString::new());
+    let shim_dir = &path::shim_dir().unwrap();
+    let bin_dir = &path::bin_dir().unwrap();
+    // remove the shim and bin dirs from the path
+    let split = env::split_paths(&current).filter(|s| s != shim_dir && s != bin_dir);
+    env::join_paths(split).unwrap()
+}

--- a/crates/notion-core/src/path/unix.rs
+++ b/crates/notion-core/src/path/unix.rs
@@ -126,6 +126,11 @@ pub fn yarn_version_bin_dir(version: &str) -> Fallible<PathBuf> {
     Ok(yarn_version_dir(version)?.join("bin"))
 }
 
+// 3rd-party binaries installed globally for this node version
+pub fn node_version_3p_bin_dir(version: &str) -> Fallible<PathBuf> {
+    Ok(node_version_dir(version)?.join("lib/node_modules/.bin"))
+}
+
 pub fn bin_dir() -> Fallible<PathBuf> {
     Ok(notion_home()?.join("bin"))
 }

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -86,6 +86,12 @@ pub fn node_version_bin_dir(version: &str) -> Fallible<PathBuf> {
     node_version_dir(version)
 }
 
+// 3rd-party binaries installed globally for this node version
+pub fn node_version_3p_bin_dir(version: &str) -> Fallible<PathBuf> {
+    // ISSUE (#90) Figure out where binaries are globally installed on Windows
+    unimplemented!("global 3rd party executables not yet implemented for Windows")
+}
+
 pub fn launchbin_file() -> Fallible<PathBuf> {
     Ok(program_data_root()?.join("launchbin.exe"))
 }

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -1,11 +1,13 @@
 //! Provides the `Project` type, which represents a Node project tree in
 //! the filesystem.
 
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use notion_fail::{Fallible, ResultExt};
+use package_info::PackageInfo;
 
 use manifest::Manifest;
 
@@ -28,14 +30,20 @@ fn is_project_root(dir: &Path) -> bool {
 /// A Node project tree in the filesystem.
 pub struct Project {
     manifest: Manifest,
+    project_root: PathBuf,
 }
 
 impl Project {
     /// Returns the Node project containing the current working directory,
     /// if any.
     pub fn for_current_dir() -> Fallible<Option<Project>> {
-        let mut dir: &Path = &env::current_dir().unknown()?;
+        let current_dir: &Path = &env::current_dir().unknown()?;
+        Self::for_dir(&current_dir)
+    }
 
+    /// Returns the Node project for the input directory, if any.
+    pub fn for_dir(base_dir: &Path) -> Fallible<Option<Project>> {
+        let mut dir = base_dir.clone();
         while !is_project_root(dir) {
             dir = match dir.parent() {
                 Some(parent) => parent,
@@ -52,11 +60,156 @@ impl Project {
             }
         };
 
-        Ok(Some(Project { manifest: manifest }))
+        Ok(Some(Project {
+            manifest: manifest,
+            project_root: PathBuf::from(dir),
+        }))
     }
 
     /// Returns the project manifest (`package.json`) for this project.
     pub fn manifest(&self) -> &Manifest {
         &self.manifest
+    }
+
+    /// Returns the path to the local binary directory for this project.
+    pub fn local_bin_dir(&self) -> PathBuf {
+        let mut bin_dir = self.project_root.clone();
+        bin_dir.push("node_modules/.bin");
+        bin_dir
+    }
+
+    /// Returns true if the input binary name is a direct dependency of the input project
+    pub fn has_local_bin(&self, bin_name: &OsStr) -> Fallible<bool> {
+        if let Some(dep_bins) = self.dependent_binaries()? {
+            if let Some(bin_name_str) = bin_name.to_str() {
+                if dep_bins.contains_key(bin_name_str) {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Gets the names of all the direct dependencies of the current project
+    fn all_dependencies(&self) -> Fallible<Option<HashSet<String>>> {
+        if let Some(manifest) = Manifest::for_dir(&self.project_root)? {
+            let mut dependencies = HashSet::new();
+            for (name, _version) in manifest.dependencies.iter() {
+                dependencies.insert(name.clone());
+            }
+            for (name, _version) in manifest.dev_dependencies.iter() {
+                dependencies.insert(name.clone());
+            }
+            return Ok(Some(dependencies));
+        }
+        Ok(None)
+    }
+
+    /// Gets the names of all the binaries installed by direct dependencies of the current project
+    fn dependent_binaries(&self) -> Fallible<Option<HashMap<String, String>>> {
+        if let Some(all_deps) = self.all_dependencies()? {
+            let mut retval = HashMap::new();
+
+            // convert dependency names to the path to each project
+            let all_dep_paths = all_deps
+                .iter()
+                .map(|dep_name| {
+                    let mut path_to_pkg = PathBuf::from(&self.project_root);
+                    path_to_pkg.push("node_modules");
+                    path_to_pkg.push(dep_name);
+                    path_to_pkg
+                })
+                .collect::<HashSet<PathBuf>>();
+
+            // use those project paths to get the "bin" info for each project
+            for pkg_path in all_dep_paths.iter() {
+                let pkg_info = PackageInfo::for_dir(&pkg_path)?;
+                let bin_map = pkg_info.bin;
+                for (name, path) in bin_map.iter() {
+                    retval.insert(name.clone(), path.clone());
+                }
+            }
+            return Ok(Some(retval));
+        }
+        Ok(None)
+    }
+}
+
+// unit tests
+
+#[cfg(test)]
+pub mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::ffi::OsStr;
+    use std::path::PathBuf;
+
+    use project::Project;
+
+    fn fixture_path(fixture_dir: &str) -> PathBuf {
+        let mut cargo_manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        cargo_manifest_dir.push("fixtures");
+        cargo_manifest_dir.push(fixture_dir);
+        cargo_manifest_dir
+    }
+
+    #[test]
+    fn gets_all_dependencies() {
+        let project_path = fixture_path("basic");
+        let test_project = Project::for_dir(&project_path).unwrap().unwrap();
+
+        let all_deps = match test_project.all_dependencies() {
+            Ok(deps) => deps,
+            _ => panic!(
+                "Error: Could not get dependencies for project {:?}",
+                project_path
+            ),
+        };
+        let mut expected_deps = HashSet::new();
+        expected_deps.insert("@namespace/some-dep".to_string());
+        expected_deps.insert("rsvp".to_string());
+        expected_deps.insert("@namespaced/something-else".to_string());
+        expected_deps.insert("eslint".to_string());
+        assert_eq!(all_deps, Some(expected_deps));
+    }
+
+    #[test]
+    fn gets_binary_info() {
+        let project_path = fixture_path("basic");
+        let test_project = Project::for_dir(&project_path).unwrap().unwrap();
+
+        let dep_bins = match test_project.dependent_binaries() {
+            Ok(bin_map) => bin_map,
+            _ => panic!(
+                "Error: Could not get dependent binaries for project {:?}",
+                project_path
+            ),
+        };
+        let mut expected_bins = HashMap::new();
+        expected_bins.insert("eslint".to_string(), "./bin/eslint.js".to_string());
+        expected_bins.insert("rsvp".to_string(), "./bin/rsvp.js".to_string());
+        expected_bins.insert("bin-1".to_string(), "./lib/cli.js".to_string());
+        expected_bins.insert("bin-2".to_string(), "./lib/cli.js".to_string());
+        assert_eq!(dep_bins, Some(expected_bins));
+    }
+
+    #[test]
+    fn local_bin_true() {
+        let project_path = fixture_path("basic");
+        let test_project = Project::for_dir(&project_path).unwrap().unwrap();
+        // eslint, rsvp, bin-1, and bin-2 are direct dependencies
+        assert!(test_project.has_local_bin(&OsStr::new("eslint")).unwrap());
+        assert!(test_project.has_local_bin(&OsStr::new("rsvp")).unwrap());
+        assert!(test_project.has_local_bin(&OsStr::new("bin-1")).unwrap());
+        assert!(test_project.has_local_bin(&OsStr::new("bin-2")).unwrap());
+    }
+
+    #[test]
+    fn local_bin_false() {
+        let project_path = fixture_path("basic");
+        let test_project = Project::for_dir(&project_path).unwrap().unwrap();
+        // tsc and tsserver are installed, but not direct deps
+        assert!(!test_project.has_local_bin(&OsStr::new("tsc")).unwrap());
+        assert!(!test_project.has_local_bin(&OsStr::new("tsserver")).unwrap());
     }
 }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -25,6 +25,7 @@ pub enum ActivityKind {
     Tool,
     Help,
     Version,
+    Binary,
 }
 
 impl Display for ActivityKind {
@@ -40,6 +41,7 @@ impl Display for ActivityKind {
             &ActivityKind::Tool => "tool",
             &ActivityKind::Help => "help",
             &ActivityKind::Version => "version",
+            &ActivityKind::Binary => "binary",
         };
         f.write_str(s)
     }


### PR DESCRIPTION
This implements the logic to handle shims to 3rd-party executables.

## 3rd party executables

These are executables that can be installed
* locally (in `node_modules/.bin`),
* globally with the version of node installed using Notion,
* and/or globally with the system node

## Priority

This is the priority used to decide what to execute:
1) If the executable is installed locally, and a direct dependency of the current project, then we execute that. We only execute direct dependencies because npm and yarn install executables for everything installed in `node_modules/`, not just direct dependencies. Exposing all of those on the path would be a security risk as well as confusing to debug.
2) If node is configured with Notion (using `notion use`, or Notion config in the project), we execute the globally-installed executable for the configured version of node.
3) Otherwise we run the executable installed globally with the system node.

## Shims

I haven't implemented the logic for creating the shims yet, but they should live in the `~/.notion/shim/` directory, as symlinks to the `launchbin` binary (like how `npm` and `npx` are symlinks to `launchscript` right now). And there will be a `notion shim` command to manage these accordingly.

## TODO

This needs better error handling, especially when we expect the executable to exist but it does not.