### PR TITLE
Implement new version of `notion use`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "detect-indent"
+version = "0.1.0"
+source = "git+https://github.com/stefanpenner/detect-indent-rs#573045994307588815befe7d0edcc2e864e096de"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "docopt"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +685,7 @@ dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmdline_words_parser 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "detect-indent 0.1.0 (git+https://github.com/stefanpenner/detect-indent-rs)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1526,6 +1536,7 @@ dependencies = [
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum debug-builders 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f5d8e3d14cabcb2a8a59d7147289173c6ada77a0bc526f6b85078f941c0cf12"
 "checksum debugtrace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62e432bd83c5d70317f6ebd8a50ed4afb32907c64d6e2e1e65e339b06dc553f3"
+"checksum detect-indent 0.1.0 (git+https://github.com/stefanpenner/detect-indent-rs)" = "<none>"
 "checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a39bffec1e2015c5d8a6773cb0cf48d0d758c842398f624c34969071f5499ea7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1552,6 +1558,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum libflate 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1a429b86418868c7ea91ee50e9170683f47fd9d94f5375438ec86ec3adb74e8e"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -27,3 +27,4 @@ cfg-if = "0.1"
 winfolder = "0.1"
 tempfile = "3.0.2"
 os_info = "0.7.0"
+detect-indent = { "git" = "https://github.com/stefanpenner/detect-indent-rs", "branch" = "master" }

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -12,7 +12,7 @@ term_size = "0.3.0"
 indicatif = "0.9.0"
 console = "0.6.1"
 readext = "0.1.0"
-serde_json = "1.0.3"
+serde_json = { version = "1.0.3", features = ["preserve_order"] }
 serde = "1.0.27"
 serde_derive = "1.0.27"
 node-archive = { path = "../node-archive" }

--- a/crates/notion-core/fixtures/no_toolchain/package.json
+++ b/crates/notion-core/fixtures/no_toolchain/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "basic-project",
+  "version": "0.0.7",
+  "description": "Testing that manifest pulls things out of this correctly",
+  "license": "To Kill",
+  "dependencies": {
+    "@namespace/some-dep": "0.2.4",
+    "rsvp": "^3.5.0"
+  },
+  "devDependencies": {
+    "@namespaced/something-else": "^6.3.7",
+    "eslint": "~4.8.0"
+  }
+}

--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -126,6 +126,12 @@ impl Catalog {
         Ok(fetched)
     }
 
