### PR TITLE
Improvements to `latest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "notion-core 0.1.0",
  "notion-fail 0.1.0",
  "notion-fail-derive 0.1.0",
+ "result 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1035,6 +1036,11 @@ dependencies = [
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "result"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-demangle"
@@ -1671,6 +1677,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5866613d84e2a39c0479a960bf2d0eff1fbfc934f02cd42b5c08c1e1efc5b1fd"
 "checksum reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "241faa9a8ca28a03cbbb9815a5d085f271d4c0168a19181f106aa93240c22ddb"
+"checksum result 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "acece75e0f987c48863a6c792ec8b7d6c4177d4a027f8ccc72f849794f437016"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,6 @@ failure = "0.1.1"
 notion-fail = { path = "crates/notion-fail" }
 notion-fail-derive = { path = "crates/notion-fail-derive" }
 semver = "0.9.0"
+result = "1.0.0"
 
 [workspace]

--- a/crates/notion-core/src/catalog/mod.rs
+++ b/crates/notion-core/src/catalog/mod.rs
@@ -1,7 +1,7 @@
 //! Provides types for working with Notion's local _catalog_, the local repository
 //! of available tool versions.
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::fs::{remove_dir_all, File};
 use std::io::{self, Write};
 use std::marker::PhantomData;
@@ -276,6 +276,9 @@ impl Resolve<NodeDistro> for NodeCollection {
             let mut entries = index.entries.into_iter();
             let entry = match *matching {
                 VersionSpec::Latest => {
+                    // NOTE: This assumes the registry always produces a list in sorted order
+                    //       from newest to oldest. This should be specified as a requirement
+                    //       when we document the plugin API.
                     entries.next()
                 }
                 VersionSpec::Semver(ref matching) => {

--- a/crates/notion-core/src/catalog/mod.rs
+++ b/crates/notion-core/src/catalog/mod.rs
@@ -103,8 +103,8 @@ impl Catalog {
         Ok(())
     }
 
-    /// Sets the default Node version to one matching the specified semantic versioning requirements.
-    pub fn set_default_node(&mut self, matching: &VersionSpec, config: &Config) -> Fallible<()> {
+    /// Sets the Node version in the user toolchain to one matching the specified semantic versioning requirements.
+    pub fn set_user_node(&mut self, matching: &VersionSpec, config: &Config) -> Fallible<()> {
         let fetched = self.fetch_node(matching, config)?;
         let version = Some(fetched.into_version());
 
@@ -159,8 +159,8 @@ impl Catalog {
 
     // ISSUE (#87) Abstract Catalog's activate, install and uninstall methods
     // And potentially share code between node and yarn
-    /// Sets the default Yarn version to one matching the specified semantic versioning requirements.
-    pub fn set_default_yarn(&mut self, matching: &VersionSpec, config: &Config) -> Fallible<()> {
+    /// Sets the Yarn version in the user toolchain to one matching the specified semantic versioning requirements.
+    pub fn set_user_yarn(&mut self, matching: &VersionSpec, config: &Config) -> Fallible<()> {
         let fetched = self.fetch_yarn(matching, config)?;
         let version = Some(fetched.into_version());
 

--- a/crates/notion-core/src/catalog/mod.rs
+++ b/crates/notion-core/src/catalog/mod.rs
@@ -335,7 +335,7 @@ impl Resolve<YarnDistro> for YarnCollection {
 
 /// The index of the public Node server.
 pub struct Index {
-    pub entries: BTreeMap<Version, VersionData>,
+    entries: Vec<(Version, VersionData)>
 }
 
 /// The set of available files on the public Node server for a given Node version.

--- a/crates/notion-core/src/catalog/mod.rs
+++ b/crates/notion-core/src/catalog/mod.rs
@@ -21,10 +21,10 @@ use config::{Config, ToolConfig};
 use distro::node::NodeDistro;
 use distro::yarn::YarnDistro;
 use distro::{Distro, Fetched};
+use fs::{ensure_containing_dir_exists, read_file_opt, touch};
 use notion_fail::{ExitCode, Fallible, NotionError, NotionFail, ResultExt};
 use path::{self, user_catalog_file};
 use semver::{Version, VersionReq};
-use fs::{ensure_containing_dir_exists, read_file_opt, touch};
 use style::progress_spinner;
 use version::VersionSpec;
 
@@ -239,7 +239,11 @@ impl<D: Distro> Collection<D> {
 
 pub trait Resolve<D: Distro> {
     /// Resolves the specified semantic versioning requirements from a remote distributor.
-    fn resolve_remote(&self, matching: &VersionSpec, config: Option<&ToolConfig<D>>) -> Fallible<D> {
+    fn resolve_remote(
+        &self,
+        matching: &VersionSpec,
+        config: Option<&ToolConfig<D>>,
+    ) -> Fallible<D> {
         match config {
             Some(ToolConfig {
                 resolve: Some(ref plugin),
@@ -338,7 +342,7 @@ impl Resolve<YarnDistro> for YarnCollection {
 
 /// The index of the public Node server.
 pub struct Index {
-    entries: Vec<(Version, VersionData)>
+    entries: Vec<(Version, VersionData)>,
 }
 
 /// The set of available files on the public Node server for a given Node version.
@@ -432,8 +436,7 @@ fn resolve_node_versions() -> Result<serial::Index, NotionError> {
             ensure_containing_dir_exists(&index_expiry_file)?;
             expiry.persist(index_expiry_file).unknown()?;
 
-            let serial: serial::Index =
-                serde_json::de::from_str(&response_text).unknown()?;
+            let serial: serial::Index = serde_json::de::from_str(&response_text).unknown()?;
 
             spinner.finish_and_clear();
             Ok(serial)

--- a/crates/notion-core/src/catalog/serial.rs
+++ b/crates/notion-core/src/catalog/serial.rs
@@ -134,7 +134,7 @@ pub struct Entry {
 
 impl Index {
     pub fn into_index(self) -> Fallible<super::Index> {
-        let mut entries = BTreeMap::new();
+        let mut entries = Vec::new();
         for entry in self.0 {
             let data = super::VersionData {
                 files: HashSet::from_iter(entry.files.into_iter()),
@@ -144,7 +144,7 @@ impl Index {
             if version.starts_with('v') {
                 version = &version[1..];
             }
-            entries.insert(Version::parse(version).unknown()?, data);
+            entries.push((Version::parse(version).unknown()?, data));
         }
         Ok(super::Index { entries })
     }

--- a/crates/notion-core/src/catalog/serial.rs
+++ b/crates/notion-core/src/catalog/serial.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::default::Default;
 use std::iter::FromIterator;
 use std::marker::PhantomData;

--- a/crates/notion-core/src/config/mod.rs
+++ b/crates/notion-core/src/config/mod.rs
@@ -9,11 +9,11 @@ use toml;
 use distro::Distro;
 use distro::node::NodeDistro;
 use distro::yarn::YarnDistro;
+use fs::touch;
 use notion_fail::{Fallible, NotionError, ResultExt};
 use path::user_config_file;
 use plugin;
 use readext::ReadExt;
-use fs::touch;
 
 pub(crate) mod serial;
 

--- a/crates/notion-core/src/config/serial.rs
+++ b/crates/notion-core/src/config/serial.rs
@@ -1,10 +1,10 @@
 use super::super::config;
 use std::marker::PhantomData;
 
-use plugin::serial::Plugin;
 use distro::Distro;
 use distro::node::NodeDistro;
 use distro::yarn::YarnDistro;
+use plugin::serial::Plugin;
 
 use notion_fail::Fallible;
 

--- a/crates/notion-core/src/env.rs
+++ b/crates/notion-core/src/env.rs
@@ -141,7 +141,10 @@ pub mod tests {
         pathbufs.push(PathBuf::from("/usr/bin"));
         pathbufs.push(PathBuf::from("/bin"));
 
-        let path_with_shim = env::join_paths(pathbufs.iter()).unwrap().into_string().expect("Could not create path containing shim dir");
+        let path_with_shim = env::join_paths(pathbufs.iter())
+            .unwrap()
+            .into_string()
+            .expect("Could not create path containing shim dir");
 
         env::set_var("PATH", path_with_shim);
 
@@ -168,7 +171,10 @@ pub mod tests {
         pathbufs.push(PathBuf::from("C:\\\\somebin"));
         pathbufs.push(PathBuf::from("D:\\\\ProbramFlies"));
 
-        let path_with_shim = env::join_paths(pathbufs.iter()).unwrap().into_string().expect("Could not create path containing shim dir");
+        let path_with_shim = env::join_paths(pathbufs.iter())
+            .unwrap()
+            .into_string()
+            .expect("Could not create path containing shim dir");
 
         env::set_var("PATH", path_with_shim);
 

--- a/crates/notion-core/src/fs.rs
+++ b/crates/notion-core/src/fs.rs
@@ -35,7 +35,7 @@ impl CreateDirError {
 #[derive(Debug, Fail, NotionFail)]
 #[fail(display = "`path` internal error")]
 #[notion_fail(code = "UnknownError")]
-pub (crate) struct PathInternalError;
+pub(crate) struct PathInternalError;
 
 /// This creates the parent directory of the input path, assuming the input path is a file.
 pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Fallible<()> {

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -9,9 +9,9 @@ use std::path::{Path, PathBuf};
 use lazycell::LazyCell;
 
 use manifest::Manifest;
+use manifest::serial::ToolchainManifest;
 use notion_fail::{ExitCode, Fallible, NotionError, NotionFail, ResultExt};
 use semver::Version;
-use manifest::serial::ToolchainManifest;
 
 fn is_node_root(dir: &Path) -> bool {
     dir.join("package.json").is_file()

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -165,12 +165,12 @@ impl Session {
         catalog.fetch_node(matching, config)
     }
 
-    /// Sets the default Node version to one matching the specified semantic versioning
+    /// Sets the user toolchain's Node version to one matching the specified semantic versioning
     /// requirements.
-    pub fn set_default_node(&mut self, matching: &VersionSpec) -> Fallible<()> {
+    pub fn set_user_node(&mut self, matching: &VersionSpec) -> Fallible<()> {
         let catalog = self.catalog.get_mut()?;
         let config = self.config.get()?;
-        catalog.set_default_node(matching, config)
+        catalog.set_user_node(matching, config)
     }
 
     /// Returns the version of Node matching the specified semantic versioning requirements.
@@ -226,12 +226,12 @@ impl Session {
         catalog.fetch_yarn(matching, config)
     }
 
-    /// Sets the default Yarn version to one matching the specified semantic versioning
+    /// Sets the Yarn version in the user toolchain to one matching the specified semantic versioning
     /// requirements.
-    pub fn set_default_yarn(&mut self, matching: &VersionSpec) -> Fallible<()> {
+    pub fn set_user_yarn(&mut self, matching: &VersionSpec) -> Fallible<()> {
         let catalog = self.catalog.get_mut()?;
         let config = self.config.get()?;
-        catalog.set_default_yarn(matching, config)
+        catalog.set_user_yarn(matching, config)
     }
 
     /// Returns the version of Yarn matching the specified semantic versioning requirements

--- a/crates/notion-core/src/version/mod.rs
+++ b/crates/notion-core/src/version/mod.rs
@@ -24,6 +24,12 @@ impl fmt::Display for VersionSpec {
     }
 }
 
+impl Default for VersionSpec {
+    fn default() -> Self {
+        VersionSpec::Latest
+    }
+}
+
 impl VersionSpec {
     pub fn exact(version: &Version) -> Self {
         VersionSpec::Semver(VersionReq::exact(version))

--- a/crates/notion-core/src/version/mod.rs
+++ b/crates/notion-core/src/version/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod serial;
 
-use std::str::FromStr;
 use std::fmt;
+use std::str::FromStr;
 
 use semver::{ReqParseError, SemVerError, Version, VersionReq};
 
@@ -12,14 +12,14 @@ use self::serial::parse_requirements;
 #[derive(Debug, Clone)]
 pub enum VersionSpec {
     Latest,
-    Semver(VersionReq)
+    Semver(VersionReq),
 }
 
 impl fmt::Display for VersionSpec {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
             VersionSpec::Latest => write!(f, "latest"),
-            VersionSpec::Semver(ref req) => req.fmt(f)
+            VersionSpec::Semver(ref req) => req.fmt(f),
         }
     }
 }
@@ -37,7 +37,8 @@ impl VersionSpec {
 
     pub fn parse(s: impl AsRef<str>) -> Fallible<Self> {
         let s = s.as_ref();
-        s.parse().with_context(VersionParseError::from_req_parse_error)
+        s.parse()
+            .with_context(VersionParseError::from_req_parse_error)
     }
 
     pub fn parse_requirements(s: impl AsRef<str>) -> Fallible<VersionReq> {

--- a/crates/notion-core/src/version/serial.rs
+++ b/crates/notion-core/src/version/serial.rs
@@ -16,8 +16,8 @@ pub fn parse_requirements(src: &str) -> Result<VersionReq, ReqParseError> {
 #[cfg(test)]
 pub mod tests {
 
-    use version::serial::parse_requirements;
     use semver::VersionReq;
+    use version::serial::parse_requirements;
 
     #[test]
     fn test_parse_requirements() {

--- a/crates/notion-fail-derive/src/lib.rs
+++ b/crates/notion-fail-derive/src/lib.rs
@@ -6,9 +6,9 @@ extern crate syn;
 
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
-use syn::{DeriveInput, Lit, NestedMeta};
 use syn::Meta::{List, NameValue, Word};
 use syn::NestedMeta::{Literal, Meta};
+use syn::{DeriveInput, Lit, NestedMeta};
 
 #[proc_macro_derive(NotionFail, attributes(notion_fail))]
 pub fn notion_fail(token_stream: TokenStream) -> TokenStream {
@@ -24,11 +24,11 @@ pub fn notion_fail(token_stream: TokenStream) -> TokenStream {
             match item {
                 Literal(_) => {
                     panic!("#[notion_fail()]: must be name/value pairs, not a literal");
-                },
+                }
 
                 Meta(List(_)) => {
                     panic!("#[notion_fail()]: must be name/value pairs, not a list");
-                },
+                }
 
                 Meta(NameValue(ref m)) if m.ident == "code" => {
                     if let Lit::Str(s) = &m.lit {
@@ -38,7 +38,7 @@ pub fn notion_fail(token_stream: TokenStream) -> TokenStream {
                         // Defined, but not a string.
                         panic!("#[notion_fail()]: 'code' must be a string.");
                     }
-                },
+                }
 
                 Meta(NameValue(ref m)) if m.ident == "friendly" => {
                     if let Lit::Str(s) = &m.lit {
@@ -47,15 +47,15 @@ pub fn notion_fail(token_stream: TokenStream) -> TokenStream {
                         // Defined, but not a string.
                         panic!("#[notion_fail()]: 'code' must be a string.");
                     }
-                },
+                }
 
                 Meta(NameValue(m)) => {
                     panic!("#[notion_fail()]: not a recognized name: '{}'", m.ident);
-                },
+                }
 
                 Meta(Word(_)) => {
                     panic!("#[notion_fail()]: must be name/value pairs, not an identifier");
-                },
+                }
             }
         }
     }
@@ -86,7 +86,7 @@ fn get_notion_fail_meta_items(attr: &syn::Attribute) -> Option<Vec<NestedMeta>> 
 
             _ => {
                 panic!("#[notion_fail()] must be a list of attributes");
-            },
+            }
         }
     } else {
         None

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -66,7 +66,7 @@ Options:
             Current::Help => {
                 Help::Command(CommandName::Current).run(session)?;
                 true
-            },
+            }
             Current::Project => project_node_version(&session)?
                 .map(|version| {
                     println!("v{}", version);

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -1,5 +1,5 @@
-use notion_core::version::VersionSpec;
 use notion_core::session::{ActivityKind, Session};
+use notion_core::version::VersionSpec;
 use notion_fail::{ExitCode, Fallible};
 
 use command::{Command, CommandName, Help};
@@ -43,12 +43,8 @@ Options:
         }: Args,
     ) -> Fallible<Self> {
         match &arg_tool[..] {
-            "node" => {
-                Ok(Fetch::Node(VersionSpec::parse(&arg_version)?))
-            },
-            "yarn" => {
-                Ok(Fetch::Yarn(VersionSpec::parse(&arg_version)?))
-            },
+            "node" => Ok(Fetch::Node(VersionSpec::parse(&arg_version)?)),
+            "yarn" => Ok(Fetch::Yarn(VersionSpec::parse(&arg_version)?)),
             ref tool => {
                 throw!(CliParseError {
                     usage: None,

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -1,12 +1,12 @@
-use notion_core::version::VersionSpec;
 use notion_core::session::{ActivityKind, Session};
+use notion_core::version::VersionSpec;
 use notion_fail::{ExitCode, Fallible};
 
 use result::ResultOptionExt;
 
+use CommandUnimplementedError;
 use Notion;
 use command::{Command, CommandName, Help};
-use CommandUnimplementedError;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
@@ -18,7 +18,10 @@ pub(crate) enum Install {
     Help,
     Node(VersionSpec),
     Yarn(VersionSpec),
-    Other { package: String, version: VersionSpec },
+    Other {
+        package: String,
+        version: VersionSpec,
+    },
 }
 
 impl Command for Install {
@@ -55,12 +58,8 @@ Supported Tools:
             .unwrap_or_default();
 
         match &arg_tool[..] {
-            "node" => {
-                Ok(Install::Node(version))
-            },
-            "yarn" => {
-                Ok(Install::Yarn(version))
-            },
+            "node" => Ok(Install::Node(version)),
+            "yarn" => Ok(Install::Yarn(version)),
             ref package => Ok(Install::Other {
                 package: package.to_string(),
                 version: version,
@@ -83,7 +82,10 @@ Supported Tools:
             Install::Other {
                 package,
                 version: _,
-            } => throw!(CommandUnimplementedError::new(&format!("notion install {}", package)))
+            } => throw!(CommandUnimplementedError::new(&format!(
+                "notion install {}",
+                package
+            ))),
         };
         session.add_event_end(ActivityKind::Install, ExitCode::Success);
         Ok(())

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -75,10 +75,10 @@ Supported Tools:
                 Help::Command(CommandName::Install).run(session)?;
             }
             Install::Node(requirements) => {
-                session.set_default_node(&requirements)?;
+                session.set_user_node(&requirements)?;
             }
             Install::Yarn(requirements) => {
-                session.set_default_yarn(&requirements)?;
+                session.set_user_yarn(&requirements)?;
             }
             Install::Other {
                 package,

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -2,8 +2,8 @@
 // With https://github.com/rust-lang/rfcs/blob/master/text/2151-raw-identifiers.md we
 // could consider something like `r#use` instead.
 
