### PR TITLE
Exit codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,8 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notion-fail-derive 0.1.0",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notion-core 0.1.0",
  "notion-fail 0.1.0",
+ "notion-fail-derive 0.1.0",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -692,6 +693,7 @@ dependencies = [
  "lazycell 0.6.0 (git+https://github.com/dherman/lazycell?branch=borrow_mut_with)",
  "node-archive 0.1.0",
  "notion-fail 0.1.0",
+ "notion-fail-derive 0.1.0",
  "os_info 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "readext 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -711,6 +713,16 @@ version = "0.1.0"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notion-fail-derive 0.1.0",
+]
+
+[[package]]
+name = "notion-fail-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -793,7 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -869,6 +881,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "progress-read"
 version = "0.1.0"
 
@@ -883,6 +903,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1136,8 +1164,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1166,6 +1197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1603,8 +1644,10 @@ dependencies = [
 "checksum proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ba8d4f9257b85eb6cdf13f055cea3190520aab1409ca2ab43493ea4820c25f0"
 "checksum proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5cb6f960ad471404618e9817c0e5d10b1ae74cfdf01fab89ea0641fe7fb2892"
 "checksum proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1cb7aaaa4bf022ec2b14ff2f2ba1643a22f3cee88df014a85e14b392282c61d"
+"checksum proc-macro2 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "7a17a4d77bc20d344179de803a34694c0ac7a0b3fb4384bee99783215a8e0410"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
+"checksum quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ed7d650913520df631972f21e104a4fa2f9c82a14afc65d17b388a2e29731e7c"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum readext 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "abdc58f5f18bcf347b55cebb34ed4618b0feff9a9223160f5902adbc1f6a72a6"
@@ -1634,11 +1677,12 @@ dependencies = [
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
-"checksum smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44db0ecb22921ef790d17ae13a3f6d15784183ff5f2a01aa32098c7498d2b4b9"
+"checksum smallvec 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "211a489e65e94b103926d2054ae515a1cdb5d515ea0ef414fee23b7e043ce748"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.12.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9e1c669ed757c0ebd04337f6a5bb972d05e0c08fe2540dd3ee3dd9e4daf1604c"
+"checksum syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bfcbb0c068d0f642a0ffbd5c604965a360a61f99e8add013cef23a838614f3"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ console = "0.6.1"
 failure_derive = "0.1.1"
 failure = "0.1.1"
 notion-fail = { path = "crates/notion-fail" }
+notion-fail-derive = { path = "crates/notion-fail-derive" }
 semver = "0.9.0"
 
 [workspace]

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -19,6 +19,7 @@ node-archive = { path = "../node-archive" }
 failure = "0.1.1"
 failure_derive = "0.1.1"
 notion-fail = { path = "../notion-fail" }
+notion-fail-derive = { path = "../notion-fail-derive" }
 lazycell = { "git" = "https://github.com/dherman/lazycell", "branch" = "borrow_mut_with" }
 semver = "0.9.0"
 cmdline_words_parser = "0.0.2"

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -212,22 +212,20 @@ impl Catalog {
 }
 
 /// Thrown when there is no Node version matching a requested semver specifier.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "No Node version found for {}", matching)]
+#[notion_fail(code = "NoVersionMatch")]
 struct NoNodeVersionFoundError {
     matching: VersionReq,
 }
 
-impl_notion_fail!(NoNodeVersionFoundError, NoVersionMatch);
-
 /// Thrown when there is no Yarn version matching a requested semver specifier.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "No Yarn version found for {}", matching)]
+#[notion_fail(code = "NoVersionMatch")]
 struct NoYarnVersionFoundError {
     matching: VersionReq,
 }
-
-impl_notion_fail!(NoYarnVersionFoundError, NoVersionMatch);
 
 impl<D: Distro> Collection<D> {
     /// Tests whether this Collection contains the specified Tool version.
@@ -263,8 +261,9 @@ pub trait Resolve<D: Distro> {
 }
 
 /// Thrown when the public registry for Node or Yarn could not be downloaded.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Could not fetch public registry\n{}", error)]
+#[notion_fail(code = "NetworkError")]
 pub(crate) struct RegistryFetchError {
     error: String,
 }
@@ -276,8 +275,6 @@ impl RegistryFetchError {
         }
     }
 }
-
-impl_notion_fail!(RegistryFetchError, NetworkError);
 
 impl Resolve<NodeDistro> for NodeCollection {
     fn resolve_public(&self, matching: &VersionReq) -> Fallible<NodeDistro> {

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -217,14 +217,8 @@ impl Catalog {
 struct NoNodeVersionFoundError {
     matching: VersionReq,
 }
-impl NotionFail for NoNodeVersionFoundError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NoVersionMatch
-    }
-}
+
+impl_notion_fail!(NoNodeVersionFoundError, ExitCode::NoVersionMatch);
 
 /// Thrown when there is no Yarn version matching a requested semver specifier.
 #[derive(Fail, Debug)]
@@ -232,14 +226,8 @@ impl NotionFail for NoNodeVersionFoundError {
 struct NoYarnVersionFoundError {
     matching: VersionReq,
 }
-impl NotionFail for NoYarnVersionFoundError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NoVersionMatch
-    }
-}
+
+impl_notion_fail!(NoYarnVersionFoundError, ExitCode::NoVersionMatch);
 
 impl<D: Distro> Collection<D> {
     /// Tests whether this Collection contains the specified Tool version.
@@ -289,14 +277,7 @@ impl RegistryFetchError {
     }
 }
 
-impl NotionFail for RegistryFetchError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NetworkError
-    }
-}
+impl_notion_fail!(RegistryFetchError, ExitCode::NetworkError);
 
 impl Resolve<NodeDistro> for NodeCollection {
     fn resolve_public(&self, matching: &VersionReq) -> Fallible<NodeDistro> {

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -218,7 +218,7 @@ struct NoNodeVersionFoundError {
     matching: VersionReq,
 }
 
-impl_notion_fail!(NoNodeVersionFoundError, ExitCode::NoVersionMatch);
+impl_notion_fail!(NoNodeVersionFoundError, NoVersionMatch);
 
 /// Thrown when there is no Yarn version matching a requested semver specifier.
 #[derive(Fail, Debug)]
@@ -227,7 +227,7 @@ struct NoYarnVersionFoundError {
     matching: VersionReq,
 }
 
-impl_notion_fail!(NoYarnVersionFoundError, ExitCode::NoVersionMatch);
+impl_notion_fail!(NoYarnVersionFoundError, NoVersionMatch);
 
 impl<D: Distro> Collection<D> {
     /// Tests whether this Collection contains the specified Tool version.
@@ -277,7 +277,7 @@ impl RegistryFetchError {
     }
 }
 
-impl_notion_fail!(RegistryFetchError, ExitCode::NetworkError);
+impl_notion_fail!(RegistryFetchError, NetworkError);
 
 impl Resolve<NodeDistro> for NodeCollection {
     fn resolve_public(&self, matching: &VersionReq) -> Fallible<NodeDistro> {

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -22,7 +22,7 @@ use config::{Config, ToolConfig};
 use distro::node::NodeDistro;
 use distro::yarn::YarnDistro;
 use distro::{Distro, Fetched};
-use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
+use notion_fail::{ExitCode, Fallible, NotionError, NotionFail, ResultExt};
 use path::{self, user_catalog_file};
 use semver::{Version, VersionReq};
 use serial;
@@ -221,8 +221,8 @@ impl NotionFail for NoNodeVersionFoundError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        100
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::NoVersionMatch
     }
 }
 
@@ -236,8 +236,8 @@ impl NotionFail for NoYarnVersionFoundError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        100
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::NoVersionMatch
     }
 }
 
