### PR TITLE
support "latest" to be specified as version for node and yarn

### DIFF
--- a/crates/notion-core/src/catalog.rs
+++ b/crates/notion-core/src/catalog.rs
@@ -280,7 +280,7 @@ impl RegistryFetchError {
 
 impl Resolve<NodeDistro> for NodeCollection {
     fn resolve_public(&self, matching: &VersionReq) -> Fallible<NodeDistro> {
-        let index: Index = resolve_node_versions().unwrap().into_index()?;
+        let index: Index = resolve_node_versions()?.into_index()?;
 
         let version = index.entries.iter()
             .rev()
@@ -443,7 +443,7 @@ fn resolve_node_versions() -> Result<serial::index::Index, NotionError> {
 pub fn parse_node_version(src: String) -> Fallible<String> {
     let mut version:String= src;
     if version == "latest" {
-        let index = resolve_node_versions().unwrap().into_index()?;
+        let index = resolve_node_versions()?.into_index()?;
         let mut latest_version:Version = index.entries.keys().next().unwrap().clone();
         for key in index.entries.keys() {
             if key > &latest_version {
@@ -458,7 +458,8 @@ pub fn parse_node_version(src: String) -> Fallible<String> {
 pub fn parse_yarn_version(src: String) -> Fallible<String> {
     let mut version:String = src;
     if version == "latest" {
-        let mut response: reqwest::Response = reqwest::get(PUBLIC_YARN_LATEST_VERSION).unwrap();
+        let mut response: reqwest::Response = reqwest::get(PUBLIC_YARN_LATEST_VERSION)
+            .with_context(RegistryFetchError::from_error)?;
         version = response.text().unknown()?;
     }
     Ok(version)

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -1,6 +1,7 @@
 use semver::VersionReq;
 
 use notion_core::serial::version::parse_requirements;
+use notion_core::catalog::{parse_node_version, parse_yarn_version};
 use notion_core::session::{ActivityKind, Session};
 use notion_fail::{ExitCode, Fallible};
 
@@ -45,8 +46,14 @@ Options:
         }: Args,
     ) -> Fallible<Self> {
         match &arg_tool[..] {
-            "node" => Ok(Fetch::Node(parse_requirements(&arg_version)?)),
-            "yarn" => Ok(Fetch::Yarn(parse_requirements(&arg_version)?)),
+            "node" => {
+                let node_version = parse_node_version(arg_version)?;
+                Ok(Fetch::Node(parse_requirements(&node_version)?))
+            },
+            "yarn" => {
+                let yarn_version = parse_yarn_version(arg_version)?;
+                Ok(Fetch::Yarn(parse_requirements(&yarn_version)?))
+            },
             ref tool => {
                 throw!(CliParseError {
                     usage: None,

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -2,6 +2,7 @@ use semver::VersionReq;
 
 use notion_core::serial::version::parse_requirements;
 use notion_core::session::{ActivityKind, Session};
+use notion_core::catalog::{parse_node_version, parse_yarn_version};
 use notion_fail::{ExitCode, Fallible};
 
 use Notion;
@@ -46,8 +47,14 @@ Options:
         }: Args,
     ) -> Fallible<Self> {
         match &arg_tool[..] {
-            "node" => Ok(Install::Node(parse_requirements(&arg_version)?)),
-            "yarn" => Ok(Install::Yarn(parse_requirements(&arg_version)?)),
+            "node" => {
+                let node_version = parse_node_version(arg_version)?;
+                Ok(Install::Node(parse_requirements(&node_version)?))
+            },
+            "yarn" => {
+                let yarn_version = parse_yarn_version(arg_version)?;
+                Ok(Install::Yarn(parse_requirements(&yarn_version)?))
+            },
             ref tool => Ok(Install::Other {
                 name: tool.to_string(),
                 version: parse_requirements(&arg_version)?,

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -6,6 +6,7 @@ use semver::VersionReq;
 
 use notion_core::serial::version::parse_requirements;
 use notion_core::session::{ActivityKind, Session};
+use notion_core::catalog::{parse_node_version, parse_yarn_version};
 use notion_fail::{ExitCode, Fallible, NotionFail};
 
 use Notion;
@@ -65,8 +66,14 @@ Options:
         }: Args,
     ) -> Fallible<Self> {
         match &arg_tool[..] {
-            "node" => Ok(Use::Node(parse_requirements(&arg_version)?)),
-            "yarn" => Ok(Use::Yarn(parse_requirements(&arg_version)?)),
+            "node" => {
+                let node_version = parse_node_version(arg_version)?;
+                Ok(Use::Node(parse_requirements(&node_version)?))
+            },
+            "yarn" => {
+                let yarn_version = parse_yarn_version(arg_version)?;
+                Ok(Use::Yarn(parse_requirements(&yarn_version)?))
+            },
             ref tool => Ok(Use::Other {
                 name: tool.to_string(),
                 version: parse_requirements(&arg_version)?,


### PR DESCRIPTION
notion will resolve to a version that is the latest released version of node/yarn
implemented latest for following notion commands:
`notion fetch node latest`
`notion fetch yarn latest`
`notion install node latest`
`notion install yarn latest`
`notion use node latest`
`notion use yarn latest`

moved node resolve request code out from `resolve_public` to a new method `resolve_node_versions` which can be reused for `latest`.
Yarn has a API to simply fetch the latest version number `https://yarnpkg.com/latest-version`, but couldn't find such endpoint for node, so ended up finding the latest version from `https://nodejs.org/dist/index.json`