-use notion_core::version::VersionSpec;
 use notion_core::session::{ActivityKind, Session};
+use notion_core::version::VersionSpec;
 use notion_fail::{ExitCode, Fallible, NotionFail};
 
 use Notion;
@@ -63,12 +63,8 @@ Options:
         }: Args,
     ) -> Fallible<Self> {
         match &arg_tool[..] {
-            "node" => {
-                Ok(Use::Node(VersionSpec::parse(&arg_version)?))
-            },
-            "yarn" => {
-                Ok(Use::Yarn(VersionSpec::parse(&arg_version)?))
-            },
+            "node" => Ok(Use::Node(VersionSpec::parse(&arg_version)?)),
+            "yarn" => Ok(Use::Yarn(VersionSpec::parse(&arg_version)?)),
             ref tool => Ok(Use::Other {
                 name: tool.to_string(),
                 version: VersionSpec::parse(&arg_version)?,

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -12,6 +12,7 @@ extern crate semver;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate result;
 
 mod command;
 mod error;


### PR DESCRIPTION
A few little fixes:

- Fixes the `latest` calculation which I broke in #139. (@mikrostew's test harnesses would've caught this!).
- Make the version argument to `notion install` optional, and default to `latest`.
- Stores the index as a `Vec` instead of a `BTreeMap` since we don't use any map methods; we're only operating on an iterator.
- A couple method renames to align with current terminology.