@@ -293,8 +293,8 @@ impl NotionFail for RegistryFetchError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::NetworkError
     }
 }
 

--- a/crates/notion-core/src/distro/error.rs
+++ b/crates/notion-core/src/distro/error.rs
@@ -1,6 +1,6 @@
 //! Provides error types for the installer tools.
 
-use notion_fail::NotionFail;
+use notion_fail::{ExitCode, NotionFail};
 
 use failure;
 
@@ -24,7 +24,7 @@ impl NotionFail for DownloadError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::NetworkError
     }
 }

--- a/crates/notion-core/src/distro/error.rs
+++ b/crates/notion-core/src/distro/error.rs
@@ -20,11 +20,4 @@ impl DownloadError {
     }
 }
 
-impl NotionFail for DownloadError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NetworkError
-    }
-}
+impl_notion_fail!(DownloadError, ExitCode::NetworkError);

--- a/crates/notion-core/src/distro/error.rs
+++ b/crates/notion-core/src/distro/error.rs
@@ -20,4 +20,4 @@ impl DownloadError {
     }
 }
 
-impl_notion_fail!(DownloadError, ExitCode::NetworkError);
+impl_notion_fail!(DownloadError, NetworkError);

--- a/crates/notion-core/src/distro/error.rs
+++ b/crates/notion-core/src/distro/error.rs
@@ -4,8 +4,9 @@ use notion_fail::{ExitCode, NotionFail};
 
 use failure;
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Failed to download version {}\n{}", version, error)]
+#[notion_fail(code = "NetworkError")]
 pub(crate) struct DownloadError {
     version: String,
     error: String,
@@ -19,5 +20,3 @@ impl DownloadError {
         }
     }
 }
-
-impl_notion_fail!(DownloadError, NetworkError);

--- a/crates/notion-core/src/event.rs
+++ b/crates/notion-core/src/event.rs
@@ -109,7 +109,7 @@ impl EventLog {
         let exit_code = error.exit_code();
         self.add_event(
             EventKind::Error {
-                exit_code,
+                exit_code: exit_code as i32,
                 error: error.to_string(),
                 env: get_error_env(),
             },

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -44,6 +44,8 @@ extern crate failure;
 extern crate failure_derive;
 #[macro_use]
 extern crate notion_fail;
+#[macro_use]
+extern crate notion_fail_derive;
 
 #[macro_use]
 extern crate cfg_if;

--- a/crates/notion-core/src/manifest.rs
+++ b/crates/notion-core/src/manifest.rs
@@ -6,15 +6,16 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 use detect_indent;
-use notion_fail::{Fallible, NotionFail, ResultExt};
+use notion_fail::{ExitCode, Fallible, NotionFail, ResultExt};
 use semver::VersionReq;
 use serde::Serialize;
 use serde_json;
 
 use serial;
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Could not read package info: {}", error)]
+#[notion_fail(code = "FileSystemError")]
 pub(crate) struct PackageReadError {
     pub(crate) error: String,
 }
@@ -24,15 +25,6 @@ impl PackageReadError {
         PackageReadError {
             error: error.to_string(),
         }
-    }
-}
-
-impl NotionFail for PackageReadError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> i32 {
-        4
     }
 }
 

--- a/crates/notion-core/src/path/unix.rs
+++ b/crates/notion-core/src/path/unix.rs
@@ -5,7 +5,7 @@ use std::{env, io};
 use std::path::PathBuf;
 use std::os::unix;
 
-use notion_fail::{Fallible, NotionFail};
+use notion_fail::{ExitCode, Fallible, NotionFail};
 
 #[derive(Fail, Debug)]
 #[fail(display = "environment variable 'HOME' is not set")]
@@ -13,7 +13,7 @@ pub(crate) struct NoHomeEnvVar;
 
 impl NotionFail for NoHomeEnvVar {
     fn is_user_friendly(&self) -> bool { true }
-    fn exit_code(&self) -> i32 { 4 }
+    fn exit_code(&self) -> ExitCode { ExitCode::EnvironmentError }
 }
 
 // These are taken from: https://nodejs.org/dist/index.json and are used

--- a/crates/notion-core/src/path/unix.rs
+++ b/crates/notion-core/src/path/unix.rs
@@ -11,7 +11,7 @@ use notion_fail::{ExitCode, Fallible, NotionFail};
 #[fail(display = "environment variable 'HOME' is not set")]
 pub(crate) struct NoHomeEnvVar;
 
-impl_notion_fail!(NoHomeEnvVar, ExitCode::EnvironmentError);
+impl_notion_fail!(NoHomeEnvVar, EnvironmentError);
 
 // These are taken from: https://nodejs.org/dist/index.json and are used
 // by `path::archive_root_dir` to determine the root directory of the

--- a/crates/notion-core/src/path/unix.rs
+++ b/crates/notion-core/src/path/unix.rs
@@ -7,11 +7,10 @@ use std::os::unix;
 
 use notion_fail::{ExitCode, Fallible, NotionFail};
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "environment variable 'HOME' is not set")]
+#[notion_fail(code = "EnvironmentError")]
 pub(crate) struct NoHomeEnvVar;
-
-impl_notion_fail!(NoHomeEnvVar, EnvironmentError);
 
 // These are taken from: https://nodejs.org/dist/index.json and are used
 // by `path::archive_root_dir` to determine the root directory of the

--- a/crates/notion-core/src/path/unix.rs
+++ b/crates/notion-core/src/path/unix.rs
@@ -11,10 +11,7 @@ use notion_fail::{ExitCode, Fallible, NotionFail};
 #[fail(display = "environment variable 'HOME' is not set")]
 pub(crate) struct NoHomeEnvVar;
 
-impl NotionFail for NoHomeEnvVar {
-    fn is_user_friendly(&self) -> bool { true }
-    fn exit_code(&self) -> ExitCode { ExitCode::EnvironmentError }
-}
+impl_notion_fail!(NoHomeEnvVar, ExitCode::EnvironmentError);
 
 // These are taken from: https://nodejs.org/dist/index.json and are used
 // by `path::archive_root_dir` to determine the root directory of the

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -48,8 +48,9 @@ impl LazyDependentBins {
     }
 }
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Could not read dependent package info: {}", error)]
+#[notion_fail(code = "FileSystemError")]
 pub(crate) struct DepPackageReadError {
     pub(crate) error: String,
 }
@@ -62,11 +63,10 @@ impl DepPackageReadError {
     }
 }
 
-impl_notion_fail!(DepPackageReadError, FileSystemError);
-
 /// Thrown when a user tries to pin a Yarn version before pinning a Node version.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "There is no pinned node version for this project")]
+#[notion_fail(code = "ConfigurationError")]
 pub(crate) struct NoPinnedNodeVersion;
 
 impl NoPinnedNodeVersion {
@@ -74,8 +74,6 @@ impl NoPinnedNodeVersion {
         NoPinnedNodeVersion
     }
 }
-
-impl_notion_fail!(NoPinnedNodeVersion, ConfigurationError);
 
 /// A Node project tree in the filesystem.
 pub struct Project {

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -62,14 +62,7 @@ impl DepPackageReadError {
     }
 }
 
-impl NotionFail for DepPackageReadError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::FileSystemError
-    }
-}
+impl_notion_fail!(DepPackageReadError, ExitCode::FileSystemError);
 
 /// Thrown when a user tries to pin a Yarn version before pinning a Node version.
 #[derive(Fail, Debug)]
