### PR TITLE
Better messages for common errors

### DIFF
--- a/crates/notion-core/src/installer/error.rs
+++ b/crates/notion-core/src/installer/error.rs
@@ -5,14 +5,16 @@ use notion_fail::NotionFail;
 use failure;
 
 #[derive(Fail, Debug)]
-#[fail(display = "{}", error)]
+#[fail(display = "Failed to download version {}\n{}", version, error)]
 pub(crate) struct DownloadError {
+    version: String,
     error: String,
 }
 
 impl DownloadError {
-    pub(crate) fn from_error(error: &failure::Error) -> DownloadError {
-        DownloadError {
+    pub(crate) fn for_version(version: String) -> impl FnOnce(&failure::Error) -> DownloadError {
+        move |error| DownloadError {
+            version: version,
             error: error.to_string(),
         }
     }

--- a/crates/notion-core/src/installer/error.rs
+++ b/crates/notion-core/src/installer/error.rs
@@ -1,0 +1,28 @@
+//! Provides error types for the installer tools.
+
+use notion_fail::NotionFail;
+
+use failure;
+
+#[derive(Fail, Debug)]
+#[fail(display = "{}", error)]
+pub(crate) struct DownloadError {
+    error: String,
+}
+
+impl DownloadError {
+    pub(crate) fn from_error(error: &failure::Error) -> DownloadError {
+        DownloadError {
+            error: error.to_string(),
+        }
+    }
+}
+
+impl NotionFail for DownloadError {
+    fn is_user_friendly(&self) -> bool {
+        true
+    }
+    fn exit_code(&self) -> i32 {
+        4
+    }
+}

--- a/crates/notion-core/src/installer/mod.rs
+++ b/crates/notion-core/src/installer/mod.rs
@@ -1,5 +1,6 @@
 //! Provides types for installing tools into the Notion catalog.
 
+mod error;
 pub mod node;
 pub mod yarn;
 

--- a/crates/notion-core/src/installer/node.rs
+++ b/crates/notion-core/src/installer/node.rs
@@ -5,6 +5,7 @@ use std::string::ToString;
 
 use super::{Install, Installed};
 use catalog::NodeCollection;
+use installer::error::DownloadError;
 use node_archive::{self, Archive};
 use path;
 use style::{progress_bar, Action};
@@ -38,7 +39,7 @@ impl Install for NodeInstaller {
         }
 
         Ok(NodeInstaller {
-            archive: node_archive::fetch(url, &cache_file).unknown()?,
+            archive: node_archive::fetch(url, &cache_file).with_context(DownloadError::from_error)?,
             version: version,
         })
     }

--- a/crates/notion-core/src/installer/node.rs
+++ b/crates/notion-core/src/installer/node.rs
@@ -39,7 +39,8 @@ impl Install for NodeInstaller {
         }
 
         Ok(NodeInstaller {
-            archive: node_archive::fetch(url, &cache_file).with_context(DownloadError::from_error)?,
+            archive: node_archive::fetch(url, &cache_file)
+                .with_context(DownloadError::for_version(version.to_string()))?,
             version: version,
         })
     }

--- a/crates/notion-core/src/installer/yarn.rs
+++ b/crates/notion-core/src/installer/yarn.rs
@@ -5,6 +5,7 @@ use std::string::ToString;
 
 use super::{Install, Installed};
 use catalog::YarnCollection;
+use installer::error::DownloadError;
 use node_archive::{self, Archive};
 use path;
 use style::{progress_bar, Action};
@@ -39,7 +40,7 @@ impl Install for YarnInstaller {
         }
 
         Ok(YarnInstaller {
-            archive: node_archive::fetch(url, &cache_file).unknown()?,
+            archive: node_archive::fetch(url, &cache_file).with_context(DownloadError::from_error)?,
             version: version,
         })
     }

--- a/crates/notion-core/src/installer/yarn.rs
+++ b/crates/notion-core/src/installer/yarn.rs
@@ -40,7 +40,8 @@ impl Install for YarnInstaller {
         }
 
         Ok(YarnInstaller {
-            archive: node_archive::fetch(url, &cache_file).with_context(DownloadError::from_error)?,
+            archive: node_archive::fetch(url, &cache_file)
+                .with_context(DownloadError::for_version(version.to_string()))?,
             version: version,
         })
     }

--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -20,7 +20,6 @@ impl NotionFail for VersionParseError {
         true
     }
     fn exit_code(&self) -> i32 {
-        // TODO
         4
     }
 }

--- a/crates/notion-core/src/style.rs
+++ b/crates/notion-core/src/style.rs
@@ -14,7 +14,7 @@ pub enum ErrorContext {
     Notion,
 
     /// An error reported from a shim.
-    Shim
+    Shim,
 }
 
 /// Displays an error to stderr.

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -50,6 +50,25 @@ impl NotionFail for BinaryExecError {
     }
 }
 