+    /// Resolves a Node version matching the specified semantic versioning requirements.
+    pub fn resolve_node(&self, matching: &VersionReq, config: &Config) -> Fallible<Version> {
+        let distro = self.node.resolve_remote(&matching, config.node.as_ref())?;
+        Ok(distro.version().clone())
+    }
+
     /// Uninstalls a specific Node version from the local catalog.
     pub fn uninstall_node(&mut self, version: &Version) -> Fallible<()> {
         if self.node.contains(version) {
@@ -174,6 +180,12 @@ impl Catalog {
         }
 
         Ok(fetched)
+    }
+
+    /// Resolves a Yarn version matching the specified semantic versioning requirements.
+    pub fn resolve_yarn(&self, matching: &VersionReq, config: &Config) -> Fallible<Version> {
+        let distro = self.yarn.resolve_remote(&matching, config.yarn.as_ref())?;
+        Ok(distro.version().clone())
     }
 
     /// Uninstalls a specific Yarn version from the local catalog.

--- a/crates/notion-core/src/distro/node.rs
+++ b/crates/notion-core/src/distro/node.rs
@@ -1,8 +1,8 @@
 //! Provides the `Installer` type, which represents a provisioned Node installer.
 
 use std::fs::{rename, File};
-use std::string::ToString;
 use std::path::PathBuf;
+use std::string::ToString;
 
 use super::{Distro, Fetched};
 use catalog::NodeCollection;

--- a/crates/notion-core/src/distro/node.rs
+++ b/crates/notion-core/src/distro/node.rs
@@ -2,6 +2,7 @@
 
 use std::fs::{rename, File};
 use std::string::ToString;
+use std::path::PathBuf;
 
 use super::{Distro, Fetched};
 use catalog::NodeCollection;
@@ -21,6 +22,20 @@ pub struct NodeDistro {
     version: Version,
 }
 
+/// Check if the cached file is valid. It may have been corrupted or interrupted in the middle of
+/// downloading.
+fn cache_is_valid(cache_file: &PathBuf) -> bool {
+    if cache_file.is_file() {
+        if let Ok(file) = File::open(cache_file) {
+            match node_archive::load(file) {
+                Ok(_) => return true,
+                Err(_) => return false,
+            }
+        }
+    }
+    false
+}
+
 impl Distro for NodeDistro {
     /// Provision a Node distribution from the public Node distributor (`https://nodejs.org`).
     fn public(version: Version) -> Fallible<Self> {
@@ -34,7 +49,7 @@ impl Distro for NodeDistro {
         let archive_file = path::node_archive_file(&version.to_string());
         let cache_file = path::node_cache_dir()?.join(&archive_file);
 
-        if cache_file.is_file() {
+        if cache_is_valid(&cache_file) {
             return NodeDistro::cached(version, File::open(cache_file).unknown()?);
         }
 

--- a/crates/notion-core/src/distro/yarn.rs
+++ b/crates/notion-core/src/distro/yarn.rs
@@ -1,8 +1,8 @@
 //! Provides the `Installer` type, which represents a provisioned Node installer.
 
 use std::fs::{rename, File};
-use std::string::ToString;
 use std::path::PathBuf;
+use std::string::ToString;
 
 use super::{Distro, Fetched};
 use catalog::YarnCollection;

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate cmdline_words_parser;
 extern crate console;
+extern crate detect_indent;
 extern crate indicatif;
 extern crate lazycell;
 extern crate node_archive;

--- a/crates/notion-core/src/manifest.rs
+++ b/crates/notion-core/src/manifest.rs
@@ -96,12 +96,11 @@ impl Manifest {
             let toolchain_value = serde_json::to_value(toolchain).unknown()?;
             map.insert("toolchain".to_string(), toolchain_value);
 
-            // TODO: write to file
+            // serialize the updated contents back to package.json
             let file = File::create(package_file).unknown()?;
             let formatter =
                 serde_json::ser::PrettyFormatter::with_indent(indent.indent().as_bytes());
             let mut ser = serde_json::Serializer::with_formatter(file, formatter);
-
             map.serialize(&mut ser).unknown()?;
         }
         Ok(())
@@ -128,39 +127,21 @@ pub mod tests {
     #[test]
     fn gets_node_version() {
         let project_path = fixture_path("basic");
-        let version = match Manifest::for_dir(&project_path) {
-            Ok(manifest) => manifest.node().unwrap(),
-            _ => panic!(
-                "Error: Could not get manifest for project {:?}",
-                project_path
-            ),
-        };
+        let version = Manifest::for_dir(&project_path).expect("Could not get manifest").node().unwrap();
         assert_eq!(version, VersionReq::parse("=6.11.1").unwrap());
     }
 
     #[test]
     fn gets_yarn_version() {
         let project_path = fixture_path("basic");
-        let version = match Manifest::for_dir(&project_path) {
-            Ok(manifest) => manifest.yarn(),
-            _ => panic!(
-                "Error: Could not get manifest for project {:?}",
-                project_path
-            ),
-        };
+        let version = Manifest::for_dir(&project_path).expect("Could not get manifest").yarn();
         assert_eq!(version.unwrap(), VersionReq::parse("=1.2").unwrap());
     }
 
     #[test]
     fn gets_dependencies() {
         let project_path = fixture_path("basic");
-        let dependencies = match Manifest::for_dir(&project_path) {
-            Ok(manifest) => manifest.dependencies,
-            _ => panic!(
-                "Error: Could not get manifest for project {:?}",
-                project_path
-            ),
-        };
+        let dependencies = Manifest::for_dir(&project_path).expect("Could not get manifest").dependencies;
         let mut expected_deps = HashMap::new();
         expected_deps.insert("@namespace/some-dep".to_string(), "0.2.4".to_string());
         expected_deps.insert("rsvp".to_string(), "^3.5.0".to_string());
@@ -170,13 +151,7 @@ pub mod tests {
     #[test]
     fn gets_dev_dependencies() {
         let project_path = fixture_path("basic");
-        let dev_dependencies = match Manifest::for_dir(&project_path) {
-            Ok(manifest) => manifest.dev_dependencies,
-            _ => panic!(
-                "Error: Could not get manifest for project {:?}",
-                project_path
-            ),
-        };
+        let dev_dependencies = Manifest::for_dir(&project_path).expect("Could not get manifest").dev_dependencies;
         let mut expected_deps = HashMap::new();
         expected_deps.insert(
             "@namespaced/something-else".to_string(),
@@ -189,26 +164,14 @@ pub mod tests {
     #[test]
     fn node_for_no_toolchain() {
         let project_path = fixture_path("no_toolchain");
-        let manifest = match Manifest::for_dir(&project_path) {
-            Ok(manifest) => manifest,
-            _ => panic!(
-                "Error: Could not get manifest for project {:?}",
-                project_path
-            ),
-        };
+        let manifest = Manifest::for_dir(&project_path).expect("Could not get manifest");
         assert_eq!(manifest.node(), None);
     }
 
     #[test]
     fn yarn_for_no_toolchain() {
         let project_path = fixture_path("no_toolchain");
-        let manifest = match Manifest::for_dir(&project_path) {
-            Ok(manifest) => manifest,
-            _ => panic!(
-                "Error: Could not get manifest for project {:?}",
-                project_path
-            ),
-        };
+        let manifest = Manifest::for_dir(&project_path).expect("Could not get manifest");
         assert_eq!(manifest.yarn(), None);
     }
 

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -247,13 +247,7 @@ pub mod tests {
         let project_path = fixture_path("basic");
         let test_project = Project::for_dir(&project_path).unwrap().unwrap();
 
-        let all_deps = match test_project.all_dependencies() {
-            Ok(deps) => deps,
-            _ => panic!(
-                "Error: Could not get dependencies for project {:?}",
-                project_path
-            ),
-        };
+        let all_deps = test_project.all_dependencies().expect("Could not get dependencies");
         let mut expected_deps = HashSet::new();
         expected_deps.insert("@namespace/some-dep".to_string());
         expected_deps.insert("rsvp".to_string());
@@ -267,13 +261,7 @@ pub mod tests {
         let project_path = fixture_path("basic");
         let test_project = Project::for_dir(&project_path).unwrap().unwrap();
 
-        let dep_bins = match test_project.dependent_binaries() {
-            Ok(bin_map) => bin_map,
-            _ => panic!(
-                "Error: Could not get dependent binaries for project {:?}",
-                project_path
-            ),
-        };
+        let dep_bins = test_project.dependent_binaries().expect("Could not get dependent binaries");
         let mut expected_bins = HashMap::new();
         expected_bins.insert("eslint".to_string(), "./bin/eslint.js".to_string());
         expected_bins.insert("rsvp".to_string(), "./bin/rsvp.js".to_string());

--- a/crates/notion-core/src/serial/manifest.rs
+++ b/crates/notion-core/src/serial/manifest.rs
@@ -30,7 +30,6 @@ pub struct ToolchainManifest {
 }
 
 impl Manifest {
-    // TODO - docs
     pub fn into_manifest(self) -> Fallible<manifest::Manifest> {
         Ok(manifest::Manifest {
             toolchain: self.into_toolchain_manifest()?,
@@ -39,7 +38,6 @@ impl Manifest {
         })
     }
 
-    // TODO - docs
     pub fn into_toolchain_manifest(&self) -> Fallible<Option<manifest::ToolchainManifest>> {
         if let Some(toolchain) = &self.toolchain {
             return Ok(Some(manifest::ToolchainManifest {

--- a/crates/notion-core/src/serial/manifest.rs
+++ b/crates/notion-core/src/serial/manifest.rs
@@ -33,16 +33,27 @@ impl Manifest {
         if let Some(notion) = self.toolchain {
             return Ok(Some(manifest::Manifest {
                 node: parse_requirements(&notion.node)?,
-                yarn: if let Some(yarn) = notion.yarn {
+                node_str: notion.node,
+                yarn: if let Some(yarn) = &notion.yarn {
                     Some(parse_requirements(&yarn)?)
                 } else {
                     None
                 },
+                yarn_str: notion.yarn,
                 dependencies: self.dependencies,
                 dev_dependencies: self.dev_dependencies,
             }));
         }
 
         Ok(None)
+    }
+}
+
+impl ToolchainManifest {
+    pub fn new(node_version: String, yarn_version: Option<String>) -> Self {
+        ToolchainManifest {
+            node: node_version,
+            yarn: yarn_version,
+        }
     }
 }

--- a/crates/notion-core/src/serial/manifest.rs
+++ b/crates/notion-core/src/serial/manifest.rs
@@ -25,26 +25,34 @@ pub struct Manifest {
 #[derive(Serialize, Deserialize)]
 pub struct ToolchainManifest {
     pub node: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub yarn: Option<String>,
 }
 
 impl Manifest {
-    pub fn into_manifest(self) -> Fallible<Option<manifest::Manifest>> {
-        if let Some(notion) = self.toolchain {
-            return Ok(Some(manifest::Manifest {
-                node: parse_requirements(&notion.node)?,
-                node_str: notion.node,
-                yarn: if let Some(yarn) = &notion.yarn {
+    // TODO - docs
+    pub fn into_manifest(self) -> Fallible<manifest::Manifest> {
+        Ok(manifest::Manifest {
+            toolchain: self.into_toolchain_manifest()?,
+            dependencies: self.dependencies,
+            dev_dependencies: self.dev_dependencies,
+        })
+    }
+
+    // TODO - docs
+    pub fn into_toolchain_manifest(&self) -> Fallible<Option<manifest::ToolchainManifest>> {
+        if let Some(toolchain) = &self.toolchain {
+            return Ok(Some(manifest::ToolchainManifest {
+                node: parse_requirements(&toolchain.node)?,
+                node_str: toolchain.node.clone(),
+                yarn: if let Some(yarn) = &toolchain.yarn {
                     Some(parse_requirements(&yarn)?)
                 } else {
                     None
                 },
-                yarn_str: notion.yarn,
-                dependencies: self.dependencies,
-                dev_dependencies: self.dev_dependencies,
+                yarn_str: toolchain.yarn.clone(),
             }));
         }
-
         Ok(None)
     }
 }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -13,8 +13,7 @@ use std::fmt::{self, Display, Formatter};
 use std::process::exit;
 
 use event::EventLog;
-use notion_fail::NotionFail;
-use notion_fail::{Fallible, NotionError, ResultExt};
+use notion_fail::{Fallible, NotionError, NotionFail, ResultExt};
 use semver::{Version, VersionReq};
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -150,6 +150,27 @@ impl Session {
         catalog.set_default_node(matching, config)
     }
 
+    /// Returns the version of Node matching the specified semantic versioning requirements.
+    pub fn get_matching_node(&self, matching: &VersionReq) -> Fallible<Version> {
+        let catalog = self.catalog.get()?;
+        let config = self.config.get()?;
+        catalog.resolve_node(matching, config)
+    }
+
+    /// Updates toolchain in package.json with the Node version matching the specified semantic
+    /// versioning requirements.
+    pub fn pin_node_version(&self, matching: &VersionReq) -> Fallible<bool> {
+        if let Some(ref project) = self.project {
+            let node_version = self.get_matching_node(matching)?;
+            project.pin_node_in_toolchain(node_version)?;
+        }
+        else {
+            // TODO: throw error - not in project
+            unimplemented!("Not in a project");
+        }
+        Ok(true)
+    }
+
     /// Produces the version of Yarn for the current session. If there is an
     /// active pinned project, this will ensure that project's Yarn version is
     /// installed before returning. If there is no active pinned project, this
@@ -187,6 +208,27 @@ impl Session {
         let catalog = self.catalog.get_mut()?;
         let config = self.config.get()?;
         catalog.set_default_yarn(matching, config)
+    }
+
+    /// Returns the version of Yarn matching the specified semantic versioning requirements
+    pub fn get_matching_yarn(&self, matching: &VersionReq) -> Fallible<Version> {
+        let catalog = self.catalog.get()?;
+        let config = self.config.get()?;
+        catalog.resolve_yarn(matching, config)
+    }
+
+    /// Updates toolchain in package.json with the Yarn version matching the specified semantic
+    /// versioning requirements.
+    pub fn pin_yarn_version(&self, matching: &VersionReq) -> Fallible<bool> {
+        if let Some(ref project) = self.project {
+            let yarn_version = self.get_matching_yarn(matching)?;
+            project.pin_yarn_in_toolchain(yarn_version)?;
+        }
+        else {
+            // TODO: throw error - not in project
+            unimplemented!("Not in a project");
+        }
+        Ok(true)
     }
 
     pub fn add_event_start(&mut self, activity_kind: ActivityKind) {

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -198,7 +198,7 @@ impl Tool for Binary {
 
         if session.in_pinned_project() {
             // we are in a pinned Node project
-            let project = session.node_project().unwrap();
+            let project = session.project().unwrap();
 
             // if this project has this as a local executable, use that
             if project.has_direct_bin(&exe)? {

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -196,8 +196,9 @@ impl Tool for Binary {
         let exe = arg0(&mut args)?;
         let current_path = var_os("PATH").unwrap_or(OsString::new());
 
-        if let Some(project) = session.project() {
-            // we are in a Node project
+        if session.in_pinned_project() {
+            // we are in a pinned Node project
+            let project = session.node_project().unwrap();
 
             // if this project has this as a local executable, use that
             if project.has_direct_bin(&exe)? {

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -99,17 +99,13 @@ Options:
 }
 
 fn project_node_version(session: &Session) -> Fallible<Option<String>> {
-    let project = session.project();
-    let project = match project {
-        Some(ref project) => project,
-        None => {
-            return Ok(None);
-        }
-    };
-
-    let req = &project.manifest().node;
-    let catalog = session.catalog()?;
-    Ok(catalog.node.resolve_local(&req).map(|v| v.to_string()))
+    if session.in_pinned_project() {
+        let project = session.node_project().unwrap();
+        let req = &project.manifest().node();
+        let catalog = session.catalog()?;
+        return Ok(catalog.node.resolve_local(&req).map(|v| v.to_string()));
+    }
+    Ok(None)
 }
 
 fn user_node_version(session: &Session) -> Fallible<Option<String>> {

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -100,8 +100,8 @@ Options:
 
 fn project_node_version(session: &Session) -> Fallible<Option<String>> {
     if session.in_pinned_project() {
-        let project = session.node_project().unwrap();
-        let req = &project.manifest().node();
+        let project = session.project().unwrap();
+        let req = &project.manifest().node().unwrap();
         let catalog = session.catalog()?;
         return Ok(catalog.node.resolve_local(&req).map(|v| v.to_string()));
     }

--- a/src/command/shim.rs
+++ b/src/command/shim.rs
@@ -151,7 +151,7 @@ fn resolve_shim(session: &Session, shim_name: &OsStr) -> Fallible<ShimKind> {
 }
 
 fn available_node_version(project: &Project, session: &Session) -> Fallible<Option<Version>> {
-    let requirements = &project.manifest().node();
+    let requirements = &project.manifest().node().unwrap();
     let catalog = session.catalog()?;
     Ok(catalog.node.resolve_local(&requirements))
 }
@@ -160,8 +160,8 @@ fn available_node_version(project: &Project, session: &Session) -> Fallible<Opti
 // or which version will be installed if it's not pinned by the project
 fn resolve_node_shims(session: &Session, shim_name: &OsStr) -> Fallible<ShimKind> {
     if session.in_pinned_project() {
-        let project = session.node_project().unwrap();
-        let requirements = &project.manifest().node();
+        let project = session.project().unwrap();
+        let requirements = &project.manifest().node().unwrap();
         if let Some(available) = available_node_version(&project, &session)? {
             // Node is pinned by the project - this shim will use that version
             let mut bin_path = path::node_version_bin_dir(&available.to_string()).unknown()?;
@@ -183,7 +183,7 @@ fn resolve_node_shims(session: &Session, shim_name: &OsStr) -> Fallible<ShimKind
 
 fn resolve_yarn_shims(session: &Session, shim_name: &OsStr) -> Fallible<ShimKind> {
     if session.in_pinned_project() {
-        let project = session.node_project().unwrap();
+        let project = session.project().unwrap();
         if let Some(requirements) = &project.manifest().yarn() {
             let catalog = session.catalog()?;
             if let Some(available) = catalog.yarn.resolve_local(&requirements) {
@@ -212,7 +212,7 @@ fn resolve_npx_shims(_session: &Session, _shim_name: &OsStr) -> Fallible<ShimKin
 
 fn resolve_3p_shims(session: &Session, shim_name: &OsStr) -> Fallible<ShimKind> {
     if session.in_pinned_project() {
-        let project = session.node_project().unwrap();
+        let project = session.project().unwrap();
         // if this is a local executable, get the path to that
         if project.has_direct_bin(shim_name)? {
             let mut path_to_bin = project.local_bin_dir();

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -20,16 +20,15 @@ pub(crate) struct Args {
 
 // error message for using tools that are not node|yarn
 #[derive(Fail, Debug)]
-#[fail(display = "pinning tool '{}' not yet implemented - for now you can manually edit package.json", name)]
+#[fail(display = "pinning tool '{}' not yet implemented - for now you can manually edit package.json",
+       name)]
 pub(crate) struct NoCustomUseError {
     pub(crate) name: String,
 }
 
 impl NoCustomUseError {
     pub(crate) fn new(name: String) -> Self {
-        NoCustomUseError {
-            name: name,
-        }
+        NoCustomUseError { name: name }
     }
 }
 
@@ -41,7 +40,6 @@ impl NotionFail for NoCustomUseError {
         4
     }
 }
-
 
 pub(crate) enum Use {
     Help,

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -6,8 +6,7 @@ use semver::VersionReq;
 
 use notion_core::serial::version::parse_requirements;
 use notion_core::session::{ActivityKind, Session};
-use notion_fail::Fallible;
-use notion_fail::NotionFail;
+use notion_fail::{Fallible, NotionFail};
 
 use Notion;
 use command::{Command, CommandName, Help};

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -7,6 +7,7 @@ use semver::VersionReq;
 use notion_core::serial::version::parse_requirements;
 use notion_core::session::{ActivityKind, Session};
 use notion_fail::Fallible;
+use notion_fail::NotionFail;
 
 use Notion;
 use command::{Command, CommandName, Help};
@@ -16,6 +17,31 @@ pub(crate) struct Args {
     arg_tool: String,
     arg_version: String,
 }
+
+// error message for using tools that are not node|yarn
+#[derive(Fail, Debug)]
+#[fail(display = "pinning tool '{}' not yet implemented - for now you can manually edit package.json", name)]
+pub(crate) struct NoCustomUseError {
+    pub(crate) name: String,
+}
+
+impl NoCustomUseError {
+    pub(crate) fn new(name: String) -> Self {
+        NoCustomUseError {
+            name: name,
+        }
+    }
+}
+
+impl NotionFail for NoCustomUseError {
+    fn is_user_friendly(&self) -> bool {
+        true
+    }
+    fn exit_code(&self) -> i32 {
+        4
+    }
+}
+
 
 pub(crate) enum Use {
     Help,
@@ -62,15 +88,13 @@ Options:
     fn run(self, session: &mut Session) -> Fallible<bool> {
         session.add_event_start(ActivityKind::Use);
         match self {
-            Use::Help => {
-                Help::Command(CommandName::Use).run(session)?;
-            }
-            Use::Node(_requirements) => unimplemented!(),
-            Use::Yarn(_requirements) => unimplemented!(),
+            Use::Help => Help::Command(CommandName::Use).run(session)?,
+            Use::Node(requirements) => session.pin_node_version(&requirements)?,
+            Use::Yarn(requirements) => session.pin_yarn_version(&requirements)?,
             Use::Other {
-                name: _,
+                name: _name,
                 version: _,
-            } => unimplemented!(),
+            } => throw!(NoCustomUseError::new(_name)),
         };
         session.add_event_end(ActivityKind::Use, 0);
         Ok(true)


### PR DESCRIPTION
This implements `notion use node <version>` and `notion use yarn <version>`, which pins those versions to the `"toolchain"` in package.json.

There are a lot of changes here because I re-worked some of the `Manifest` code so that it generates a Manifest even if the "toolchain" has not been pinned yet. That should make it easier to do https://github.com/notion-cli/notion/issues/85, which I will do at some point as a follow-up.

Closes https://github.com/notion-cli/notion/issues/115