@@ -82,14 +75,7 @@ impl NoPinnedNodeVersion {
     }
 }
 
-impl NotionFail for NoPinnedNodeVersion {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::ConfigurationError
-    }
-}
+impl_notion_fail!(NoPinnedNodeVersion, ExitCode::ConfigurationError);
 
 /// A Node project tree in the filesystem.
 pub struct Project {

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use lazycell::LazyCell;
 
 use manifest::Manifest;
-use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
+use notion_fail::{ExitCode, Fallible, NotionError, NotionFail, ResultExt};
 use semver::Version;
 use serial::manifest::ToolchainManifest;
 
@@ -66,8 +66,8 @@ impl NotionFail for DepPackageReadError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::FileSystemError
     }
 }
 
@@ -86,8 +86,8 @@ impl NotionFail for NoPinnedNodeVersion {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::ConfigurationError
     }
 }
 

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -62,7 +62,7 @@ impl DepPackageReadError {
     }
 }
 
-impl_notion_fail!(DepPackageReadError, ExitCode::FileSystemError);
+impl_notion_fail!(DepPackageReadError, FileSystemError);
 
 /// Thrown when a user tries to pin a Yarn version before pinning a Node version.
 #[derive(Fail, Debug)]
@@ -75,7 +75,7 @@ impl NoPinnedNodeVersion {
     }
 }
 
-impl_notion_fail!(NoPinnedNodeVersion, ExitCode::ConfigurationError);
+impl_notion_fail!(NoPinnedNodeVersion, ConfigurationError);
 
 /// A Node project tree in the filesystem.
 pub struct Project {

--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -1,4 +1,4 @@
-use notion_fail::{Fallible, NotionFail, ResultExt};
+use notion_fail::{ExitCode, Fallible, NotionFail, ResultExt};
 use semver::{ReqParseError, VersionReq};
 
 #[derive(Fail, Debug)]
@@ -19,8 +19,8 @@ impl NotionFail for VersionParseError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::NoVersionMatch
     }
 }
 

--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -15,7 +15,7 @@ impl VersionParseError {
     }
 }
 
-impl_notion_fail!(VersionParseError, ExitCode::NoVersionMatch);
+impl_notion_fail!(VersionParseError, NoVersionMatch);
 
 pub fn parse_requirements(src: &str) -> Fallible<VersionReq> {
     let src = src.trim();

--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -15,14 +15,7 @@ impl VersionParseError {
     }
 }
 
-impl NotionFail for VersionParseError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NoVersionMatch
-    }
-}
+impl_notion_fail!(VersionParseError, ExitCode::NoVersionMatch);
 
 pub fn parse_requirements(src: &str) -> Fallible<VersionReq> {
     let src = src.trim();

--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -1,8 +1,9 @@
 use notion_fail::{ExitCode, Fallible, NotionFail, ResultExt};
 use semver::{ReqParseError, VersionReq};
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "{}", error)]
+#[notion_fail(code = "NoVersionMatch")]
 pub(crate) struct VersionParseError {
     pub(crate) error: ReqParseError,
 }
@@ -14,8 +15,6 @@ impl VersionParseError {
         }
     }
 }
-
-impl_notion_fail!(VersionParseError, NoVersionMatch);
 
 pub fn parse_requirements(src: &str) -> Fallible<VersionReq> {
     let src = src.trim();

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -264,7 +264,7 @@ impl Session {
         self.event_log.add_event_error(activity_kind, error)
     }
 
-    fn publish_plugin(mut self) {
+    fn publish_to_event_log(mut self) {
         match publish_plugin(&self.config) {
             Ok(plugin) => {
                 self.event_log.publish(plugin);
@@ -276,12 +276,12 @@ impl Session {
     }
 
     pub fn exit(self, code: ExitCode) -> ! {
-        self.publish_plugin();
+        self.publish_to_event_log();
         code.exit();
     }
 
     pub fn exit_tool(self, code: i32) -> ! {
-        self.publish_plugin();
+        self.publish_to_event_log();
         exit(code);
     }
 }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -68,14 +68,8 @@ impl NotInPackageError {
         NotInPackageError
     }
 }
-impl NotionFail for NotInPackageError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::ConfigurationError
-    }
-}
+
+impl_notion_fail!(NotInPackageError, ExitCode::ConfigurationError);
 
 /// Represents the user's state during an execution of a Notion tool. The session
 /// encapsulates a number of aspects of the environment in which the tool was

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -13,7 +13,7 @@ use std::fmt::{self, Display, Formatter};
 use std::process::exit;
 
 use event::EventLog;
-use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
+use notion_fail::{ExitCode, Fallible, NotionError, NotionFail, ResultExt};
 use semver::{Version, VersionReq};
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
@@ -72,8 +72,8 @@ impl NotionFail for NotInPackageError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::ConfigurationError
     }
 }
 

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -59,8 +59,9 @@ impl Display for ActivityKind {
 }
 
 /// Thrown when the user tries to pin Node or Yarn versions outside of a package.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Not in a node package")]
+#[notion_fail(code = "ConfigurationError")]
 pub(crate) struct NotInPackageError;
 
 impl NotInPackageError {
@@ -68,8 +69,6 @@ impl NotInPackageError {
         NotInPackageError
     }
 }
-
-impl_notion_fail!(NotInPackageError, ConfigurationError);
 
 /// Represents the user's state during an execution of a Notion tool. The session
 /// encapsulates a number of aspects of the environment in which the tool was

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -254,14 +254,17 @@ impl Session {
     pub fn add_event_start(&mut self, activity_kind: ActivityKind) {
         self.event_log.add_event_start(activity_kind)
     }
-    pub fn add_event_end(&mut self, activity_kind: ActivityKind, exit_code: i32) {
+    pub fn add_event_end(&mut self, activity_kind: ActivityKind, exit_code: ExitCode) {
         self.event_log.add_event_end(activity_kind, exit_code)
+    }
+    pub fn add_event_tool_end(&mut self, activity_kind: ActivityKind, exit_code: i32) {
+        self.event_log.add_event_tool_end(activity_kind, exit_code)
     }
     pub fn add_event_error(&mut self, activity_kind: ActivityKind, error: &NotionError) {
         self.event_log.add_event_error(activity_kind, error)
     }
 
-    pub fn exit(mut self, code: i32) -> ! {
+    fn publish_plugin(mut self) {
         match publish_plugin(&self.config) {
             Ok(plugin) => {
                 self.event_log.publish(plugin);
@@ -270,6 +273,15 @@ impl Session {
                 eprintln!("Warning: invalid config file ({})", e);
             }
         }
+    }
+
+    pub fn exit(self, code: ExitCode) -> ! {
+        self.publish_plugin();
+        code.exit();
+    }
+
+    pub fn exit_tool(self, code: i32) -> ! {
+        self.publish_plugin();
         exit(code);
     }
 }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -69,7 +69,7 @@ impl NotInPackageError {
     }
 }
 
-impl_notion_fail!(NotInPackageError, ExitCode::ConfigurationError);
+impl_notion_fail!(NotInPackageError, ConfigurationError);
 
 /// Represents the user's state during an execution of a Notion tool. The session
 /// encapsulates a number of aspects of the environment in which the tool was

--- a/crates/notion-core/src/shell/mod.rs
+++ b/crates/notion-core/src/shell/mod.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use semver::Version;
 
-use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
+use notion_fail::{ExitCode, Fallible, NotionError, NotionFail, ResultExt};
 
 use env;
 
@@ -27,8 +27,8 @@ impl NotionFail for UnspecifiedPostscriptError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        100
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::EnvironmentError
     }
 }
 
