### PR TITLE
[WIP] Fix windows build failures

### DIFF
--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -60,6 +60,10 @@ pub fn node_cache_dir() -> Fallible<PathBuf> {
     Ok(cache_dir()?.join("node"))
 }
 
+pub fn yarn_cache_dir() -> Fallible<PathBuf> {
+    Ok(cache_dir()?.join("yarn"))
+}
+
 pub fn node_index_file() -> Fallible<PathBuf> {
     Ok(node_cache_dir()?.join("index.json"))
 }
@@ -80,12 +84,24 @@ pub fn node_versions_dir() -> Fallible<PathBuf> {
     Ok(versions_dir()?.join("node"))
 }
 
+pub fn yarn_versions_dir() -> Fallible<PathBuf> {
+    Ok(versions_dir()?.join("yarn"))
+}
+
 pub fn node_version_dir(version: &str) -> Fallible<PathBuf> {
     Ok(node_versions_dir()?.join(version))
 }
 
+pub fn yarn_version_dir(version: &str) -> Fallible<PathBuf> {
+    Ok(yarn_versions_dir()?.join(version))
+}
+
 pub fn node_version_bin_dir(version: &str) -> Fallible<PathBuf> {
     node_version_dir(version)
+}
+
+pub fn yarn_version_bin_dir(version: &str) -> Fallible<PathBuf> {
+    Ok(yarn_version_dir(version)?.join("bin"))
 }
 
 // 3rd-party binaries installed globally for this node version


### PR DESCRIPTION
Trying to fix the build failures so appveyor will be passing. Looks like the problems are simply missing functions in the windows-specific modules.