### PR TITLE
Project autoshim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/notion-cli/notion"
 [features]
 universal-docs = ["notion-core/universal-docs"]
 mock-network = ["mockito", "notion-core/mock-network"]
+notion-dev = []
 
 [[bin]]
 name = "notion"

--- a/crates/notion-core/src/manifest/mod.rs
+++ b/crates/notion-core/src/manifest/mod.rs
@@ -1,6 +1,6 @@
 //! Provides the `Manifest` type, which represents a Node manifest file (`package.json`).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -54,6 +54,14 @@ impl Manifest {
     /// Returns a reference to the platform image specified by manifest, if any.
     pub fn platform(&self) -> Option<Rc<Image>> {
         self.platform_image.as_ref().map(|p| p.clone())
+    }
+
+    /// Gets the names of all the direct dependencies in the manifest.
+    pub fn merged_dependencies(&self) -> HashSet<String> {
+        self.dependencies.iter()
+            .chain(self.dev_dependencies.iter())
+            .map(|(name, _version)| name.clone())
+            .collect()
     }
 
     /// Returns the pinned version of Node as a Version, if any.

--- a/crates/notion-core/src/manifest/tests.rs
+++ b/crates/notion-core/src/manifest/tests.rs
@@ -1,6 +1,6 @@
 use manifest::Manifest;
 use semver::Version;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 fn fixture_path(fixture_dir: &str) -> PathBuf {
@@ -54,6 +54,20 @@ fn gets_dev_dependencies() {
     );
     expected_deps.insert("eslint".to_string(), "~4.8.0".to_string());
     assert_eq!(dev_dependencies, expected_deps);
+}
+
+#[test]
+fn gets_merged_dependencies() {
+    let project_path = fixture_path("basic");
+    let test_manifest = Manifest::for_dir(&project_path).expect("Could not get manifest");
+
+    let all_deps = test_manifest.merged_dependencies();
+    let mut expected_deps = HashSet::new();
+    expected_deps.insert("@namespace/some-dep".to_string());
+    expected_deps.insert("rsvp".to_string());
+    expected_deps.insert("@namespaced/something-else".to_string());
+    expected_deps.insert("eslint".to_string());
+    assert_eq!(all_deps, expected_deps);
 }
 
 #[test]

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -203,7 +203,9 @@ impl Project {
                     }
                 },
                 Err(error) => {
-                    results.push(Result::Err(error))
+                    if !error.to_string().contains("directory does not exist") {
+                        results.push(Result::Err(error))
+                    }
                 },
             }
         }

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -251,7 +251,7 @@ impl Project {
 
 #[cfg(test)]
 pub mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::ffi::OsStr;
     use std::path::PathBuf;
 
@@ -278,6 +278,33 @@ pub mod tests {
         expected_bins.insert("bin-1".to_string(), "./lib/cli.js".to_string());
         expected_bins.insert("bin-2".to_string(), "./lib/cli.js".to_string());
         assert_eq!(dep_bins, expected_bins);
+    }
+
+    #[test]
+    fn gets_binary_names() {
+        let project = Project::for_dir(&fixture_path("basic")).unwrap().unwrap();
+        let binary_names = project.dependent_binary_names_fault_tolerant();
+        let mut expected = HashSet::new();
+
+        expected.insert("eslint".to_string());
+        expected.insert("rsvp".to_string());
+        expected.insert("bin-1".to_string());
+        expected.insert("bin-2".to_string());
+
+        let mut iterator = binary_names.iter();
+        let mut actual = HashSet::new();
+
+        while let Some(fallible) = iterator.next() {
+            match fallible {
+                Ok(binary_name) => {
+                    actual.insert(binary_name.clone());
+                },
+
+                Err(error) => panic!("encountered error {:?}", error),
+            }
+        }
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -337,14 +337,12 @@ impl Tool for Yarn {
 
     /// Perform any tasks which must be run after the tool runs but before exiting.
     fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
-        if let Ok(status) = maybe_status {
-            if status.success() {
-                if let Some(project) = session.project() {
-                    let errors = project.autoshim();
+        if let Ok(_) = maybe_status {
+            if let Some(project) = session.project() {
+                let errors = project.autoshim();
 
-                    for error in errors {
-                        display_error(&error);
-                    }
+                for error in errors {
+                    display_error(&error);
                 }
             }
         }

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -5,7 +5,7 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::marker::Sized;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 
 use notion_fail::{ExitCode, FailExt, Fallible, NotionError, NotionFail};
 use path;
@@ -86,10 +86,14 @@ pub trait Tool: Sized {
     /// Extracts the `Command` from this tool.
     fn command(self) -> Command;
 
+    /// Perform any tasks which must be run after the tool runs but before exiting.
+    fn finalize(_session: &Session, _maybe_status: &io::Result<ExitStatus>) {}
+
     /// Delegates the current process to this tool.
     fn exec(self, mut session: Session) -> ! {
         let mut command = self.command();
         let status = command.status();
+        Self::finalize(&session, &status);
         match status {
             Ok(status) if status.success() => {
                 session.add_event_end(ActivityKind::Tool, ExitCode::Success);
@@ -329,5 +333,20 @@ impl Tool for Yarn {
 
     fn command(self) -> Command {
         self.0
+    }
+
+    /// Perform any tasks which must be run after the tool runs but before exiting.
+    fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
+        if let Ok(status) = maybe_status {
+            if status.success() {
+                if let Some(project) = session.project() {
+                    let errors = project.autoshim();
+
+                    for error in errors {
+                        display_error(&error);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/command/help.rs
+++ b/src/command/help.rs
@@ -1,8 +1,10 @@
 use notion_core::session::{ActivityKind, Session};
 use notion_fail::{ExitCode, Fallible};
 
-use command::{Command, CommandName, Config, Current, Deactivate, Fetch, Install, Shim, Use,
+use command::{Command, CommandName, Config, Current, Deactivate, Fetch, Install, Use,
               Version};
+#[cfg(feature = "notion-dev")]
+use command::Shim;
 use {CliParseError, Notion};
 
 #[derive(Debug, Deserialize)]
@@ -63,6 +65,7 @@ Options:
                 Help::Command(CommandName::Version) => Version::USAGE,
                 Help::Command(CommandName::Fetch) => Fetch::USAGE,
                 Help::Command(CommandName::Install) => Install::USAGE,
+                #[cfg(feature = "notion-dev")]
                 Help::Command(CommandName::Shim) => Shim::USAGE,
             }
         );

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -14,6 +14,7 @@ pub(crate) use self::deactivate::Deactivate;
 pub(crate) use self::fetch::Fetch;
 pub(crate) use self::help::Help;
 pub(crate) use self::install::Install;
+#[cfg(feature = "notion-dev")]
 pub(crate) use self::shim::Shim;
 pub(crate) use self::use_::Use;
 pub(crate) use self::version::Version;
@@ -38,6 +39,7 @@ pub(crate) enum CommandName {
     Config,
     Current,
     Deactivate,
+    #[cfg(feature = "notion-dev")]
     Shim,
     Help,
     Version,
@@ -55,6 +57,7 @@ impl Display for CommandName {
                 CommandName::Config => "config",
                 CommandName::Deactivate => "deactivate",
                 CommandName::Current => "current",
+                #[cfg(feature = "notion-dev")]
                 CommandName::Shim => "shim",
                 CommandName::Help => "help",
                 CommandName::Version => "version",
@@ -74,6 +77,7 @@ impl FromStr for CommandName {
             "config" => CommandName::Config,
             "current" => CommandName::Current,
             "deactivate" => CommandName::Deactivate,
+            #[cfg(feature = "notion-dev")]
             "shim" => CommandName::Shim,
             "help" => CommandName::Help,
             "version" => CommandName::Version,

--- a/src/command/shim.rs
+++ b/src/command/shim.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "notion-dev")]
+
 use std::ffi::OsStr;
 use std::fmt::{self, Display, Formatter};
 use std::fs;

--- a/src/command/shim.rs
+++ b/src/command/shim.rs
@@ -188,27 +188,21 @@ fn print_file_info(file: fs::DirEntry, session: &Session, verbose: bool) -> Fall
 }
 
 fn create(_session: &Session, shim_name: String, _verbose: bool) -> Fallible<()> {
-    let result = shim::create(&shim_name)?;
-
-    if result == shim::ShimResult::AlreadyExists {
-        throw!(ShimAlreadyExistsError {
+    match shim::create(&shim_name)? {
+        shim::ShimResult::AlreadyExists => throw!(ShimAlreadyExistsError {
             name: shim_name,
-        });
+        }),
+        _ => Ok(()),
     }
-
-    Ok(())
 }
 
 fn delete(_session: &Session, shim_name: String, _verbose: bool) -> Fallible<()> {
-    let result = shim::delete(&shim_name)?;
-
-    if result == shim::ShimResult::DoesntExist {
-        throw!(ShimDoesntExistError {
+    match shim::delete(&shim_name)? {
+        shim::ShimResult::DoesntExist => throw!(ShimDoesntExistError {
             name: shim_name,
-        });
+        }),
+        _ => Ok(()),
     }
-
-    Ok(())
 }
 
 fn autoshim(session: &Session, maybe_path: Option<PathBuf>, _verbose: bool) -> Fallible<()> {

--- a/src/command/shim.rs
+++ b/src/command/shim.rs
@@ -121,29 +121,29 @@ Options:
             flag_verbose,
         }: Args,
     ) -> Fallible<Self> {
-        Ok(match arg_command {
-            Some(ref command) if command == &"auto".to_string() => {
+        Ok(match arg_command.as_ref().map(|command| command.as_str()) {
+            Some("auto") => {
                 if let Some(path_string) = arg_shim_name_or_path {
                     Shim::Auto(Some(PathBuf::from(path_string)), flag_verbose)
                 } else {
                     Shim::Auto(None, flag_verbose)
                 }
             },
-            Some(ref command) if command == &"create".to_string() => {
+            Some("create") => {
                 if let Some(shim_name) = arg_shim_name_or_path {
                     Shim::Create(shim_name, flag_verbose)
                 } else {
                     throw!(MissingShimNameError);
                 }
             },
-            Some(ref command) if command == &"delete".to_string() => {
+            Some("delete") => {
                 if let Some(shim_name) = arg_shim_name_or_path {
                     Shim::Delete(shim_name, flag_verbose)
                 } else {
                     throw!(MissingShimNameError);
                 }
             },
-            Some(ref command) if command == &"list".to_string() => {
+            Some("list") => {
                 if let Some(_) = arg_shim_name_or_path {
                     throw!(PresentShimNameError);
                 } else {
@@ -151,7 +151,7 @@ Options:
                 }
             },
             Some(command) => throw!(UnrecognizedCommandError {
-                command: command,
+                command: command.to_string(),
             }),
             None => Shim::Help,
         })

--- a/src/command/use_.rs
+++ b/src/command/use_.rs
@@ -3,6 +3,7 @@
 // could consider something like `r#use` instead.
 
 use notion_core::session::{ActivityKind, Session};
+use notion_core::style::{display_error, display_unknown_error, ErrorContext};
 use notion_core::version::VersionSpec;
 use notion_fail::{ExitCode, Fallible, NotionFail};
 
@@ -85,6 +86,17 @@ Options:
             Use::Yarn(spec) => session.pin_yarn_version(&spec)?,
             Use::Other { name, .. } => throw!(NoCustomUseError::new(name)),
         };
+        if let Some(project) = session.project() {
+            let errors = project.autoshim();
+
+            for error in errors {
+                if error.is_user_friendly() {
+                    display_error(ErrorContext::Notion, &error);
+                } else {
+                    display_unknown_error(ErrorContext::Notion, &error);
+                }
+            }
+        }
         session.add_event_end(ActivityKind::Use, ExitCode::Success);
         Ok(())
     }

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -25,8 +25,10 @@ use notion_core::session::{ActivityKind, Session};
 use notion_core::style::{display_error, display_unknown_error, ErrorContext};
 use notion_fail::{ExitCode, FailExt, Fallible, NotionError};
 
-use command::{Command, CommandName, Config, Current, Deactivate, Fetch, Help, Install, Shim, Use,
+use command::{Command, CommandName, Config, Current, Deactivate, Fetch, Help, Install, Use,
               Version};
+#[cfg(feature = "notion-dev")]
+use command::Shim;
 use error::{CliParseError, CommandUnimplementedError, DocoptExt, NotionErrorExt};
 
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -66,7 +68,6 @@ Some common notion commands are:
     config         Get or set configuration values
     current        Display the currently activated Node version
     deactivate     Remove Notion from the current shell
-    shim           View and manage shims
     help           Display this message
     version        Print version info and exit
 
@@ -179,6 +180,7 @@ See 'notion help <command>' for more information on a specific command.
             CommandName::Config => Config::go(self, session),
             CommandName::Current => Current::go(self, session),
             CommandName::Deactivate => Deactivate::go(self, session),
+            #[cfg(feature = "notion-dev")]
             CommandName::Shim => Shim::go(self, session),
             CommandName::Help => Help::go(self, session),
             CommandName::Version => Version::go(self, session),


### PR DESCRIPTION
This is a speculative implementation of [RFC 23](https://github.com/notion-cli/rfcs/pull/23).

A notable change with this PR is the grammar for the `notion shim` command, which has been moved behind the `notion-dev` feature flag.

* `notion shim` => `notion shim list`
* `notion shim foo` => `notion shim create foo`
* `notion shim foo --delete` => `notion shim delete foo`