@@ -56,8 +56,8 @@ impl NotionFail for UnspecifiedShellError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        100
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::EnvironmentError
     }
 }
 
@@ -95,8 +95,8 @@ impl NotionFail for UnrecognizedShellError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        100
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::EnvironmentError
     }
 }
 

--- a/crates/notion-core/src/shell/mod.rs
+++ b/crates/notion-core/src/shell/mod.rs
@@ -19,11 +19,10 @@ pub enum Postscript {
 }
 
 /// Thrown when the postscript file was not specified in the Notion environment.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Notion postscript file not specified")]
+#[notion_fail(code = "EnvironmentError")]
 struct UnspecifiedPostscriptError;
-
-impl_notion_fail!(UnspecifiedPostscriptError, EnvironmentError);
 
 pub trait Shell {
     fn postscript_path(&self) -> &Path;
@@ -41,11 +40,10 @@ pub trait Shell {
 pub struct CurrentShell(Box<dyn Shell>);
 
 /// Thrown when the shell name was not specified in the Notion environment.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Notion shell not specified")]
+#[notion_fail(code = "EnvironmentError")]
 struct UnspecifiedShellError;
-
-impl_notion_fail!(UnspecifiedShellError, EnvironmentError);
 
 impl CurrentShell {
     pub fn detect() -> Fallible<Self> {
@@ -71,13 +69,12 @@ impl Shell for CurrentShell {
 }
 
 /// Thrown when the shell name specified in the Notion environment is not supported.
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "Unrecognized command shell name: {}", name)]
+#[notion_fail(code = "EnvironmentError")]
 struct UnrecognizedShellError {
     name: String,
 }
-
-impl_notion_fail!(UnrecognizedShellError, EnvironmentError);
 
 impl FromStr for CurrentShell {
     type Err = NotionError;

--- a/crates/notion-core/src/shell/mod.rs
+++ b/crates/notion-core/src/shell/mod.rs
@@ -23,14 +23,7 @@ pub enum Postscript {
 #[fail(display = "Notion postscript file not specified")]
 struct UnspecifiedPostscriptError;
 
-impl NotionFail for UnspecifiedPostscriptError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::EnvironmentError
-    }
-}
+impl_notion_fail!(UnspecifiedPostscriptError, ExitCode::EnvironmentError);
 
 pub trait Shell {
     fn postscript_path(&self) -> &Path;
@@ -52,14 +45,7 @@ pub struct CurrentShell(Box<dyn Shell>);
 #[fail(display = "Notion shell not specified")]
 struct UnspecifiedShellError;
 
-impl NotionFail for UnspecifiedShellError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::EnvironmentError
-    }
-}
+impl_notion_fail!(UnspecifiedShellError, ExitCode::EnvironmentError);
 
 impl CurrentShell {
     pub fn detect() -> Fallible<Self> {
@@ -91,14 +77,7 @@ struct UnrecognizedShellError {
     name: String,
 }
 
-impl NotionFail for UnrecognizedShellError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::EnvironmentError
-    }
-}
+impl_notion_fail!(UnrecognizedShellError, ExitCode::EnvironmentError);
 
 impl FromStr for CurrentShell {
     type Err = NotionError;

--- a/crates/notion-core/src/shell/mod.rs
+++ b/crates/notion-core/src/shell/mod.rs
@@ -23,7 +23,7 @@ pub enum Postscript {
 #[fail(display = "Notion postscript file not specified")]
 struct UnspecifiedPostscriptError;
 
-impl_notion_fail!(UnspecifiedPostscriptError, ExitCode::EnvironmentError);
+impl_notion_fail!(UnspecifiedPostscriptError, EnvironmentError);
 
 pub trait Shell {
     fn postscript_path(&self) -> &Path;
@@ -45,7 +45,7 @@ pub struct CurrentShell(Box<dyn Shell>);
 #[fail(display = "Notion shell not specified")]
 struct UnspecifiedShellError;
 
-impl_notion_fail!(UnspecifiedShellError, ExitCode::EnvironmentError);
+impl_notion_fail!(UnspecifiedShellError, EnvironmentError);
 
 impl CurrentShell {
     pub fn detect() -> Fallible<Self> {
@@ -77,7 +77,7 @@ struct UnrecognizedShellError {
     name: String,
 }
 
-impl_notion_fail!(UnrecognizedShellError, ExitCode::EnvironmentError);
+impl_notion_fail!(UnrecognizedShellError, EnvironmentError);
 
 impl FromStr for CurrentShell {
     type Err = NotionError;

--- a/crates/notion-core/src/shim.rs
+++ b/crates/notion-core/src/shim.rs
@@ -2,7 +2,7 @@
 
 use std::{fs, io};
 
-use notion_fail::{FailExt, Fallible, NotionFail};
+use notion_fail::{ExitCode, FailExt, Fallible, NotionFail};
 use path;
 
 #[derive(Fail, Debug)]
@@ -15,8 +15,8 @@ impl NotionFail for SymlinkError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::FileSystemError
     }
 }
 

--- a/crates/notion-core/src/shim.rs
+++ b/crates/notion-core/src/shim.rs
@@ -5,13 +5,12 @@ use std::{fs, io};
 use notion_fail::{ExitCode, FailExt, Fallible, NotionFail};
 use path;
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "{}", error)]
+#[notion_fail(code = "FileSystemError")]
 pub(crate) struct SymlinkError {
     error: String,
 }
-
-impl_notion_fail!(SymlinkError, FileSystemError);
 
 impl SymlinkError {
     pub(crate) fn from_io_error(error: &io::Error) -> Self {

--- a/crates/notion-core/src/shim.rs
+++ b/crates/notion-core/src/shim.rs
@@ -11,7 +11,7 @@ pub(crate) struct SymlinkError {
     error: String,
 }
 
-impl_notion_fail!(SymlinkError, ExitCode::FileSystemError);
+impl_notion_fail!(SymlinkError, FileSystemError);
 
 impl SymlinkError {
     pub(crate) fn from_io_error(error: &io::Error) -> Self {

--- a/crates/notion-core/src/shim.rs
+++ b/crates/notion-core/src/shim.rs
@@ -11,14 +11,7 @@ pub(crate) struct SymlinkError {
     error: String,
 }
 
-impl NotionFail for SymlinkError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::FileSystemError
-    }
-}
+impl_notion_fail!(SymlinkError, ExitCode::FileSystemError);
 
 impl SymlinkError {
     pub(crate) fn from_io_error(error: &io::Error) -> Self {

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -21,8 +21,9 @@ fn display_error(err: &NotionError) {
     }
 }
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "{}", error)]
+#[notion_fail(code = "ExecutionFailure")]
 pub(crate) struct BinaryExecError {
     pub(crate) error: String,
 }
@@ -41,10 +42,9 @@ impl BinaryExecError {
     }
 }
 
-impl_notion_fail!(BinaryExecError, ExecutionFailure);
-
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "this tool is not yet implemented")]
+#[notion_fail(code = "ExecutableNotFound")]
 pub(crate) struct ToolUnimplementedError;
 
 impl ToolUnimplementedError {
@@ -52,8 +52,6 @@ impl ToolUnimplementedError {
         ToolUnimplementedError
     }
 }
-
-impl_notion_fail!(ToolUnimplementedError, ExecutableNotFound);
 
 /// Represents a command-line tool that Notion shims delegate to.
 pub trait Tool: Sized {
@@ -243,13 +241,12 @@ fn arg0(args: &mut ArgsOs) -> Fallible<OsString> {
     }
 }
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "No {} version selected", tool)]
+#[notion_fail(code = "NoVersionMatch")]
 struct NoGlobalError {
     tool: String,
 }