+#[derive(Fail, Debug)]
+#[fail(display = "this tool is not yet implemented")]
+pub(crate) struct ToolUnimplementedError;
+
+impl ToolUnimplementedError {
+    pub(crate) fn new() -> Self {
+        ToolUnimplementedError {}
+    }
+}
+
+impl NotionFail for ToolUnimplementedError {
+    fn is_user_friendly(&self) -> bool {
+        true
+    }
+    fn exit_code(&self) -> i32 {
+        4
+    }
+}
+
 /// Represents a command-line tool that Notion shims delegate to.
 pub trait Tool: Sized {
     fn launch() -> ! {
@@ -124,7 +143,7 @@ pub struct Yarn(Command);
 #[cfg(windows)]
 impl Tool for Script {
     fn new(session: &mut Session) -> Fallible<Self> {
-        unimplemented!()
+        throw!(ToolUnimplementedError::new())
     }
 
     fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
@@ -157,7 +176,7 @@ fn command_for(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Command {
 #[cfg(unix)]
 impl Tool for Script {
     fn new(_session: &mut Session) -> Fallible<Self> {
-        unimplemented!()
+        throw!(ToolUnimplementedError::new())
     }
 
     fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
@@ -167,8 +186,6 @@ impl Tool for Script {
     fn command(self) -> Command {
         self.0
     }
-
-
 }
 
 impl Tool for Binary {
@@ -242,7 +259,7 @@ fn arg0(args: &mut ArgsOs) -> Fallible<OsString> {
 #[derive(Fail, Debug)]
 #[fail(display = "No {} version selected", tool)]
 struct NoGlobalError {
-    tool: String
+    tool: String,
 }
 
 impl NotionFail for NoGlobalError {
@@ -263,7 +280,9 @@ impl Tool for Node {
         let version = if let Some(version) = session.current_node()? {
             version
         } else {
-            throw!(NoGlobalError { tool: "Node".to_string() });
+            throw!(NoGlobalError {
+                tool: "Node".to_string()
+            });
         };
         let path_var = env::path_for_installed_node(&version.to_string());
         Ok(Self::from_components(&exe, args, &path_var))
@@ -287,7 +306,9 @@ impl Tool for Yarn {
         let version = if let Some(version) = session.current_yarn()? {
             version
         } else {
-            throw!(NoGlobalError { tool: "Yarn".to_string() });
+            throw!(NoGlobalError {
+                tool: "Yarn".to_string()
+            });
         };
         let path_var = env::path_for_installed_node(&version.to_string());
         Ok(Self::from_components(&exe, args, &path_var))

--- a/src/command/config.rs
+++ b/src/command/config.rs
@@ -11,6 +11,7 @@ use Notion;
 use command::{Command, CommandName, Help};
 
 use CliParseError;
+use CommandUnimplementedError;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
@@ -181,10 +182,14 @@ Config commands:
         let result = match self {
             Config::Help => Help::Command(CommandName::Config).run(session),
             Config::Subcommand(Subcommand::Get { key: _ }) => Ok(true),
-            Config::Subcommand(Subcommand::Set { key: _, value: _ }) => unimplemented!(),
-            Config::Subcommand(Subcommand::Delete { key: _ }) => unimplemented!(),
-            Config::Subcommand(Subcommand::List) => unimplemented!(),
-            Config::Subcommand(Subcommand::Edit) => unimplemented!(),
+            Config::Subcommand(Subcommand::Set { key: _, value: _ }) => {
+                throw!(CommandUnimplementedError::new("set"))
+            }
+            Config::Subcommand(Subcommand::Delete { key: _ }) => {
+                throw!(CommandUnimplementedError::new("delete"))
+            }
+            Config::Subcommand(Subcommand::List) => throw!(CommandUnimplementedError::new("list")),
+            Config::Subcommand(Subcommand::Edit) => throw!(CommandUnimplementedError::new("edit")),
         };
         //session.add_event_end(ActivityKind::Version, 0);
         result

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,3 +71,26 @@ impl NotionErrorExt for NotionError {
         None
     }
 }
+
+#[derive(Fail, Debug)]
+#[fail(display = "command `{}` is not yet implemented", name)]
+pub(crate) struct CommandUnimplementedError {
+    pub(crate) name: String,
+}
+
+impl CommandUnimplementedError {
+    pub(crate) fn new(cmd_name: &str) -> Self {
+        CommandUnimplementedError {
+            name: cmd_name.to_string(),
+        }
+    }
+}
+
+impl NotionFail for CommandUnimplementedError {
+    fn is_user_friendly(&self) -> bool {
+        true
+    }
+    fn exit_code(&self) -> i32 {
+        4
+    }
+}

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -25,7 +25,7 @@ use notion_fail::{FailExt, Fallible, NotionError};
 
 use command::{Command, CommandName, Config, Current, Deactivate, Default, Help, Install, Shim,
               Uninstall, Use, Version};
-use error::{CliParseError, DocoptExt, NotionErrorExt};
+use error::{CliParseError, CommandUnimplementedError, DocoptExt, NotionErrorExt};
 
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
I implemented error messages for common error cases where we usually get `error: an internal error occurred`, or `thread 'main' panicked at 'not yet implemented'`, which are not user-friendly or helpful.

Instead, we get these errors now:

```
$ notion install 6.5.4.3
error: the given version requirement is invalid
```

```
$ notion config list
error: command `list` is not yet implemented
```

```
$ notion install 8
error: Could not fetch public registry
https://nodejs.org/dist/index.json: failed to lookup address information: nodename nor servname provided, or not known
```

```
$ notion install 9
error: Failed to download version 9.11.2
https://nodejs.org/dist/v9.11.2/node-v9.11.2-darwin-x64.tar.gz: failed to lookup address information: nodename nor servname provided, or not known
```

```
$ notion uninstall 6
error: Could not parse version: Expected dot
```

```
$ notion shim -v
error: Could not read dependent package info: Could not read package info: No such file or directory (os error 2)
```

Most of these are just surfacing lower-level errors. If there are better messages we can use for these I am fine with changing them to be more helpful/descriptive.

Closes #70.