### PR TITLE
Rename the `package.json` key to `"toolchain"`

### DIFF
--- a/crates/notion-core/fixtures/basic/package.json
+++ b/crates/notion-core/fixtures/basic/package.json
@@ -11,7 +11,7 @@
     "@namespaced/something-else": "^6.3.7",
     "eslint": "~4.8.0"
   },
-  "notion": {
+  "toolchain": {
     "node": "6.11.1",
     "yarn": "1.2"
   }

--- a/crates/notion-core/src/serial/manifest.rs
+++ b/crates/notion-core/src/serial/manifest.rs
@@ -19,11 +19,11 @@ pub struct Manifest {
     #[serde(rename = "devDependencies")]
     pub dev_dependencies: HashMap<String, String>,
 
-    pub notion: Option<NotionManifest>,
+    pub toolchain: Option<ToolchainManifest>,
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct NotionManifest {
+pub struct ToolchainManifest {
     pub node: String,
     pub yarn: Option<String>,
     // FIXME: this should be in the notion config file
@@ -32,7 +32,7 @@ pub struct NotionManifest {
 
 impl Manifest {
     pub fn into_manifest(self) -> Fallible<Option<manifest::Manifest>> {
-        if let Some(notion) = self.notion {
+        if let Some(notion) = self.toolchain {
             return Ok(Some(manifest::Manifest {
                 node: parse_requirements(&notion.node)?,
                 yarn: if let Some(yarn) = notion.yarn {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "ember-cli": "2.18.1"
   },
-  "notion": {
+  "toolchain": {
     "node": "6.11.1",
     "yarn": "1.7.0"
   }


### PR DESCRIPTION
The mental model of static linking is that you're specifying the version of the toolchain you want your package to be executed with. So it's more general than just "tell Notion what to do" -- it's really _documenting how your project is meant to be run_. So this PR renames the key to `"toolchain"` to express this intent.