-
-impl_notion_fail!(NoGlobalError, NoVersionMatch);
 
 impl Tool for Node {
     fn new(session: &mut Session) -> Fallible<Self> {

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -5,7 +5,7 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::marker::Sized;
 use std::path::Path;
-use std::process::{exit, Command};
+use std::process::Command;
 
 use env;
 use notion_fail::{ExitCode, FailExt, Fallible, NotionError, NotionFail};
@@ -60,7 +60,7 @@ pub trait Tool: Sized {
             Ok(session) => session,
             Err(err) => {
                 display_error(&err);
-                exit(ExitCode::ExecutionFailure as i32);
+                ExitCode::ExecutionFailure.exit();
             }
         };
 
@@ -73,7 +73,7 @@ pub trait Tool: Sized {
             Err(err) => {
                 display_error(&err);
                 session.add_event_error(ActivityKind::Tool, &err);
-                session.exit(ExitCode::ExecutionFailure as i32);
+                session.exit(ExitCode::ExecutionFailure);
             }
         }
     }
@@ -93,20 +93,20 @@ pub trait Tool: Sized {
         let status = command.status();
         match status {
             Ok(status) if status.success() => {
-                session.add_event_end(ActivityKind::Tool, 0);
-                session.exit(ExitCode::Success as i32);
+                session.add_event_end(ActivityKind::Tool, ExitCode::Success);
+                session.exit(ExitCode::Success);
             }
             Ok(status) => {
                 // ISSUE (#36): if None, in unix, find out the signal
                 let code = status.code().unwrap_or(1);
-                session.add_event_end(ActivityKind::Tool, code);
-                session.exit(code);
+                session.add_event_tool_end(ActivityKind::Tool, code);
+                session.exit_tool(code);
             }
             Err(err) => {
                 let notion_err = err.with_context(BinaryExecError::from_io_error);
                 display_error(&notion_err);
                 session.add_event_error(ActivityKind::Tool, &notion_err);
-                session.exit(ExitCode::ExecutionFailure as i32);
+                session.exit(ExitCode::ExecutionFailure);
             }
         }
     }

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -41,7 +41,7 @@ impl BinaryExecError {
     }
 }
 
-impl_notion_fail!(BinaryExecError, ExitCode::ExecutionFailure);
+impl_notion_fail!(BinaryExecError, ExecutionFailure);
 
 #[derive(Fail, Debug)]
 #[fail(display = "this tool is not yet implemented")]
@@ -53,7 +53,7 @@ impl ToolUnimplementedError {
     }
 }
 
-impl_notion_fail!(ToolUnimplementedError, ExitCode::ExecutableNotFound);
+impl_notion_fail!(ToolUnimplementedError, ExecutableNotFound);
 
 /// Represents a command-line tool that Notion shims delegate to.
 pub trait Tool: Sized {
@@ -249,7 +249,7 @@ struct NoGlobalError {
     tool: String,
 }
 
-impl_notion_fail!(NoGlobalError, ExitCode::NoVersionMatch);
+impl_notion_fail!(NoGlobalError, NoVersionMatch);
 
 impl Tool for Node {
     fn new(session: &mut Session) -> Fallible<Self> {

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -41,14 +41,7 @@ impl BinaryExecError {
     }
 }
 
-impl NotionFail for BinaryExecError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::ExecutionFailure
-    }
-}
+impl_notion_fail!(BinaryExecError, ExitCode::ExecutionFailure);
 
 #[derive(Fail, Debug)]
 #[fail(display = "this tool is not yet implemented")]
@@ -60,14 +53,7 @@ impl ToolUnimplementedError {
     }
 }
 
