### PR TITLE
Cleanup formatting and enforce.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+rust: stable
 language: rust
 cache: cargo
 
@@ -12,13 +13,17 @@ env:
 jobs:
   include:
     - stage: test
-      rust: stable
+      name: "Tests"
       script: |
         # the unit tests for all crates (without mocking the network)
         # run single-threaded because some tests change environment variables, which is not thread-safe
         cargo test --package notion-core --package notion-fail --package node-archive --package notion-fail-derive --package progress-read -- --test-threads=1 &&
         # the acceptance tests, using network mocks
         cargo test --features mock-network
+    - name: "Formatting"
+      # run rustfmt (using a specific locked down version)
+      # to fix any failures in this job run `./dev/unix/rustfmt.sh` and commit the resulting changes
+      script: ./dev/unix/rustfmt.sh --check
     - stage: publish
       # Conditional builds: https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
       if: (branch = master) AND (type = push)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ To run the tests in this repo, run the following:
 cargo test --all --features mock-network
 ```
 
+When running tests in CI we also check that code formatting matches the
+`rustfmt` generated style, follow the steps in the Formatting section below to
+avoid issue.
+
+## Formatting
+
+To ensure your code is formatted correctly, run the following:
+
+```
+./dev/unix/rustfmt.sh
+```
+
 ## License
 
 Notion is licensed under a [BSD 2-clause license](https://github.com/notion-cli/notion/blob/master/LICENSE).

--- a/crates/notion-core/src/image/mod.rs
+++ b/crates/notion-core/src/image/mod.rs
@@ -50,38 +50,33 @@ impl Image {
 pub struct System;
 
 impl System {
-
     /// Produces a modified version of the current `PATH` environment variable that
     /// removes the Notion shims and binaries, to use for running system node and
     /// executables.
     pub fn path() -> Fallible<OsString> {
         let old_path = envoy::path().unwrap_or(envoy::Var::from(""));
 
-        let new_path = old_path
-            .split()
-            .remove(path::shim_dir()?)
-            .join()
-            .unknown()?;
+        let new_path = old_path.split().remove(path::shim_dir()?).join().unknown()?;
 
         Ok(new_path)
     }
-
 }
 
 #[cfg(test)]
 mod test {
 
     use super::*;
+    use semver::Version;
     use std;
     use std::path::PathBuf;
-    use semver::Version;
 
     #[cfg(windows)]
     use winfolder;
 
     fn notion_base() -> PathBuf {
         #[cfg(unix)]
-        return PathBuf::from(std::env::home_dir().expect("Could not get home directory")).join(".notion");
+        return PathBuf::from(std::env::home_dir().expect("Could not get home directory"))
+            .join(".notion");
 
         #[cfg(all(windows, target_arch = "x86"))]
         return winfolder::Folder::ProgramFiles.path().join("Notion");
@@ -131,7 +126,7 @@ mod test {
             node: v123.clone(),
             node_str: v123.to_string(),
             yarn: None,
-            yarn_str: None
+            yarn_str: None,
         };
 
         assert_eq!(
@@ -143,12 +138,15 @@ mod test {
             node: v123.clone(),
             node_str: v123.to_string(),
             yarn: Some(v457.clone()),
-            yarn_str: Some(v457.to_string())
+            yarn_str: Some(v457.to_string()),
         };
 
         assert_eq!(
             with_yarn_image.path().unwrap().into_string().unwrap(),
-            format!("{}:{}:/usr/bin:/blah:/doesnt/matter/bin", expected_node_bin, expected_yarn_bin),
+            format!(
+                "{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
+                expected_node_bin, expected_yarn_bin
+            ),
         );
     }
 
@@ -187,7 +185,7 @@ mod test {
             node: v123.clone(),
             node_str: v123.to_string(),
             yarn: None,
-            yarn_str: None
+            yarn_str: None,
         };
 
         assert_eq!(
@@ -199,12 +197,15 @@ mod test {
             node: v123.clone(),
             node_str: v123.to_string(),
             yarn: Some(v457.clone()),
-            yarn_str: Some(v457.to_string())
+            yarn_str: Some(v457.to_string()),
         };
 
         assert_eq!(
             with_yarn_image.path().unwrap().into_string().unwrap(),
-            format!("{};{};C:\\\\somebin;D:\\\\ProbramFlies", expected_node_bin, expected_yarn_bin),
+            format!(
+                "{};{};C:\\\\somebin;D:\\\\ProbramFlies",
+                expected_node_bin, expected_yarn_bin
+            ),
         );
     }
 
@@ -213,15 +214,15 @@ mod test {
     fn test_system_path() {
         std::env::set_var(
             "PATH",
-            format!(
-                "{}:/usr/bin:/bin",
-                shim_dir().to_string_lossy()
-            ),
+            format!("{}:/usr/bin:/bin", shim_dir().to_string_lossy()),
         );
 
         let expected_path = String::from("/usr/bin:/bin");
 
-        assert_eq!(System::path().unwrap().into_string().unwrap(), expected_path);
+        assert_eq!(
+            System::path().unwrap().into_string().unwrap(),
+            expected_path
+        );
     }
 
     #[test]
@@ -241,7 +242,10 @@ mod test {
 
         let expected_path = String::from("C:\\\\somebin;D:\\\\ProbramFlies");
 
-        assert_eq!(System::path().unwrap().into_string().unwrap(), expected_path);
+        assert_eq!(
+            System::path().unwrap().into_string().unwrap(),
+            expected_path
+        );
     }
 
 }

--- a/crates/notion-core/src/manifest/mod.rs
+++ b/crates/notion-core/src/manifest/mod.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use detect_indent;
-use notion_fail::{ExitCode, Fallible, NotionFail, ResultExt};
 use image::Image;
+use notion_fail::{ExitCode, Fallible, NotionFail, ResultExt};
 use semver::Version;
 use serde::Serialize;
 use serde_json;
@@ -68,24 +68,17 @@ impl Manifest {
 
     /// Returns the pinned verison of Yarn as a Version, if any.
     pub fn yarn(&self) -> Option<Version> {
-        self.platform()
-            .map(|t| t.yarn.clone())
-            .unwrap_or(None)
+        self.platform().map(|t| t.yarn.clone()).unwrap_or(None)
     }
 
     /// Returns the pinned verison of Yarn as a String, if any.
     pub fn yarn_str(&self) -> Option<String> {
-        self.platform()
-            .map(|t| t.yarn_str.clone())
-            .unwrap_or(None)
+        self.platform().map(|t| t.yarn_str.clone()).unwrap_or(None)
     }
 
     /// Writes the input ToolchainManifest to package.json, adding the "toolchain" key if
     /// necessary.
-    pub fn update_toolchain(
-        toolchain: serial::Image,
-        package_file: PathBuf,
-    ) -> Fallible<()> {
+    pub fn update_toolchain(toolchain: serial::Image, package_file: PathBuf) -> Fallible<()> {
         // parse the entire package.json file into a Value
         let file = File::open(&package_file).unknown()?;
         let mut v: serde_json::Value = serde_json::from_reader(file).unknown()?;

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -203,8 +203,7 @@ impl Project {
     pub fn pin_yarn_in_toolchain(&self, yarn_version: Version) -> Fallible<()> {
         // update the toolchain yarn version
         if let Some(node_str) = self.manifest().node_str() {
-            let toolchain =
-                serial::Image::new(node_str.clone(), Some(yarn_version.to_string()));
+            let toolchain = serial::Image::new(node_str.clone(), Some(yarn_version.to_string()));
             Manifest::update_toolchain(toolchain, self.package_file())?;
             println!("Pinned yarn to version {} in package.json", yarn_version);
         } else {

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -127,7 +127,7 @@ impl Session {
                     node,
                     node_str,
                     yarn: Some(yarn),
-                    yarn_str: Some(yarn_str)
+                    yarn_str: Some(yarn_str),
                 })));
             }
 
@@ -135,7 +135,7 @@ impl Session {
                 node,
                 node_str,
                 yarn: None,
-                yarn_str: None
+                yarn_str: None,
             })));
         }
         Ok(None)

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -214,7 +214,7 @@ impl Tool for Binary {
                         &path_to_bin.as_os_str(),
                         args,
                         &platform.path()?,
-                    ))
+                    ));
                 }
 
                 // if there's no user platform selected, fail.
@@ -276,7 +276,8 @@ No {} version selected.
 
 See `notion help use` for help adding {} to a project toolchain.
 
-See `notion help install` for help adding {} to your personal toolchain."#, tool, tool, tool)]
+See `notion help install` for help adding {} to your personal toolchain."#,
+       tool, tool, tool)]
 #[notion_fail(code = "NoVersionMatch")]
 struct NoSuchToolError {
     tool: String,

--- a/crates/test-support/src/matchers.rs
+++ b/crates/test-support/src/matchers.rs
@@ -5,7 +5,7 @@ use std::usize;
 
 use process::{ProcessBuilder, ProcessError};
 
-use hamcrest2::core::{Matcher, MatchResult};
+use hamcrest2::core::{MatchResult, Matcher};
 use serde_json::{self, Value};
 
 #[derive(Clone)]
@@ -725,4 +725,3 @@ fn substitute_macros(input: &str) -> String {
     }
     result
 }
-

--- a/crates/test-support/src/process.rs
+++ b/crates/test-support/src/process.rs
@@ -244,4 +244,3 @@ pub fn process_error(
         status.to_string()
     }
 }
-

--- a/tests/acceptance/notion_current.rs
+++ b/tests/acceptance/notion_current.rs
@@ -1,6 +1,6 @@
 use hamcrest2::core::Matcher;
-use test_support::matchers::execs;
 use support::sandbox::sandbox;
+use test_support::matchers::execs;
 
 use notion_fail::ExitCode;
 

--- a/tests/acceptance/notion_deactivate.rs
+++ b/tests/acceptance/notion_deactivate.rs
@@ -1,6 +1,6 @@
 use hamcrest2::core::Matcher;
-use test_support::matchers::execs;
 use support::sandbox::sandbox;
+use test_support::matchers::execs;
 
 #[test]
 #[cfg(unix)]

--- a/tests/acceptance/notion_use.rs
+++ b/tests/acceptance/notion_use.rs
@@ -1,6 +1,6 @@
 use hamcrest2::core::Matcher;
-use test_support::matchers::execs;
 use support::sandbox::sandbox;
+use test_support::matchers::execs;
 
 use notion_fail::ExitCode;
 

--- a/tests/acceptance/support/paths.rs
+++ b/tests/acceptance/support/paths.rs
@@ -10,7 +10,6 @@ static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 
 thread_local!(static TASK_ID: usize = NEXT_ID.fetch_add(1, Ordering::SeqCst));
 
-
 // creates the root directory for the acceptancce tests (once), and
 // initializes the root and home directories for the current task
 fn init() {
@@ -56,12 +55,15 @@ pub fn home() -> PathBuf {
     root().join("home")
 }
 
-enum Remove { File, Dir }
+enum Remove {
+    File,
+    Dir,
+}
 impl Remove {
     fn to_str(&self) -> &'static str {
         match *self {
             Remove::File => "remove file",
-            Remove::Dir => "remove dir"
+            Remove::Dir => "remove dir",
         }
     }
 
@@ -73,7 +75,7 @@ impl Remove {
         }
         match *self {
             Remove::File => fs::remove_file(path),
-            Remove::Dir => fs::remove_dir(path)
+            Remove::Dir => fs::remove_dir(path),
         }.unwrap_or_else(|e| {
             panic!("failed to {} {}: {}", self.to_str(), path.display(), e);
         })

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -285,8 +285,10 @@ impl SandboxBuilder {
             .collect();
 
         // mock the HEAD request, which gets the file size
-        let head_mock = mock(method_name("HEAD"), Matcher::Regex(r"^/yarn-v\d+.\d+.\d+".to_string()))
-            .with_header("Accept-Ranges", "bytes")
+        let head_mock = mock(
+            method_name("HEAD"),
+            Matcher::Regex(r"^/yarn-v\d+.\d+.\d+".to_string()),
+        ).with_header("Accept-Ranges", "bytes")
             .with_body(&archive_file_mock)
             .create();
         self.root.mocks.push(head_mock);
@@ -294,15 +296,19 @@ impl SandboxBuilder {
         // mock the "Range: bytes" request, which gets the ISIZE value (last 4 bytes)
         // this will be interpreted as a packed integer value
         // (doesn't really matter - used for progress bar)
-        let range_mock = mock(method_name("GET"), Matcher::Regex(r"^/yarn-v\d+.\d+.\d+".to_string()))
-            .match_header("Range", Matcher::Any)
+        let range_mock = mock(
+            method_name("GET"),
+            Matcher::Regex(r"^/yarn-v\d+.\d+.\d+".to_string()),
+        ).match_header("Range", Matcher::Any)
             .with_body("1234")
             .create();
         self.root.mocks.push(range_mock);
 
         // mock the file download
-        let file_mock = mock(method_name("GET"), Matcher::Regex(r"^/yarn-v\d+.\d+.\d+".to_string()))
-            .match_header("Range", Matcher::Missing)
+        let file_mock = mock(
+            method_name("GET"),
+            Matcher::Regex(r"^/yarn-v\d+.\d+.\d+".to_string()),
+        ).match_header("Range", Matcher::Missing)
             .with_body(&archive_file_mock)
             .create();
         self.root.mocks.push(file_mock);


### PR DESCRIPTION
* Adds `./dev/unix/rustfmt.sh --check` to CI runs
* Runs `./dev/unix/rustfmt.sh` across the codebase to reformat as needed