### PR TITLE
Allow optional `v` prefix for version specifiers

### DIFF
--- a/crates/notion-core/src/serial/version.rs
+++ b/crates/notion-core/src/serial/version.rs
@@ -22,8 +22,42 @@ pub fn parse_requirements(src: &str) -> Fallible<VersionReq> {
         if src.len() > 0 && src.chars().next().unwrap().is_digit(10) {
             let defaulted = format!("={}", src);
             VersionReq::parse(&defaulted).with_context(VersionParseError::from_req_parse_error)?
+        } else if src.len() > 0 && src.chars().next().unwrap() == 'v' {
+            let defaulted = src.replacen("v", "=", 1);
+            VersionReq::parse(&defaulted).with_context(VersionParseError::from_req_parse_error)?
         } else {
             VersionReq::parse(src).with_context(VersionParseError::from_req_parse_error)?
         },
     )
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use serial::version::parse_requirements;
+    use semver::VersionReq;
+
+    #[test]
+    fn test_parse_requirements() {
+        assert_eq!(
+            parse_requirements("1.2.3").unwrap(),
+            VersionReq::parse("=1.2.3").unwrap()
+        );
+        assert_eq!(
+            parse_requirements("v1.5").unwrap(),
+            VersionReq::parse("=1.5").unwrap()
+        );
+        assert_eq!(
+            parse_requirements("=1.2.3").unwrap(),
+            VersionReq::parse("=1.2.3").unwrap()
+        );
+        assert_eq!(
+            parse_requirements("^1.2").unwrap(),
+            VersionReq::parse("^1.2").unwrap()
+        );
+        assert_eq!(
+            parse_requirements(">=1.4").unwrap(),
+            VersionReq::parse(">=1.4").unwrap()
+        );
+    }
 }


### PR DESCRIPTION
So users can do things like `notion use node v1.2`, which some people expect