### PR TITLE
[WIP] First pass at fish shell support

### DIFF
--- a/crates/notion-core/src/shell/fish.rs
+++ b/crates/notion-core/src/shell/fish.rs
@@ -1,0 +1,29 @@
+use std::path::{Path, PathBuf};
+
+use super::{Postscript, Shell};
+
+pub(crate) struct Fish {
+    pub(crate) postscript_path: PathBuf,
+}
+
+impl Shell for Fish {
+    fn postscript_path(&self) -> &Path {
+        &self.postscript_path
+    }
+
+    fn compile_postscript(&self, postscript: &Postscript) -> String {
+        match postscript {
+            &Postscript::Path(ref s) => {
+                format!("set -U fish_user_paths '{}'\n $fish_user_paths", s)
+            }
+            &Postscript::ToolVersion {
+                ref tool,
+                ref version,
+            } => format!(
+                "set -U NOTION_{}_VERSION {}\n",
+                tool.to_ascii_uppercase(),
+                version
+            ),
+        }
+    }
+}

--- a/crates/notion-core/src/shell/fish.rs
+++ b/crates/notion-core/src/shell/fish.rs
@@ -14,7 +14,7 @@ impl Shell for Fish {
     fn compile_postscript(&self, postscript: &Postscript) -> String {
         match postscript {
             &Postscript::Path(ref s) => {
-                format!("set -U fish_user_paths '{}'\n $fish_user_paths", s)
+                format!("set -U fish_user_paths '{}' $fish_user_paths\n", s)
             }
             &Postscript::ToolVersion {
                 ref tool,


### PR DESCRIPTION
Adding fish shell support to notion (#152)

TODO:

- [x] Adding a backend (fish.rs) to crates/notion-core/src/shell/, with a type Fish that implements Shell
- [ ] Adding a bootup script (notion.fish) to shell/unix/, with a wrapper function notion to get installed at console boot time
- [ ] Edit install.sh.in to include installing notion.fish to ~/.config/fish/functions