-impl NotionFail for ToolUnimplementedError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::ExecutableNotFound
-    }
-}
+impl_notion_fail!(ToolUnimplementedError, ExitCode::ExecutableNotFound);
 
 /// Represents a command-line tool that Notion shims delegate to.
 pub trait Tool: Sized {
@@ -263,14 +249,7 @@ struct NoGlobalError {
     tool: String,
 }
 
-impl NotionFail for NoGlobalError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NoVersionMatch
-    }
-}
+impl_notion_fail!(NoGlobalError, ExitCode::NoVersionMatch);
 
 impl Tool for Node {
     fn new(session: &mut Session) -> Fallible<Self> {

--- a/crates/notion-fail-derive/Cargo.toml
+++ b/crates/notion-fail-derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "notion-fail-derive"
+version = "0.1.0"
+authors = ["Ben Blank <ben.blank@gmail.com>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "0.4.12"
+quote = "0.6.6"
+syn = "0.14.8"

--- a/crates/notion-fail-derive/src/lib.rs
+++ b/crates/notion-fail-derive/src/lib.rs
@@ -1,0 +1,94 @@
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+extern crate syn;
+
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Span};
+use syn::{DeriveInput, Lit, NestedMeta};
+use syn::Meta::{List, NameValue, Word};
+use syn::NestedMeta::{Literal, Meta};
+
+#[proc_macro_derive(NotionFail, attributes(notion_fail))]
+pub fn notion_fail(token_stream: TokenStream) -> TokenStream {
+    let input: DeriveInput = syn::parse(token_stream).unwrap();
+    let name = &input.ident;
+
+    let mut code = Ident::new("UnknownError", Span::call_site());
+    let mut code_set = false;
+    let mut is_friendly = Ident::new("true", Span::call_site());
+
+    for meta in input.attrs.iter().filter_map(get_notion_fail_meta_items) {
+        for item in meta {
+            match item {
+                Literal(_) => {
+                    panic!("#[notion_fail()]: must be name/value pairs, not a literal");
+                },
+
+                Meta(List(_)) => {
+                    panic!("#[notion_fail()]: must be name/value pairs, not a list");
+                },
+
+                Meta(NameValue(ref m)) if m.ident == "code" => {
+                    if let Lit::Str(s) = &m.lit {
+                        code = Ident::new(&s.value(), Span::call_site());
+                        code_set = true;
+                    } else {
+                        // Defined, but not a string.
+                        panic!("#[notion_fail()]: 'code' must be a string.");
+                    }
+                },
+
+                Meta(NameValue(ref m)) if m.ident == "friendly" => {
+                    if let Lit::Str(s) = &m.lit {
+                        is_friendly = Ident::new(&s.value(), Span::call_site());
+                    } else {
+                        // Defined, but not a string.
+                        panic!("#[notion_fail()]: 'code' must be a string.");
+                    }
+                },
+
+                Meta(NameValue(m)) => {
+                    panic!("#[notion_fail()]: not a recognized name: '{}'", m.ident);
+                },
+
+                Meta(Word(_)) => {
+                    panic!("#[notion_fail()]: must be name/value pairs, not an identifier");
+                },
+            }
+        }
+    }
+
+    if !code_set {
+        panic!("#[notion_fail()] must set an exit code");
+    }
+
+    let tokens = quote! {
+        impl NotionFail for #name {
+            fn exit_code(&self) -> ExitCode {
+                ExitCode::#code
+            }
+
+            fn is_user_friendly(&self) -> bool {
+                #is_friendly
+            }
+        }
+    };
+
+    tokens.into()
+}
+
+fn get_notion_fail_meta_items(attr: &syn::Attribute) -> Option<Vec<NestedMeta>> {
+    if attr.path.segments.len() == 1 && attr.path.segments[0].ident == "notion_fail" {
+        match attr.interpret_meta() {
+            Some(List(ref meta)) => Some(meta.nested.iter().cloned().collect()),
+
+            _ => {
+                panic!("#[notion_fail()] must be a list of attributes");
+            },
+        }
+    } else {
+        None
+    }
+}

--- a/crates/notion-fail/Cargo.toml
+++ b/crates/notion-fail/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Dave Herman <david.herman@gmail.com>"]
 [dependencies]
 failure = "0.1.1"
 failure_derive = "0.1.1"
+notion-fail-derive = { path = "../notion-fail-derive" }

--- a/crates/notion-fail/Cargo.toml
+++ b/crates/notion-fail/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Dave Herman <david.herman@gmail.com>"]
 failure = "0.1.1"
 failure_derive = "0.1.1"
 notion-fail-derive = { path = "../notion-fail-derive" }
+serde = "1.0.27"
+serde_derive = "1.0.27"

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -239,9 +239,12 @@
 extern crate failure;
 #[macro_use]
 extern crate notion_fail_derive;
+#[macro_use]
+extern crate serde_derive;
 
 use std::convert::{From, Into};
 use std::fmt::{self, Display};
+use std::process::exit;
 
 use failure::{Backtrace, Fail};
 
@@ -254,7 +257,7 @@ macro_rules! throw {
 }
 
 /// Exit codes supported by the NotionFail trait.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub enum ExitCode {
     /// No error occurred.
     Success = 0,
@@ -288,6 +291,12 @@ pub enum ExitCode {
 
     /// The requested executable is not available.
     ExecutableNotFound = 127,
+}
+
+impl ExitCode {
+    pub fn exit(self) -> ! {
+        exit(self as i32);
+    }
 }
 
 /// The failure trait for all Notion errors.

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -106,6 +106,7 @@
 //!
 //! ```
 //! # #[macro_use] extern crate notion_fail;
+//! # #[macro_use] extern crate notion_fail_derive;
 //! # #[macro_use] extern crate failure_derive;
 //! # extern crate failure;
 //! # use notion_fail::{ExitCode, Fallible, NotionFail};
@@ -142,6 +143,7 @@
 //!
 //! ```
 //! # #[macro_use] extern crate notion_fail;
+//! # #[macro_use] extern crate notion_fail_derive;
 //! # #[macro_use] extern crate failure_derive;
 //! # extern crate failure;
 //! # use notion_fail::{ExitCode, Fallible, NotionFail};

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -93,13 +93,8 @@
 //! #[fail(display = "unexpected end of string")]
 //! struct UnexpectedEndOfString;
 //!
-//! impl NotionFail for UnexpectedEndOfString {
-//!     // this is a user-friendly error type
-//!     fn is_user_friendly(&self) -> bool { true }
-//!
-//!     // abort the process with the exit code for invalid arguments if this failure goes uncaught
-//!     fn exit_code(&self) -> ExitCode { ExitCode::InvalidArguments }
-//! }
+//! // A shortcut for implementing NotionFail; defaults to user-friendly.
+//! impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
 //! ```
 //!
 //! # Throwing errors
@@ -120,13 +115,7 @@
 //! # #[fail(display = "unexpected end of string")]
 //! # struct UnexpectedEndOfString;
 //! #
-//! # impl NotionFail for UnexpectedEndOfString {
-//! #     // this is a user-friendly error type
-//! #     fn is_user_friendly(&self) -> bool { true }
-//! #
-//! #     // abort the process with the exit code for invalid arguments if this failure goes uncaught
-//! #     fn exit_code(&self) -> ExitCode { ExitCode::InvalidArguments }
-//! # }
+//! # impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
 //! #
 //! fn parse_component(src: &str, i: usize) -> Fallible<u8> {
 //!     if i + 2 > src.len() {
@@ -165,13 +154,7 @@
 //! # #[fail(display = "unexpected end of string")]
 //! # struct UnexpectedEndOfString;
 //! #
-//! # impl NotionFail for UnexpectedEndOfString {
-//! #     // this is a user-friendly error type
-//! #     fn is_user_friendly(&self) -> bool { true }
-//! #
-//! #     // abort the process with the exit code for invalid arguments if this failure goes uncaught
-//! #     fn exit_code(&self) -> ExitCode { ExitCode::InvalidArguments }
-//! # }
+//! # impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
 //!
 //! fn parse_component(src: &str, i: usize) -> Fallible<u8> {
 //!     if i + 2 > src.len() {
@@ -219,13 +202,7 @@
 //! # #[fail(display = "unexpected end of string")]
 //! # struct UnexpectedEndOfString;
 //! #
-//! # impl NotionFail for UnexpectedEndOfString {
-//! #     // this is a user-friendly error type
-//! #     fn is_user_friendly(&self) -> bool { true }
-//! #
-//! #     // abort the process with the exit code for invalid arguments if this failure goes uncaught
-//! #     fn exit_code(&self) -> ExitCode { ExitCode::InvalidArguments }
-//! # }
+//! # impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
 //! #
 //! # fn parse_component(src: &str, i: usize) -> Fallible<u8> {
 //! #     if i + 2 > src.len() {
@@ -240,10 +217,7 @@
 //! #[fail(display = "invalid RGB string: ", details)]
 //! struct InvalidRgbString { details: String }
 //!
-//! impl NotionFail for InvalidRgbString {
-//!     fn is_user_friendly(&self) -> bool { true}
-//!     fn exit_code(&self) -> ExitCode { ExitCode::InvalidArguments }
-//! }
+//! impl_notion_fail!(InvalidRgbString, ExitCode::InvalidArguments);
 //!
 //! impl InvalidRgbString {
 //!     fn new<D: Display>(details: &D) -> InvalidRgbString {
@@ -327,6 +301,32 @@ pub trait NotionFail: Fail {
 
     /// Returns the process exit code that should be returned if the process exits with this error.
     fn exit_code(&self) -> ExitCode;
+}
+
+/// A typical implementation of NotionFail.
+#[macro_export]
+macro_rules! impl_notion_fail {
+    ($error_name: ident, $exit_code: expr) => (
+        impl NotionFail for $error_name {
+            fn is_user_friendly(&self) -> bool {
+                true
+            }
+            fn exit_code(&self) -> ExitCode {
+                $exit_code
+            }
+        }
+    );
+
+    ($error_name: ident, $is_friendly: expr, $exit_code: expr) => (
+        impl NotionFail for $error_name {
+            fn is_user_friendly(&self) -> bool {
+                $is_friendly
+            }
+            fn exit_code(&self) -> ExitCode {
+                $exit_code
+            }
+        }
+    );
 }
 
 /// The `NotionError` type, which can contain any Notion failure.
@@ -464,14 +464,7 @@ impl Fail for UnknownNotionError {
     }
 }
 
