### PR TITLE
Use released version of lazycell.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,11 +535,11 @@ dependencies = [
 [[package]]
 name = "lazycell"
 version = "0.6.0"
-source = "git+https://github.com/dherman/lazycell?branch=borrow_mut_with#a4111857df019e3406678044f3ab6ebf76f81589"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazycell"
-version = "0.6.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -767,7 +767,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 0.6.0 (git+https://github.com/dherman/lazycell?branch=borrow_mut_with)",
+ "lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.13.0 (git+https://github.com/lipanski/mockito?rev=48c5a93bcf8cc434875ed8aed22bff9623cb1ff4)",
  "node-archive 0.1.0",
  "notion-fail 0.1.0",
@@ -1830,8 +1830,8 @@ dependencies = [
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-"checksum lazycell 0.6.0 (git+https://github.com/dherman/lazycell?branch=borrow_mut_with)" = "<none>"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
+"checksum lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum libflate 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1a429b86418868c7ea91ee50e9170683f47fd9d94f5375438ec86ec3adb74e8e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -21,7 +21,7 @@ failure = "0.1.1"
 failure_derive = "0.1.1"
 notion-fail = { path = "../notion-fail" }
 notion-fail-derive = { path = "../notion-fail-derive" }
-lazycell = { git = "https://github.com/dherman/lazycell", branch = "borrow_mut_with" }
+lazycell = "1.2.0"
 semver = "0.9.0"
 cmdline_words_parser = "0.0.2"
 reqwest = "0.8.5"


### PR DESCRIPTION
The changes in the fork of lazycell have been incorporated with upstream and are included in version 1.2.0.

Closes https://github.com/notion-cli/notion/issues/137 by deciding _not_ to switch from lazycell to once_cell.