### PR TITLE
Fix so publishing universal docs stops failing

### DIFF
--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -2,8 +2,8 @@
 //! in a standard Notion layout in Windows operating systems.
 
 use std::path::PathBuf;
-// using std::os instead of std::os::windows because that was causing `cargo doc --features universal-docs` to fail
-use std::os;
+#[cfg(windows)]
+use std::os::windows;
 use std::io;
 
 use winfolder;
@@ -49,6 +49,7 @@ fn program_data_root() -> Fallible<PathBuf> {
     #[cfg(windows)]
     return Ok(winfolder::Folder::ProgramData.path().join("Notion"));
 
+    // "universal-docs" is built on a Unix machine, so we can't include Windows-specific libs
     #[cfg(feature = "universal-docs")]
     unimplemented!()
 }
@@ -117,6 +118,7 @@ fn program_files_root() -> Fallible<PathBuf> {
     #[cfg(windows)]
     return Ok(winfolder::Folder::ProgramFilesX64.path().join("Notion"));
 
+    // "universal-docs" is built on a Unix machine, so we can't include Windows-specific libs
     #[cfg(feature = "universal-docs")]
     unimplemented!()
 }
@@ -146,6 +148,7 @@ fn local_data_root() -> Fallible<PathBuf> {
     #[cfg(windows)]
     return Ok(winfolder::Folder::LocalAppData.path().join("Notion"));
 
+    // "universal-docs" is built on a Unix machine, so we can't include Windows-specific libs
     #[cfg(feature = "universal-docs")]
     unimplemented!()
 }
@@ -159,5 +162,10 @@ pub fn user_catalog_file() -> Fallible<PathBuf> {
 }
 
 pub fn create_file_symlink(src: PathBuf, dst: PathBuf) -> Result<(), io::Error> {
-    os::windows::fs::symlink_file(src, dst)
+    #[cfg(windows)]
+    return windows::fs::symlink_file(src, dst);
+
+    // "universal-docs" is built on a Unix machine, so we can't include Windows-specific libs
+    #[cfg(feature = "universal-docs")]
+    unimplemented!()
 }

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -2,6 +2,7 @@
 //! in a standard Notion layout in Windows operating systems.
 
 use std::path::PathBuf;
+// using std::os instead of std::os::windows because that was causing `cargo doc --features universal-docs` to fail
 use std::os;
 use std::io;
 

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -2,7 +2,7 @@
 //! in a standard Notion layout in Windows operating systems.
 
 use std::path::PathBuf;
-use std::os::windows;
+use std::os;
 use std::io;
 
 use winfolder;
@@ -158,5 +158,5 @@ pub fn user_catalog_file() -> Fallible<PathBuf> {
 }
 
 pub fn create_file_symlink(src: PathBuf, dst: PathBuf) -> Result<(), io::Error> {
-    windows::fs::symlink_file(src, dst)
+    os::windows::fs::symlink_file(src, dst)
 }


### PR DESCRIPTION
## Problem

The "Publish" step is currently failing on travis, so all the build badges on https://github.com/notion-cli/notion are red - that's not a good look when we are getting ready to MVP this.

## Repro

```
$ rustup install nightly
$ rustup run nightly cargo doc --features universal-docs -p notion-core --no-deps
```

## This fix

I'm not sure why this is failing, since this is already using `#[doc(cfg(windows))]` for the windows module. All I did was split up the usage of `std::os::windows` so the compilation stops failing.