### PR TITLE
Robust progress

### DIFF
--- a/crates/notion-core/src/distro/yarn.rs
+++ b/crates/notion-core/src/distro/yarn.rs
@@ -25,7 +25,7 @@ cfg_if! {
         }
     } else {
         fn public_yarn_server_root() -> String {
-            "https://github.com/notion-cli/yarn-releases/raw/master/dist".to_string()
+            "https://github.com/yarnpkg/yarn/releases/download".to_string()
         }
     }
 }
@@ -56,8 +56,9 @@ impl Distro for YarnDistro {
 
     /// Provision a distribution from the public Yarn distributor (`https://yarnpkg.com`).
     fn public(version: Version) -> Fallible<Self> {
-        let distro_file_name = path::yarn_distro_file_name(&version.to_string());
-        let url = format!("{}/{}", public_yarn_server_root(), distro_file_name);
+        let version_str = version.to_string();
+        let distro_file_name = path::yarn_distro_file_name(&version_str);
+        let url = format!("{}/v{}/{}", public_yarn_server_root(), version_str, distro_file_name);
         YarnDistro::remote(version, &url)
     }
 

--- a/crates/notion-core/src/inventory/serial.rs
+++ b/crates/notion-core/src/inventory/serial.rs
@@ -134,8 +134,7 @@ impl YarnEntry {
         let release_filename = &format!("yarn-{}.tar.gz", self.tag_name)[..];
         self.assets
             .iter()
-            .find(|&&YarnAsset { ref name }| { name == release_filename })
-            .is_some()
+            .any(|&YarnAsset { ref name }| { name == release_filename })
     }
 }
 

--- a/crates/notion-core/src/inventory/serial.rs
+++ b/crates/notion-core/src/inventory/serial.rs
@@ -74,35 +74,86 @@ impl YarnCollection {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Index(Vec<Entry>);
+pub struct NodeIndex(Vec<NodeEntry>);
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Entry {
+pub struct NodeEntry {
     pub version: String,
     pub npm: Option<String>,
     pub files: Vec<String>,
 }
 
-impl Index {
-    pub fn into_index(self) -> Fallible<super::Index> {
+fn trim_version(s: &str) -> &str {
+    let s = s.trim();
+    if s.starts_with('v') {
+        s[1..].trim()
+    } else {
+        s
+    }
+}
+
+impl NodeIndex {
+    pub fn into_index(self) -> Fallible<super::NodeIndex> {
         let mut entries = Vec::new();
         for entry in self.0 {
             if let Some(npm) = entry.npm {
                 let data = super::NodeDistroFiles {
                     files: HashSet::from_iter(entry.files.into_iter()),
                 };
-                let mut version = &entry.version[..];
-                version = version.trim();
-                if version.starts_with('v') {
-                    version = &version[1..];
-                }
-                entries.push(super::Entry {
+                let version = trim_version(&entry.version[..]);
+                entries.push(super::NodeEntry {
                     version: Version::parse(version).unknown()?,
                     npm: Version::parse(&npm).unknown()?,
                     files: data
                 });
             }
         }
-        Ok(super::Index { entries })
+        Ok(super::NodeIndex { entries })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct YarnIndex(Vec<YarnEntry>);
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct YarnEntry {
+    /// Yarn releases are given a tag name of the form "v$version" where $version
+    /// is the release's version string.
+    pub tag_name: String,
+
+    /// The GitHub API provides a list of assets. Some Yarn releases don't include
+    /// a tarball, so we don't support them and remove them from the set of available
+    /// Yarn versions.
+    pub assets: Vec<YarnAsset>,
+}
+
+impl YarnEntry {
+    /// Is this entry a full release, i.e., does this entry's asset list include a
+    /// proper release tarball?
+    fn is_full_release(&self) -> bool {
+        let release_filename = &format!("yarn-{}.tar.gz", self.tag_name)[..];
+        self.assets
+            .iter()
+            .find(|&&YarnAsset { ref name }| { name == release_filename })
+            .is_some()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct YarnAsset {
+    /// The filename of an asset included in a Yarn GitHub release.
+    pub name: String,
+}
+
+impl YarnIndex {
+    pub fn into_index(self) -> Fallible<super::YarnIndex> {
+        let mut entries = BTreeSet::new();
+        for entry in self.0 {
+            if entry.is_full_release() {
+                let version = trim_version(&entry.tag_name[..]);
+                entries.insert(Version::parse(version).unknown()?);
+            }
+        }
+        Ok(super::YarnIndex { entries })
     }
 }


### PR DESCRIPTION
Fixes #214.

This PR streamlines the implementation of progress reporting for fetching and unpacking tarballs: it eliminates the unnecessary extra `HEAD` request and gets both the `Content-Length` and `Accepts` headers from a `GET` request of the full payload. Since [reqwest fetches payloads by-need](https://twitter.com/seanmonstar/status/1073634882469781504), we can kick of a second `GET` request to compute the uncompressed size before fetching the full tarball payload.

This means once we ship this, we no longer need to maintain the [Yarn release proxy repo](https://github.com/notion-cli/yarn-releases/), because the implementation just fetches releases directly from the GitHub releases API of the official public Yarn repo.