### PR TITLE
Prevent unneeded fetching of Yarn version / index #202

### DIFF
--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -174,8 +174,10 @@ impl Session {
         }
 
         if let Some(ref yarn_version) = &image.yarn {
-            let config = self.config.get()?;
-            let _ = catalog.fetch_yarn(&VersionSpec::exact(yarn_version), config)?;
+            if !catalog.yarn.contains(yarn_version) {
+                let config = self.config.get()?;
+                let _ = catalog.fetch_yarn(&VersionSpec::exact(yarn_version), config)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Fixes #202 

The `prepare_image` function was checking if the `node` version exists in the catalog before fetching it, however it was only checking if `yarn` was set on the project, not whether it had already been downloaded. This was causing the Yarn index to be re-fetched on every invocation, showing a spinner with `Fetching public registry: ...` before executing any command.

Updated `prepare_image` to _also_ check `if !catalog.yarn.contains(yarn_version)`, in the same way that Node is checked, before executing the fetch.

Tested locally with a project that was showing the `Fetching ...` spinner and verified that no spinner is shown when executing a `node` or `yarn` command.