-impl NotionFail for UnknownNotionError {
-    fn is_user_friendly(&self) -> bool {
-        false
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::UnknownError
-    }
-}
+impl_notion_fail!(UnknownNotionError, false, ExitCode::UnknownError);
 
 impl<E: Into<failure::Error>> FailExt for E {
     fn unknown(self) -> NotionError {

--- a/crates/notion-fail/src/lib.rs
+++ b/crates/notion-fail/src/lib.rs
@@ -94,7 +94,7 @@
 //! struct UnexpectedEndOfString;
 //!
 //! // A shortcut for implementing NotionFail; defaults to user-friendly.
-//! impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
+//! impl_notion_fail!(UnexpectedEndOfString, InvalidArguments);
 //! ```
 //!
 //! # Throwing errors
@@ -115,7 +115,7 @@
 //! # #[fail(display = "unexpected end of string")]
 //! # struct UnexpectedEndOfString;
 //! #
-//! # impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
+//! # impl_notion_fail!(UnexpectedEndOfString, InvalidArguments);
 //! #
 //! fn parse_component(src: &str, i: usize) -> Fallible<u8> {
 //!     if i + 2 > src.len() {
@@ -154,7 +154,7 @@
 //! # #[fail(display = "unexpected end of string")]
 //! # struct UnexpectedEndOfString;
 //! #
-//! # impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
+//! # impl_notion_fail!(UnexpectedEndOfString, InvalidArguments);
 //!
 //! fn parse_component(src: &str, i: usize) -> Fallible<u8> {
 //!     if i + 2 > src.len() {
@@ -202,7 +202,7 @@
 //! # #[fail(display = "unexpected end of string")]
 //! # struct UnexpectedEndOfString;
 //! #
-//! # impl_notion_fail!(UnexpectedEndOfString, ExitCode::InvalidArguments);
+//! # impl_notion_fail!(UnexpectedEndOfString, InvalidArguments);
 //! #
 //! # fn parse_component(src: &str, i: usize) -> Fallible<u8> {
 //! #     if i + 2 > src.len() {
@@ -217,7 +217,7 @@
 //! #[fail(display = "invalid RGB string: ", details)]
 //! struct InvalidRgbString { details: String }
 //!
-//! impl_notion_fail!(InvalidRgbString, ExitCode::InvalidArguments);
+//! impl_notion_fail!(InvalidRgbString, InvalidArguments);
 //!
 //! impl InvalidRgbString {
 //!     fn new<D: Display>(details: &D) -> InvalidRgbString {
@@ -306,24 +306,24 @@ pub trait NotionFail: Fail {
 /// A typical implementation of NotionFail.
 #[macro_export]
 macro_rules! impl_notion_fail {
-    ($error_name: ident, $exit_code: expr) => (
+    ($error_name: ident, $exit_code: ident) => (
         impl NotionFail for $error_name {
             fn is_user_friendly(&self) -> bool {
                 true
             }
             fn exit_code(&self) -> ExitCode {
-                $exit_code
+                $crate::ExitCode::$exit_code
             }
         }
     );
 
-    ($error_name: ident, $is_friendly: expr, $exit_code: expr) => (
+    ($error_name: ident, $is_friendly: expr, $exit_code: ident) => (
         impl NotionFail for $error_name {
             fn is_user_friendly(&self) -> bool {
                 $is_friendly
             }
             fn exit_code(&self) -> ExitCode {
-                $exit_code
+                $crate::ExitCode::$exit_code
             }
         }
     );
@@ -464,7 +464,7 @@ impl Fail for UnknownNotionError {
     }
 }
 
-impl_notion_fail!(UnknownNotionError, false, ExitCode::UnknownError);
+impl_notion_fail!(UnknownNotionError, false, UnknownError);
 
 impl<E: Into<failure::Error>> FailExt for E {
     fn unknown(self) -> NotionError {

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -1,7 +1,7 @@
 use std::string::ToString;
 
 use notion_core::session::{ActivityKind, Session};
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 use Notion;
 use command::{Command, CommandName, Help};
@@ -93,7 +93,7 @@ Options:
                 Ok(any)
             }
         };
-        session.add_event_end(ActivityKind::Current, 0);
+        session.add_event_end(ActivityKind::Current, ExitCode::Success);
         result
     }
 }

--- a/src/command/deactivate.rs
+++ b/src/command/deactivate.rs
@@ -1,7 +1,7 @@
 use notion_core::env;
 use notion_core::session::{ActivityKind, Session};
 use notion_core::shell::{CurrentShell, Postscript, Shell};
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 use Notion;
 use command::{Command, CommandName, Help};
@@ -53,7 +53,7 @@ Options:
                 shell.save_postscript(&postscript)?;
             }
         };
-        session.add_event_end(ActivityKind::Deactivate, 0);
+        session.add_event_end(ActivityKind::Deactivate, ExitCode::Success);
         Ok(true)
     }
 }

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -2,7 +2,7 @@ use semver::VersionReq;
 
 use notion_core::serial::version::parse_requirements;
 use notion_core::session::{ActivityKind, Session};
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 use command::{Command, CommandName, Help};
 use {CliParseError, Notion};
@@ -69,7 +69,7 @@ Options:
                 Ok(true)
             }
         };
-        session.add_event_end(ActivityKind::Fetch, 0);
+        session.add_event_end(ActivityKind::Fetch, ExitCode::Success);
         result
     }
 }

--- a/src/command/help.rs
+++ b/src/command/help.rs
@@ -1,5 +1,5 @@
 use notion_core::session::{ActivityKind, Session};
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 use command::{Command, CommandName, Config, Current, Deactivate, Fetch, Install, Shim, Use,
               Version};
@@ -66,7 +66,7 @@ Options:
                 Help::Command(CommandName::Shim) => Shim::USAGE,
             }
         );
-        session.add_event_end(ActivityKind::Help, 0);
+        session.add_event_end(ActivityKind::Help, ExitCode::Success);
         Ok(true)
     }
 }

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -2,7 +2,7 @@ use semver::VersionReq;
 
 use notion_core::serial::version::parse_requirements;
 use notion_core::session::{ActivityKind, Session};
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 use Notion;
 use command::{Command, CommandName, Help};
@@ -72,7 +72,7 @@ Options:
                 version: _,
             } => unimplemented!(),
         };
-        session.add_event_end(ActivityKind::Install, 0);
+        session.add_event_end(ActivityKind::Install, ExitCode::Success);
         Ok(true)
     }
 }

--- a/src/command/shim.rs
+++ b/src/command/shim.rs
@@ -7,7 +7,7 @@ use console::style;
 use notion_core::project::Project;
 use notion_core::session::{ActivityKind, Session};
 use notion_core::{path, shim};
-use notion_fail::{Fallible, ResultExt};
+use notion_fail::{ExitCode, Fallible, ResultExt};
 use semver::{Version, VersionReq};
 
 use Notion;
@@ -103,7 +103,7 @@ Options:
             Shim::Create(shim_name, verbose) => create(session, shim_name, verbose),
             Shim::Delete(shim_name, verbose) => delete(session, shim_name, verbose),
         };
-        session.add_event_end(ActivityKind::Shim, 0);
+        session.add_event_end(ActivityKind::Shim, ExitCode::Success);
         result
     }
 }

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -31,14 +31,7 @@ impl NoCustomUseError {
     }
 }
 
-impl NotionFail for NoCustomUseError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NotYetImplemented
-    }
-}
+impl_notion_fail!(NoCustomUseError, ExitCode::NotYetImplemented);
 
 pub(crate) enum Use {
     Help,

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -18,9 +18,10 @@ pub(crate) struct Args {
 }
 
 // error message for using tools that are not node|yarn
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "pinning tool '{}' not yet implemented - for now you can manually edit package.json",
        name)]
+#[notion_fail(code = "NotYetImplemented")]
 pub(crate) struct NoCustomUseError {
     pub(crate) name: String,
 }
@@ -30,8 +31,6 @@ impl NoCustomUseError {
         NoCustomUseError { name: name }
     }
 }
