### PR TITLE
`notion deacctivate` also unsets NOTION_HOME

### DIFF
--- a/crates/notion-core/src/shell/bash.rs
+++ b/crates/notion-core/src/shell/bash.rs
@@ -13,9 +13,9 @@ impl Shell for Bash {
 
     fn compile_postscript(&self, postscript: &Postscript) -> String {
         match postscript {
-            &Postscript::Path(ref s) => {
+            &Postscript::Deactivate(ref s) => {
                 // ISSUE(#99): proper escaping
-                format!("export PATH='{}'\n", s)
+                format!("export PATH='{}'\nunset NOTION_HOME\n", s)
             }
             &Postscript::ToolVersion {
                 ref tool,

--- a/crates/notion-core/src/shell/mod.rs
+++ b/crates/notion-core/src/shell/mod.rs
@@ -15,7 +15,7 @@ mod bash;
 pub(crate) use self::bash::Bash;
 
 pub enum Postscript {
-    Path(String),
+    Deactivate(String),
     ToolVersion { tool: String, version: Version },
 }
 
@@ -107,14 +107,16 @@ pub mod tests {
         let bash = CurrentShell::from_str("bash").expect("Could not create bash shell");
 
         assert_eq!(
-            bash.compile_postscript(&Postscript::Path("some:path".to_string())),
-            "export PATH='some:path'\n"
+            bash.compile_postscript(&Postscript::Deactivate("some:path".to_string())),
+            "export PATH='some:path'\nunset NOTION_HOME\n"
         );
 
         // ISSUE(#99): proper escaping
         assert_eq!(
-            bash.compile_postscript(&Postscript::Path("/path:/with:/single'quotes'".to_string())),
-            "export PATH='/path:/with:/single'quotes''\n"
+            bash.compile_postscript(&Postscript::Deactivate(
+                "/path:/with:/single'quotes'".to_string()
+            )),
+            "export PATH='/path:/with:/single'quotes''\nunset NOTION_HOME\n"
         );
 
         assert_eq!(

--- a/src/command/deactivate.rs
+++ b/src/command/deactivate.rs
@@ -46,7 +46,7 @@ Options:
                 let shell = CurrentShell::detect()?;
 
                 let postscript = match System::path()?.into_string() {
-                    Ok(path) => Postscript::Path(path),
+                    Ok(path) => Postscript::Deactivate(path),
                     Err(_) => unimplemented!(),
                 };
 

--- a/tests/acceptance/notion_deactivate.rs
+++ b/tests/acceptance/notion_deactivate.rs
@@ -1,6 +1,6 @@
 use hamcrest2::core::Matcher;
-use test_support::matchers::execs;
 use support::sandbox::sandbox;
+use test_support::matchers::execs;
 
 #[test]
 #[cfg(unix)]
@@ -15,6 +15,6 @@ fn deactivate_bash() {
 
     assert_eq!(
         s.read_postscript(),
-        "export PATH='/usr/bin:/usr/local/bin'\n",
+        "export PATH='/usr/bin:/usr/local/bin'\nunset NOTION_HOME\n",
     )
 }


### PR DESCRIPTION
Closes #193.

I also changed `Postscript::Path` to `Postscript::Deactivate` to more closely match what it's actually doing.