### PR TITLE
Update to released version of mockito.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "mockito"
 version = "0.13.0"
-source = "git+https://github.com/lipanski/mockito?rev=48c5a93bcf8cc434875ed8aed22bff9623cb1ff4#48c5a93bcf8cc434875ed8aed22bff9623cb1ff4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -736,7 +736,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hamcrest2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "mockito 0.13.0 (git+https://github.com/lipanski/mockito?rev=48c5a93bcf8cc434875ed8aed22bff9623cb1ff4)",
+ "mockito 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notion-core 0.1.0",
  "notion-fail 0.1.0",
  "notion-fail-derive 0.1.0",
@@ -763,7 +763,7 @@ dependencies = [
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (git+https://github.com/dherman/lazycell?branch=borrow_mut_with)",
- "mockito 0.13.0 (git+https://github.com/lipanski/mockito?rev=48c5a93bcf8cc434875ed8aed22bff9623cb1ff4)",
+ "mockito 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-archive 0.1.0",
  "notion-fail 0.1.0",
  "notion-fail-derive 0.1.0",
@@ -1839,7 +1839,7 @@ dependencies = [
 "checksum miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "92d98fdbd6145645828069b37ea92ca3de225e000d80702da25c20d3584b38a5"
 "checksum mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "75f72a93f046f1517e3cfddc0a096eb756a2ba727d36edc8227dee769a50a9b0"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum mockito 0.13.0 (git+https://github.com/lipanski/mockito?rev=48c5a93bcf8cc434875ed8aed22bff9623cb1ff4)" = "<none>"
+"checksum mockito 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a537602ee7f006ce70bae242e847871ca8c054f6902452b6e46e2c5e8f8dd53a"
 "checksum msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65ba9d75bcea84e07812618fedf284a64776c2f2ea0cad6bca7f69739695a958"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ semver = "0.9.0"
 result = "1.0.0"
 rand = "0.5"
 cfg-if = "0.1"
-mockito = { "git" = "https://github.com/lipanski/mockito", "rev" = "48c5a93bcf8cc434875ed8aed22bff9623cb1ff4", optional = true }
+mockito = { "version" = "0.13.0", optional = true }
 test-support = { path = "crates/test-support" }
 
 [dev-dependencies]

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -31,4 +31,4 @@ tempfile = "3.0.2"
 os_info = { git = "https://github.com/DarkEld3r/os_info", rev = "912a7941cd797e9fca83f4fe858ed684baa5fc40" }
 detect-indent = { git = "https://github.com/stefanpenner/detect-indent-rs", branch = "master" }
 envoy = "0.1.3"
-mockito = { git = "https://github.com/lipanski/mockito", rev = "48c5a93bcf8cc434875ed8aed22bff9623cb1ff4", optional = true }
+mockito = { "version" = "0.13.0", optional = true }


### PR DESCRIPTION
Looks like we were using a specific revision in order to grab the changes from https://github.com/lipanski/mockito/pull/48 until there was a release. Well the time has come! mockito@0.13.0 includes the required changes and was released a few weeks ago...