### PR TITLE
Use `NOTION_HOME` for all sandboxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "build_const"
@@ -192,6 +218,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "conv"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +295,16 @@ dependencies = [
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dirs"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "docopt"
@@ -723,6 +764,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "notion"
 version = "0.1.5"
 dependencies = [
@@ -756,6 +802,7 @@ dependencies = [
  "cmdline_words_parser 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "detect-indent 0.1.0 (git+https://github.com/stefanpenner/detect-indent-rs)",
+ "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1098,6 +1145,17 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_users"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1293,11 @@ dependencies = [
 [[package]]
 name = "scoped-tls"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1751,6 +1814,8 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
+"checksum arrayvec 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d18513977c2d8261c448511c5c53dc66b26dfccbc3d4446672dea1e71a7d8a26"
 "checksum backtrace 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "150ae7828afa7afb6d474f909d64072d21de1f3365b6e8ad8029bf7b1c6350a0"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
@@ -1758,6 +1823,7 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
@@ -1771,6 +1837,7 @@ dependencies = [
 "checksum cmdline_words_parser 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "346b10598869bcdcd53cd166ecfb04ff8a4d5d7bb33e4ef4acbdb2a447ac3c73"
 "checksum colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533"
 "checksum console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7649ca90478264b9686aac8d269fcb014f14c2bed7c79a7e51b9f6afd4d783eb"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
@@ -1781,6 +1848,7 @@ dependencies = [
 "checksum debugtrace 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62e432bd83c5d70317f6ebd8a50ed4afb32907c64d6e2e1e65e339b06dc553f3"
 "checksum detect-indent 0.1.0 (git+https://github.com/stefanpenner/detect-indent-rs)" = "<none>"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
 "checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a39bffec1e2015c5d8a6773cb0cf48d0d758c842398f624c34969071f5499ea7"
@@ -1832,6 +1900,7 @@ dependencies = [
 "checksum msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65ba9d75bcea84e07812618fedf284a64776c2f2ea0cad6bca7f69739695a958"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
@@ -1867,6 +1936,7 @@ dependencies = [
 "checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
 "checksum readext 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "abdc58f5f18bcf347b55cebb34ed4618b0feff9a9223160f5902adbc1f6a72a6"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
@@ -1882,6 +1952,7 @@ dependencies = [
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "acece75e0f987c48863a6c792ec8b7d6c4177d4a027f8ccc72f849794f437016"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
+"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -33,3 +33,4 @@ detect-indent = { git = "https://github.com/stefanpenner/detect-indent-rs", bran
 envoy = "0.1.3"
 mockito = { version = "0.14.0", optional = true }
 regex = "1.0.6"
+dirs = "1.0.4"

--- a/crates/notion-core/src/image/mod.rs
+++ b/crates/notion-core/src/image/mod.rs
@@ -84,13 +84,20 @@ mod test {
     use std;
     use std::path::PathBuf;
 
+    #[cfg(unix)]
+    use dirs;
+
     #[cfg(windows)]
     use winfolder;
 
     fn notion_base() -> PathBuf {
         #[cfg(unix)]
+<<<<<<< HEAD
         return PathBuf::from(std::env::home_dir().expect("Could not get home directory"))
             .join(".notion");
+=======
+        return PathBuf::from(dirs::home_dir().expect("Could not get home directory")).join(".notion");
+>>>>>>> Fix Windows compile errors and warnings, and eliminate another use of `std::env::home_dir()`.
 
         #[cfg(windows)]
         return winfolder::Folder::LocalAppData.path().join("Notion");

--- a/crates/notion-core/src/image/mod.rs
+++ b/crates/notion-core/src/image/mod.rs
@@ -152,7 +152,7 @@ mod test {
     #[cfg(windows)]
     fn test_image_path() {
         let mut pathbufs: Vec<PathBuf> = Vec::new();
-        pathbufs.push(shim_dir());
+        pathbufs.push(shim_dir().unwrap());
         pathbufs.push(PathBuf::from("C:\\\\somebin"));
         pathbufs.push(PathBuf::from("D:\\\\ProbramFlies"));
 
@@ -225,7 +225,7 @@ mod test {
     #[cfg(windows)]
     fn test_system_path() {
         let mut pathbufs: Vec<PathBuf> = Vec::new();
-        pathbufs.push(shim_dir());
+        pathbufs.push(shim_dir().unwrap());
         pathbufs.push(PathBuf::from("C:\\\\somebin"));
         pathbufs.push(PathBuf::from("D:\\\\ProbramFlies"));
 
@@ -274,7 +274,7 @@ mod test {
     #[cfg(windows)]
     fn test_system_enabled_path() {
         let mut pathbufs: Vec<PathBuf> = Vec::new();
-        pathbufs.push(shim_dir());
+        pathbufs.push(shim_dir().unwrap());
         pathbufs.push(PathBuf::from("C:\\\\somebin"));
         pathbufs.push(PathBuf::from("D:\\\\Program Files"));
 

--- a/crates/notion-core/src/image/mod.rs
+++ b/crates/notion-core/src/image/mod.rs
@@ -80,32 +80,10 @@ impl System {
 mod test {
 
     use super::*;
+    use path::{notion_home, shim_dir};
     use semver::Version;
     use std;
     use std::path::PathBuf;
-
-    #[cfg(unix)]
-    use dirs;
-
-    #[cfg(windows)]
-    use winfolder;
-
-    fn notion_base() -> PathBuf {
-        #[cfg(unix)]
-<<<<<<< HEAD
-        return PathBuf::from(std::env::home_dir().expect("Could not get home directory"))
-            .join(".notion");
-=======
-        return PathBuf::from(dirs::home_dir().expect("Could not get home directory")).join(".notion");
->>>>>>> Fix Windows compile errors and warnings, and eliminate another use of `std::env::home_dir()`.
-
-        #[cfg(windows)]
-        return winfolder::Folder::LocalAppData.path().join("Notion");
-    }
-
-    fn shim_dir() -> PathBuf {
-        notion_base().join("bin")
-    }
 
     // Since unit tests are run in parallel, tests that modify the PATH environment variable are subject to race conditions
     // To prevent that, ensure that all tests that rely on PATH are run in serial by adding them to this meta-test
@@ -122,11 +100,11 @@ mod test {
             "PATH",
             format!(
                 "/usr/bin:/blah:{}:/doesnt/matter/bin",
-                shim_dir().to_string_lossy()
+                shim_dir().unwrap().to_string_lossy()
             ),
         );
 
-        let node_bin = notion_base()
+        let node_bin = notion_home().unwrap()
             .join("tools")
             .join("image")
             .join("node")
@@ -135,7 +113,7 @@ mod test {
             .join("bin");
         let expected_node_bin = node_bin.as_path().to_str().unwrap();
 
-        let yarn_bin = notion_base()
+        let yarn_bin = notion_home().unwrap()
             .join("tools")
             .join("image")
             .join("yarn")
@@ -185,7 +163,7 @@ mod test {
 
         std::env::set_var("PATH", path_with_shims);
 
-        let node_bin = notion_base()
+        let node_bin = notion_home().unwrap()
             .join("tools")
             .join("image")
             .join("node")
@@ -193,7 +171,7 @@ mod test {
             .join("6.4.3");
         let expected_node_bin = node_bin.as_path().to_str().unwrap();
 
-        let yarn_bin = notion_base()
+        let yarn_bin = notion_home().unwrap()
             .join("tools")
             .join("image")
             .join("yarn")
@@ -233,7 +211,7 @@ mod test {
     fn test_system_path() {
         std::env::set_var(
             "PATH",
-            format!("{}:/usr/bin:/bin", shim_dir().to_string_lossy()),
+            format!("{}:/usr/bin:/bin", shim_dir().unwrap().to_string_lossy()),
         );
 
         let expected_path = String::from("/usr/bin:/bin");
@@ -269,7 +247,7 @@ mod test {
     #[cfg(unix)]
     fn test_system_enabled_path() {
         let mut pathbufs: Vec<PathBuf> = Vec::new();
-        pathbufs.push(shim_dir());
+        pathbufs.push(shim_dir().unwrap());
         pathbufs.push(PathBuf::from("/usr/bin"));
         pathbufs.push(PathBuf::from("/bin"));
 

--- a/crates/notion-core/src/lib.rs
+++ b/crates/notion-core/src/lib.rs
@@ -6,6 +6,7 @@ extern crate archive;
 extern crate cmdline_words_parser;
 extern crate console;
 extern crate detect_indent;
+extern crate dirs;
 extern crate envoy;
 extern crate indicatif;
 extern crate lazycell;

--- a/crates/notion-core/src/path/mod.rs
+++ b/crates/notion-core/src/path/mod.rs
@@ -1,7 +1,10 @@
 //! Provides functions for determining the paths of files and directories
 //! in a standard Notion layout.
 
+use std::env;
 use std::path::{Path, PathBuf};
+
+use notion_fail::Fallible;
 
 cfg_if! {
     if #[cfg(feature = "universal-docs")] {
@@ -19,6 +22,90 @@ cfg_if! {
         mod windows;
         pub use self::windows::*;
     }
+}
+
+pub fn notion_home() -> Fallible<PathBuf> {
+    if let Some(home) = env::var_os("NOTION_HOME") {
+        Ok(Path::new(&home).to_path_buf())
+    } else {
+        default_notion_home()
+    }
+}
+
+pub fn cache_dir() -> Fallible<PathBuf> {
+    Ok(notion_home()?.join("cache"))
+}
+
+pub fn node_inventory_dir() -> Fallible<PathBuf> {
+    Ok(inventory_dir()?.join("node"))
+}
+
+pub fn yarn_inventory_dir() -> Fallible<PathBuf> {
+    Ok(inventory_dir()?.join("yarn"))
+}
+
+pub fn package_inventory_dir() -> Fallible<PathBuf> {
+    Ok(inventory_dir()?.join("packages"))
+}
+
+pub fn node_cache_dir() -> Fallible<PathBuf> {
+    Ok(cache_dir()?.join("node"))
+}
+
+pub fn node_index_file() -> Fallible<PathBuf> {
+    Ok(node_cache_dir()?.join("index.json"))
+}
+
+pub fn node_index_expiry_file() -> Fallible<PathBuf> {
+    Ok(node_cache_dir()?.join("index.json.expires"))
+}
+
+pub fn image_dir() -> Fallible<PathBuf> {
+    Ok(tools_dir()?.join("image"))
+}
+
+pub fn node_image_root_dir() -> Fallible<PathBuf> {
+    Ok(image_dir()?.join("node"))
+}
+
+pub fn node_image_dir(node: &str, npm: &str) -> Fallible<PathBuf> {
+    Ok(node_image_root_dir()?.join(node).join(npm))
+}
+
+pub fn yarn_image_root_dir() -> Fallible<PathBuf> {
+    Ok(image_dir()?.join("yarn"))
+}
+
+pub fn yarn_image_dir(version: &str) -> Fallible<PathBuf> {
+    Ok(yarn_image_root_dir()?.join(version))
+}
+
+pub fn yarn_image_bin_dir(version: &str) -> Fallible<PathBuf> {
+    Ok(yarn_image_dir(version)?.join("bin"))
+}
+
+pub fn shim_dir() -> Fallible<PathBuf> {
+    Ok(notion_home()?.join("bin"))
+}
+
+pub fn user_config_file() -> Fallible<PathBuf> {
+    Ok(notion_home()?.join("config.toml"))
+}
+
+pub fn tools_dir() -> Fallible<PathBuf> {
+    Ok(notion_home()?.join("tools"))
+}
+
+pub fn inventory_dir() -> Fallible<PathBuf> {
+    Ok(tools_dir()?.join("inventory"))
+}
+
+pub fn user_toolchain_dir() -> Fallible<PathBuf> {
+    Ok(tools_dir()?.join("user"))
+}
+
+pub fn user_platform_file() -> Fallible<PathBuf> {
+    Ok(user_toolchain_dir()?.join("platform.json"))
 }
 
 pub fn node_distro_file_name(version: &str) -> String {

--- a/crates/notion-core/src/path/unix.rs
+++ b/crates/notion-core/src/path/unix.rs
@@ -1,11 +1,15 @@
 //! Provides functions for determining the paths of files and directories
 //! in a standard Notion layout in Unix-based operating systems.
 
-use std::{env, io};
+use std::io;
 use std::path::PathBuf;
 use std::os::unix;
 
+use dirs;
+
 use notion_fail::{ExitCode, Fallible, NotionFail};
+
+use super::{notion_home, node_image_dir, shim_dir};
 
 #[derive(Debug, Fail, NotionFail)]
 #[fail(display = "environment variable 'HOME' is not set")]
@@ -79,53 +83,13 @@ cfg_if! {
 //         launchscript                                    launchscript_file
 //         config.toml                                     user_config_file
 
-fn notion_home() -> Fallible<PathBuf> {
-    let home = env::home_dir().ok_or(NoHomeEnvVar)?;
+pub fn default_notion_home() -> Fallible<PathBuf> {
+    let home = dirs::home_dir().ok_or(NoHomeEnvVar)?;
     Ok(home.join(".notion"))
-}
-
-pub fn cache_dir() -> Fallible<PathBuf> {
-    Ok(notion_home()?.join("cache"))
-}
-
-pub fn node_inventory_dir() -> Fallible<PathBuf> {
-    Ok(inventory_dir()?.join("node"))
-}
-
-pub fn yarn_inventory_dir() -> Fallible<PathBuf> {
-    Ok(inventory_dir()?.join("yarn"))
-}
-
-pub fn package_inventory_dir() -> Fallible<PathBuf> {
-    Ok(inventory_dir()?.join("packages"))
-}
-
-pub fn node_cache_dir() -> Fallible<PathBuf> {
-    Ok(cache_dir()?.join("node"))
-}
-
-pub fn node_index_file() -> Fallible<PathBuf> {
-    Ok(node_cache_dir()?.join("index.json"))
-}
-
-pub fn node_index_expiry_file() -> Fallible<PathBuf> {
-    Ok(node_cache_dir()?.join("index.json.expires"))
 }
 
 pub fn archive_extension() -> String {
     String::from("tar.gz")
-}
-
-pub fn image_dir() -> Fallible<PathBuf> {
-    Ok(tools_dir()?.join("image"))
-}
-
-pub fn node_image_root_dir() -> Fallible<PathBuf> {
-    Ok(image_dir()?.join("node"))
-}
-
-pub fn node_image_dir(node: &str, npm: &str) -> Fallible<PathBuf> {
-    Ok(node_image_root_dir()?.join(node).join(npm))
 }
 
 pub fn node_image_bin_dir(node: &str, npm: &str) -> Fallible<PathBuf> {
@@ -137,28 +101,12 @@ pub fn node_image_3p_bin_dir(node: &str, npm: &str) -> Fallible<PathBuf> {
     Ok(node_image_dir(node, npm)?.join("lib/node_modules/.bin"))
 }
 
-pub fn yarn_image_root_dir() -> Fallible<PathBuf> {
-    Ok(image_dir()?.join("yarn"))
-}
-
-pub fn yarn_image_dir(version: &str) -> Fallible<PathBuf> {
-    Ok(yarn_image_root_dir()?.join(version))
-}
-
-pub fn yarn_image_bin_dir(version: &str) -> Fallible<PathBuf> {
-    Ok(yarn_image_dir(version)?.join("bin"))
+pub fn shim_file(toolname: &str) -> Fallible<PathBuf> {
+    Ok(shim_dir()?.join(toolname))
 }
 
 pub fn notion_file() -> Fallible<PathBuf> {
     Ok(notion_home()?.join("notion"))
-}
-
-pub fn shim_dir() -> Fallible<PathBuf> {
-    Ok(notion_home()?.join("bin"))
-}
-
-pub fn shim_file(toolname: &str) -> Fallible<PathBuf> {
-    Ok(shim_dir()?.join(toolname))
 }
 
 pub fn launchbin_file() -> Fallible<PathBuf> {
@@ -167,26 +115,6 @@ pub fn launchbin_file() -> Fallible<PathBuf> {
 
 pub fn launchscript_file() -> Fallible<PathBuf> {
     Ok(notion_home()?.join("launchscript"))
-}
-
-pub fn user_config_file() -> Fallible<PathBuf> {
-    Ok(notion_home()?.join("config.toml"))
-}
-
-pub fn tools_dir() -> Fallible<PathBuf> {
-    Ok(notion_home()?.join("tools"))
-}
-
-pub fn inventory_dir() -> Fallible<PathBuf> {
-    Ok(tools_dir()?.join("inventory"))
-}
-
-pub fn user_toolchain_dir() -> Fallible<PathBuf> {
-    Ok(tools_dir()?.join("user"))
-}
-
-pub fn user_platform_file() -> Fallible<PathBuf> {
-    Ok(user_toolchain_dir()?.join("platform.json"))
 }
 
 pub fn create_file_symlink(src: PathBuf, dst: PathBuf) -> Result<(), io::Error> {

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -1,16 +1,14 @@
 //! Provides functions for determining the paths of files and directories
 //! in a standard Notion layout in Windows operating systems.
 
-use std::env;
 use std::path::PathBuf;
 #[cfg(windows)]
 use std::os::windows;
 use std::io;
 
 use dirs;
-use winfolder;
 
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible, NotionFail};
 
 use super::{notion_home, node_image_dir, shim_dir};
 
@@ -29,6 +27,11 @@ cfg_if! {
         compile_error!("Unsupported target_arch variant of Windows (expected 'x86' or 'x64').");
     }
 }
+
+#[derive(Debug, Fail, NotionFail)]
+#[fail(display = "Windows LocalAppData directory not found")]
+#[notion_fail(code = "EnvironmentError")]
+pub(crate) struct NoDataLocalDir;
 
 // C:\Users\johndoe\AppData\Local\
 //     Notion\
@@ -70,7 +73,7 @@ cfg_if! {
 //         config.toml                                     user_config_file
 
 pub fn default_notion_home() -> Fallible<PathBuf> {
-    let home = dirs::data_local_dir().ok_or(NoHomeEnvVar)?;
+    let home = dirs::data_local_dir().ok_or(NoDataLocalDir)?;
     Ok(home.join("Notion"))
 }
 

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -7,9 +7,12 @@ use std::path::PathBuf;
 use std::os::windows;
 use std::io;
 
+use dirs;
 use winfolder;
 
 use notion_fail::Fallible;
+
+use super::{notion_home, node_image_dir, shim_dir};
 
 // These are taken from: https://nodejs.org/dist/index.json and are used
 // by `path::archive_root_dir` to determine the root directory of the
@@ -66,56 +69,13 @@ cfg_if! {
 //         launchscript.exe                                launchscript_file
 //         config.toml                                     user_config_file
 
-pub fn cache_dir() -> Fallible<PathBuf> {
-    Ok(local_data_root()?.join("cache"))
-}
-
-pub fn node_cache_dir() -> Fallible<PathBuf> {
-    Ok(cache_dir()?.join("node"))
-}
-
-pub fn yarn_cache_dir() -> Fallible<PathBuf> {
-    Ok(cache_dir()?.join("yarn"))
-}
-
-pub fn node_index_file() -> Fallible<PathBuf> {
-    Ok(node_cache_dir()?.join("index.json"))
-}
-
-pub fn node_index_expiry_file() -> Fallible<PathBuf> {
-    Ok(node_cache_dir()?.join("index.json.expires"))
+pub fn default_notion_home() -> Fallible<PathBuf> {
+    let home = dirs::data_local_dir().ok_or(NoHomeEnvVar)?;
+    Ok(home.join("Notion"))
 }
 
 pub fn archive_extension() -> String {
     String::from("zip")
-}
-
-pub fn inventory_dir() -> Fallible<PathBuf> {
-    Ok(tools_dir()?.join("inventory"))
-}
-
-pub fn node_inventory_dir() -> Fallible<PathBuf> {
-    Ok(inventory_dir()?.join("node"))
-}
-
-pub fn yarn_inventory_dir() -> Fallible<PathBuf> {
-    Ok(inventory_dir()?.join("yarn"))
-}
-
-pub fn package_inventory_dir() -> Fallible<PathBuf> {
-    Ok(inventory_dir()?.join("packages"))
-}
-
-pub fn image_dir() -> Fallible<PathBuf> {
-    Ok(tools_dir()?.join("image"))
-}
-
-pub fn node_image_root_dir() -> Fallible<PathBuf> {
-    Ok(image_dir()?.join("node"))
-}
-
-pub fn node_image_dir(node: &str, npm: &str) -> Fallible<PathBuf> {
-    Ok(node_image_root_dir()?.join(node).join(npm))
 }
 
 pub fn node_image_bin_dir(node: &str, npm: &str) -> Fallible<PathBuf> {
@@ -128,67 +88,20 @@ pub fn node_image_3p_bin_dir(_node: &str, _npm: &str) -> Fallible<PathBuf> {
     unimplemented!("global 3rd party executables not yet implemented for Windows")
 }
 
-pub fn yarn_image_root_dir() -> Fallible<PathBuf> {
-    Ok(image_dir()?.join("yarn"))
-}
-
-pub fn yarn_image_dir(version: &str) -> Fallible<PathBuf> {
-    Ok(yarn_image_root_dir()?.join(version))
-}
-
-pub fn yarn_image_bin_dir(version: &str) -> Fallible<PathBuf> {
-    Ok(yarn_image_dir(version)?.join("bin"))
-}
-
 pub fn launchbin_file() -> Fallible<PathBuf> {
-    Ok(local_data_root()?.join("launchbin.exe"))
+    Ok(notion_home()?.join("launchbin.exe"))
 }
 
 pub fn launchscript_file() -> Fallible<PathBuf> {
-    Ok(local_data_root()?.join("launchscript.exe"))
+    Ok(notion_home()?.join("launchscript.exe"))
 }
 
 pub fn notion_file() -> Fallible<PathBuf> {
-    Ok(local_data_root()?.join("notion.exe"))
-}
-
-pub fn shim_dir() -> Fallible<PathBuf> {
-    Ok(local_data_root()?.join("bin"))
+    Ok(notion_home()?.join("notion.exe"))
 }
 
 pub fn shim_file(toolname: &str) -> Fallible<PathBuf> {
     Ok(shim_dir()?.join(&format!("{}.exe", toolname)))
-}
-
-fn local_data_root() -> Fallible<PathBuf> {
-    // if this is sandboxed in CI, use the sandboxed AppData directory
-    if env::var("NOTION_SANDBOX").is_ok() {
-        let home_dir = env::home_dir().unwrap();
-        return Ok(home_dir.join("AppData").join("Local").join("Notion"));
-    } else {
-        #[cfg(windows)]
-        return Ok(winfolder::Folder::LocalAppData.path().join("Notion"));
-
-        // "universal-docs" is built on a Unix machine, so we can't include Windows-specific libs
-        #[cfg(feature = "universal-docs")]
-        unimplemented!()
-    }
-}
-
-pub fn user_config_file() -> Fallible<PathBuf> {
-    Ok(local_data_root()?.join("config.toml"))
-}
-
-pub fn tools_dir() -> Fallible<PathBuf> {
-    Ok(local_data_root()?.join("tools"))
-}
-
-pub fn user_toolchain_dir() -> Fallible<PathBuf> {
-    Ok(tools_dir()?.join("user"))
-}
-
-pub fn user_platform_file() -> Fallible<PathBuf> {
-    Ok(user_toolchain_dir()?.join("platform.json"))
 }
 
 pub fn create_file_symlink(src: PathBuf, dst: PathBuf) -> Result<(), io::Error> {

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -359,13 +359,8 @@ impl SandboxBuilder {
 fn home_dir() -> PathBuf {
     paths::home()
 }
-#[cfg(unix)]
 fn notion_home() -> PathBuf {
     home_dir().join(".notion")
-}
-#[cfg(windows)]
-fn notion_home() -> PathBuf {
-    home_dir().join("AppData").join("Local").join("Notion")
 }
 fn notion_tmp_dir() -> PathBuf {
     notion_home().join("tmp")
@@ -439,9 +434,6 @@ impl Sandbox {
         let mut p = test_support::process::process(program);
         p.cwd(self.root())
             // sandbox the Notion environment
-            .env("NOTION_SANDBOX", "true") // used to indicate that Notion is running sandboxed, for directory logic in Windows
-            .env("HOME", home_dir())
-            .env("USERPROFILE", home_dir()) // windows
             .env("NOTION_HOME", notion_home())
             .env("PATH", &self.path)
             .env("NOTION_POSTSCRIPT", notion_postscript())


### PR DESCRIPTION
Fixes #207.

Reduces the OS-specific logic by building everything on top of a `notion_home()` function. Most of the directory layout is OS-independent.

Also eliminates the Rust compiler warning for the deprecated `std::env::home_dir()` function, replacing it with the recommended `dirs` crate.

This PR is the first step towards making a more abstracted and manageable approach to the Notion directory layout. My goal is to create a `Layout` data structure with methods for extracting all the paths. This will then be something that can be shared by not only Notion, but also the test harness's sandbox setup code, as well as a migration tool for upgrading between different layouts.