-
-impl_notion_fail!(NoCustomUseError, NotYetImplemented);
 
 pub(crate) enum Use {
     Help,

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -31,7 +31,7 @@ impl NoCustomUseError {
     }
 }
 
-impl_notion_fail!(NoCustomUseError, ExitCode::NotYetImplemented);
+impl_notion_fail!(NoCustomUseError, NotYetImplemented);
 
 pub(crate) enum Use {
     Help,

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -85,7 +85,7 @@ Options:
                 version: _,
             } => throw!(NoCustomUseError::new(_name)),
         };
-        session.add_event_end(ActivityKind::Use, 0);
+        session.add_event_end(ActivityKind::Use, ExitCode::Success);
         Ok(true)
     }
 }

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -6,7 +6,7 @@ use semver::VersionReq;
 
 use notion_core::serial::version::parse_requirements;
 use notion_core::session::{ActivityKind, Session};
-use notion_fail::{Fallible, NotionFail};
+use notion_fail::{ExitCode, Fallible, NotionFail};
 
 use Notion;
 use command::{Command, CommandName, Help};
@@ -35,8 +35,8 @@ impl NotionFail for NoCustomUseError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::NotYetImplemented
     }
 }
 

--- a/src/command/version.rs
+++ b/src/command/version.rs
@@ -1,5 +1,5 @@
 use notion_core::session::{ActivityKind, Session};
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 use Notion;
 use command::{Command, CommandName, Help};
@@ -43,7 +43,7 @@ Options:
                 Ok(true)
             }
         };
-        session.add_event_end(ActivityKind::Version, 0);
+        session.add_event_end(ActivityKind::Version, ExitCode::Success);
         result
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,14 +25,7 @@ impl CliParseError {
     }
 }
 
-impl NotionFail for CliParseError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::InvalidArguments
-    }
-}
+impl_notion_fail!(CliParseError, ExitCode::InvalidArguments);
 
 pub(crate) trait DocoptExt {
     fn is_help(&self) -> bool;
@@ -86,11 +79,4 @@ impl CommandUnimplementedError {
     }
 }
 
-impl NotionFail for CommandUnimplementedError {
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
-    fn exit_code(&self) -> ExitCode {
-        ExitCode::NotYetImplemented
-    }
-}
+impl_notion_fail!(CommandUnimplementedError, ExitCode::NotYetImplemented);

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ impl CliParseError {
     }
 }
 
-impl_notion_fail!(CliParseError, ExitCode::InvalidArguments);
+impl_notion_fail!(CliParseError, InvalidArguments);
 
 pub(crate) trait DocoptExt {
     fn is_help(&self) -> bool;
@@ -79,4 +79,4 @@ impl CommandUnimplementedError {
     }
 }
 
-impl_notion_fail!(CommandUnimplementedError, ExitCode::NotYetImplemented);
+impl_notion_fail!(CommandUnimplementedError, NotYetImplemented);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use docopt;
 use failure::Context;
-use notion_fail::{NotionError, NotionFail};
+use notion_fail::{ExitCode, NotionError, NotionFail};
 
 #[derive(Fail, Debug)]
 #[fail(display = "{}", error)]
@@ -29,8 +29,8 @@ impl NotionFail for CliParseError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        3
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::InvalidArguments
     }
 }
 
@@ -90,7 +90,7 @@ impl NotionFail for CommandUnimplementedError {
     fn is_user_friendly(&self) -> bool {
         true
     }
-    fn exit_code(&self) -> i32 {
-        4
+    fn exit_code(&self) -> ExitCode {
+        ExitCode::NotYetImplemented
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,9 @@ use docopt;
 use failure::Context;
 use notion_fail::{ExitCode, NotionError, NotionFail};
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "{}", error)]
+#[notion_fail(code = "InvalidArguments")]
 pub(crate) struct CliParseError {
     pub(crate) usage: Option<String>,
     pub(crate) error: String,
@@ -24,8 +25,6 @@ impl CliParseError {
         }
     }
 }
-
-impl_notion_fail!(CliParseError, InvalidArguments);
 
 pub(crate) trait DocoptExt {
     fn is_help(&self) -> bool;
@@ -65,8 +64,9 @@ impl NotionErrorExt for NotionError {
     }
 }
 
-#[derive(Fail, Debug)]
+#[derive(Debug, Fail, NotionFail)]
 #[fail(display = "command `{}` is not yet implemented", name)]
+#[notion_fail(code = "NotYetImplemented")]
 pub(crate) struct CommandUnimplementedError {
     pub(crate) name: String,
 }
@@ -78,5 +78,3 @@ impl CommandUnimplementedError {
         }
     }
 }
-
-impl_notion_fail!(CommandUnimplementedError, NotYetImplemented);

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -6,6 +6,8 @@ extern crate failure_derive;
 extern crate notion_core;
 #[macro_use]
 extern crate notion_fail;
+#[macro_use]
+extern crate notion_fail_derive;
 extern crate semver;
 extern crate serde;
 #[macro_use]

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -21,7 +21,7 @@ use docopt::Docopt;
 
 use notion_core::session::{ActivityKind, Session};
 use notion_core::style::{display_error, display_unknown_error, ErrorContext};
-use notion_fail::{FailExt, Fallible, NotionError};
+use notion_fail::{ExitCode, FailExt, Fallible, NotionError};
 
 use command::{Command, CommandName, Config, Current, Deactivate, Fetch, Help, Install, Shim, Use,
               Version};
@@ -203,19 +203,19 @@ pub fn main() {
         Ok(session) => session,
         Err(err) => {
             display_error_and_usage(&err);
-            exit(1);
+            exit(ExitCode::UnknownError as i32);
         }
     };
 
     session.add_event_start(ActivityKind::Notion);
 
     let exit_code = match Notion::go(&mut session) {
-        Ok(true) => 0,
-        Ok(false) => 1,
+        Ok(true) => ExitCode::Success as i32,
+        Ok(false) => ExitCode::UnknownError as i32,
         Err(err) => {
             display_error_and_usage(&err);
             session.add_event_error(ActivityKind::Notion, &err);
-            err.exit_code()
+            err.exit_code() as i32
         }
     };
     session.add_event_end(ActivityKind::Notion, exit_code);

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -16,7 +16,6 @@ extern crate serde_derive;
 mod command;
 mod error;
 
-use std::process::exit;
 use std::string::ToString;
 
 use docopt::Docopt;
@@ -205,19 +204,19 @@ pub fn main() {
         Ok(session) => session,
         Err(err) => {
             display_error_and_usage(&err);
-            exit(ExitCode::UnknownError as i32);
+            ExitCode::UnknownError.exit();
         }
     };
 
     session.add_event_start(ActivityKind::Notion);
 
     let exit_code = match Notion::go(&mut session) {
-        Ok(true) => ExitCode::Success as i32,
-        Ok(false) => ExitCode::UnknownError as i32,
+        Ok(true) => ExitCode::Success,
+        Ok(false) => ExitCode::UnknownError,
         Err(err) => {
             display_error_and_usage(&err);
             session.add_event_error(ActivityKind::Notion, &err);
-            err.exit_code() as i32
+            err.exit_code()
         }
     };
     session.add_event_end(ActivityKind::Notion, exit_code);


### PR DESCRIPTION
This is an implementation of the ["Exit codes" RFC](https://github.com/notion-cli/rfcs/pull/20).  It consists of two primary changes:

* Implement `ExitCode` enum and convert existing errors and error-handling code to use it.
* Add a derivation for the `NotionFail` trait.