### PR TITLE
Make "npm" key optional in package.json

### DIFF
--- a/crates/notion-core/src/manifest/mod.rs
+++ b/crates/notion-core/src/manifest/mod.rs
@@ -83,12 +83,12 @@ impl Manifest {
 
     /// Returns the pinned version of Node as a Version, if any.
     pub fn node(&self) -> Option<Version> {
-        self.platform().map(|t| t.node.runtime.clone())
+        self.platform().map(|t| t.node_runtime.clone())
     }
 
     /// Returns the pinned verison of Node as a String, if any.
     pub fn node_str(&self) -> Option<String> {
-        self.platform().map(|t| t.node.runtime.to_string())
+        self.platform().map(|t| t.node_runtime.to_string())
     }
 
     /// Returns the pinned verison of Yarn as a Version, if any.

--- a/crates/notion-core/src/manifest/mod.rs
+++ b/crates/notion-core/src/manifest/mod.rs
@@ -104,7 +104,7 @@ impl Manifest {
 
     /// Writes the input ToolchainManifest to package.json, adding the "toolchain" key if
     /// necessary.
-    pub fn update_toolchain(toolchain: serial::Image, package_file: PathBuf) -> Fallible<()> {
+    pub fn update_toolchain(toolchain: serial::ToolchainSpec, package_file: PathBuf) -> Fallible<()> {
         // parse the entire package.json file into a Value
         let file = File::open(&package_file).unknown()?;
         let mut v: serde_json::Value = serde_json::from_reader(file).unknown()?;

--- a/crates/notion-core/src/manifest/serial.rs
+++ b/crates/notion-core/src/manifest/serial.rs
@@ -1,7 +1,6 @@
 use super::super::{manifest, platform};
 use version::VersionSpec;
 
-use distro::node::NodeVersion;
 use notion_fail::Fallible;
 
 use serde::de::{Deserialize, Deserializer, Error, MapAccess, Visitor};
@@ -93,10 +92,8 @@ impl Manifest {
     pub fn into_platform(&self) -> Fallible<Option<platform::PlatformSpec>> {
         if let Some(toolchain) = &self.toolchain {
             return Ok(Some(platform::PlatformSpec {
-                node: NodeVersion {
-                    runtime: VersionSpec::parse_version(&toolchain.node)?,
-                    npm: VersionSpec::parse_version(&toolchain.npm)?,
-                },
+                node_runtime: VersionSpec::parse_version(&toolchain.node)?,
+                npm: VersionSpec::parse_version(&toolchain.npm)?,
                 yarn: if let Some(yarn) = &toolchain.yarn {
                     Some(VersionSpec::parse_version(&yarn)?)
                 } else {

--- a/crates/notion-core/src/path/mod.rs
+++ b/crates/notion-core/src/path/mod.rs
@@ -112,8 +112,9 @@ pub fn node_distro_file_name(version: &str) -> String {
     format!("{}.{}", node_archive_root_dir_name(version), archive_extension())
 }
 
-pub fn node_npm_version_file_name(version: &str) -> String {
-    format!("node-v{}-npm", version)
+pub fn node_npm_version_file(version: &str) -> Fallible<PathBuf> {
+    let filename = format!("node-v{}-npm", version);
+    Ok(node_inventory_dir()?.join(&filename))
 }
 
 pub fn node_archive_root_dir_name(version: &str) -> String {

--- a/crates/notion-core/src/platform/mod.rs
+++ b/crates/notion-core/src/platform/mod.rs
@@ -13,21 +13,26 @@ use session::Session;
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct PlatformSpec {
     /// The pinned version of Node.
-    pub node: NodeVersion,
+    pub node_runtime: Version,
+    /// The pinned version of npm, if any.
+    pub npm: Version,
     /// The pinned version of Yarn, if any.
     pub yarn: Option<Version>,
 }
 
 impl PlatformSpec {
     pub fn checkout(&self, session: &mut Session) -> Fallible<Image> {
-        session.ensure_node(&self.node.runtime)?;
+        session.ensure_node(&self.node_runtime)?;
 
         if let Some(ref yarn_version) = self.yarn {
             session.ensure_yarn(yarn_version)?;
         }
 
         Ok(Image {
-            node: self.node.clone(),
+            node: NodeVersion {
+                runtime: self.node_runtime.clone(),
+                npm: self.npm.clone(),
+            },
             yarn: self.yarn.clone(),
         })
     }

--- a/crates/notion-core/src/platform/mod.rs
+++ b/crates/notion-core/src/platform/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use envoy;
 use semver::Version;
 
-use distro::node::NodeVersion;
+use distro::node::{load_default_npm_version, NodeVersion};
 use notion_fail::{Fallible, ResultExt};
 use path;
 use session::Session;
@@ -33,8 +33,8 @@ impl PlatformSpec {
                 runtime: self.node_runtime.clone(),
                 npm: match self.npm {
                     Some(ref version) => version.clone(),
-                    None => NodeVersion::default_npm_version(&self.node_runtime)?
-                }
+                    None => load_default_npm_version(&self.node_runtime)?,
+                },
             },
             yarn: self.yarn.clone(),
         })
@@ -90,7 +90,11 @@ impl System {
     pub fn path() -> Fallible<OsString> {
         let old_path = envoy::path().unwrap_or(envoy::Var::from(""));
 
-        let new_path = old_path.split().remove(path::shim_dir()?).join().unknown()?;
+        let new_path = old_path
+            .split()
+            .remove(path::shim_dir()?)
+            .join()
+            .unknown()?;
 
         Ok(new_path)
     }
@@ -137,7 +141,8 @@ mod test {
             ),
         );
 
-        let node_bin = notion_home().unwrap()
+        let node_bin = notion_home()
+            .unwrap()
             .join("tools")
             .join("image")
             .join("node")
@@ -146,7 +151,8 @@ mod test {
             .join("bin");
         let expected_node_bin = node_bin.as_path().to_str().unwrap();
 
-        let yarn_bin = notion_home().unwrap()
+        let yarn_bin = notion_home()
+            .unwrap()
             .join("tools")
             .join("image")
             .join("yarn")
@@ -159,7 +165,10 @@ mod test {
         let v643 = Version::parse("6.4.3").unwrap();
 
         let no_yarn_image = Image {
-            node: NodeVersion { runtime: v123.clone(), npm: v643.clone() },
+            node: NodeVersion {
+                runtime: v123.clone(),
+                npm: v643.clone(),
+            },
             yarn: None,
         };
 
@@ -169,7 +178,10 @@ mod test {
         );
 
         let with_yarn_image = Image {
-            node: NodeVersion { runtime: v123.clone(), npm: v643.clone() },
+            node: NodeVersion {
+                runtime: v123.clone(),
+                npm: v643.clone(),
+            },
             yarn: Some(v457.clone()),
         };
 
@@ -196,7 +208,8 @@ mod test {
 
         std::env::set_var("PATH", path_with_shims);
 
-        let node_bin = notion_home().unwrap()
+        let node_bin = notion_home()
+            .unwrap()
             .join("tools")
             .join("image")
             .join("node")
@@ -204,7 +217,8 @@ mod test {
             .join("6.4.3");
         let expected_node_bin = node_bin.as_path().to_str().unwrap();
 
-        let yarn_bin = notion_home().unwrap()
+        let yarn_bin = notion_home()
+            .unwrap()
             .join("tools")
             .join("image")
             .join("yarn")
@@ -217,7 +231,10 @@ mod test {
         let v643 = Version::parse("6.4.3").unwrap();
 
         let no_yarn_image = Image {
-            node: NodeVersion { runtime: v123.clone(), npm: v643.clone() },
+            node: NodeVersion {
+                runtime: v123.clone(),
+                npm: v643.clone(),
+            },
             yarn: None,
         };
 
@@ -227,7 +244,10 @@ mod test {
         );
 
         let with_yarn_image = Image {
-            node: NodeVersion { runtime: v123.clone(), npm: v643.clone() },
+            node: NodeVersion {
+                runtime: v123.clone(),
+                npm: v643.clone(),
+            },
             yarn: Some(v457.clone()),
         };
 

--- a/crates/notion-core/src/platform/mod.rs
+++ b/crates/notion-core/src/platform/mod.rs
@@ -15,7 +15,7 @@ pub struct PlatformSpec {
     /// The pinned version of Node.
     pub node_runtime: Version,
     /// The pinned version of npm, if any.
-    pub npm: Version,
+    pub npm: Option<Version>,
     /// The pinned version of Yarn, if any.
     pub yarn: Option<Version>,
 }
@@ -31,7 +31,10 @@ impl PlatformSpec {
         Ok(Image {
             node: NodeVersion {
                 runtime: self.node_runtime.clone(),
-                npm: self.npm.clone(),
+                npm: match self.npm {
+                    Some(ref version) => version.clone(),
+                    None => NodeVersion::default_npm_version(&self.node_runtime)?
+                }
             },
             yarn: self.yarn.clone(),
         })

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -244,7 +244,7 @@ impl Project {
         // update the toolchain yarn version
         if let Some(image) = self.manifest().platform() {
             let toolchain =
-                serial::Image::new(image.node.runtime.to_string(), image.node.npm.to_string(), Some(yarn_version.to_string()));
+                serial::Image::new(image.node_runtime.to_string(), image.npm.to_string(), Some(yarn_version.to_string()));
             Manifest::update_toolchain(toolchain, self.package_file())?;
             println!("Pinned yarn to version {} in package.json", yarn_version);
         } else {

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -230,9 +230,9 @@ impl Project {
     /// Writes the specified version of Node to the `toolchain.node` key in package.json.
     pub fn pin_node_in_toolchain(&self, node_version: NodeVersion) -> Fallible<()> {
         // update the toolchain node version
-        let toolchain = serial::Image::new(
+        let toolchain = serial::ToolchainSpec::new(
             node_version.runtime.to_string(),
-            node_version.npm.to_string(),
+            Some(node_version.npm.to_string()),
             self.manifest().yarn_str().clone());
         Manifest::update_toolchain(toolchain, self.package_file())?;
         println!("Pinned node to version {} in package.json", node_version.runtime);
@@ -242,9 +242,9 @@ impl Project {
     /// Writes the specified version of Yarn to the `toolchain.yarn` key in package.json.
     pub fn pin_yarn_in_toolchain(&self, yarn_version: Version) -> Fallible<()> {
         // update the toolchain yarn version
-        if let Some(image) = self.manifest().platform() {
+        if let Some(platform) = self.manifest().platform() {
             let toolchain =
-                serial::Image::new(image.node_runtime.to_string(), image.npm.to_string(), Some(yarn_version.to_string()));
+                serial::ToolchainSpec::new(platform.node_runtime.to_string(), platform.npm.as_ref().map(|npm| npm.to_string()), Some(yarn_version.to_string()));
             Manifest::update_toolchain(toolchain, self.package_file())?;
             println!("Pinned yarn to version {} in package.json", yarn_version);
         } else {

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -113,33 +113,12 @@ impl Session {
         self.project.clone()
     }
 
-    pub fn current_platform(&mut self) -> Fallible<Option<Rc<PlatformSpec>>> {
-        if let Some(image) = self.project_platform() {
-            return Ok(Some(image));
-        }
-
-        if let Some(image) = self.user_platform()? {
-            return Ok(Some(image));
-        }
-
-        return Ok(None);
+    pub fn current_platform(&mut self) -> Option<Rc<PlatformSpec>> {
+        self.project_platform().or_else(|| self.user_platform())
     }
 
-    pub fn user_platform(&mut self) -> Fallible<Option<Rc<PlatformSpec>>> {
-        if let Some(node) = self.user_node() {
-            if let Some(yarn) = self.user_yarn() {
-                return Ok(Some(Rc::new(PlatformSpec {
-                    node,
-                    yarn: Some(yarn),
-                })));
-            }
-
-            return Ok(Some(Rc::new(PlatformSpec {
-                node,
-                yarn: None,
-            })));
-        }
-        Ok(None)
+    pub fn user_platform(&self) -> Option<Rc<PlatformSpec>> {
+        self.toolchain.platform_ref().map(|platform| Rc::new(platform.clone()))
     }
 
     /// Returns the current project's pinned platform image, if any.
@@ -189,10 +168,6 @@ impl Session {
         Ok(())
     }
 
-    pub fn user_node(&self) -> Option<NodeVersion> {
-        self.toolchain.get_active_node().map(|ref nv| nv.clone())
-    }
-
     /// Fetches a version of Node matching the specified semantic verisoning
     /// requirements.
     pub fn fetch_node(&mut self, matching: &VersionSpec) -> Fallible<Fetched<NodeVersion>> {
@@ -221,10 +196,6 @@ impl Session {
             throw!(NotInPackageError::new());
         }
         Ok(())
-    }
-
-    pub fn user_yarn(&mut self) -> Option<Version> {
-        self.toolchain.get_active_yarn().map(|ref v| v.clone())
     }
 
     /// Fetches a version of Node matching the specified semantic verisoning

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -113,7 +113,7 @@ impl Session {
         self.project.clone()
     }
 
-    pub fn current_platform(&mut self) -> Option<Rc<PlatformSpec>> {
+    pub fn current_platform(&self) -> Option<Rc<PlatformSpec>> {
         self.project_platform().or_else(|| self.user_platform())
     }
 

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -221,7 +221,7 @@ impl Tool for Binary {
                 }
 
                 // otherwise use the user platform.
-                if let Some(ref platform) = session.user_platform()? {
+                if let Some(ref platform) = session.user_platform() {
                     let image = platform.checkout(session)?;
                     return Ok(Self::from_components(
                         &path_to_bin.as_os_str(),
@@ -238,7 +238,7 @@ impl Tool for Binary {
         }
 
         // next try to use the user toolchain
-        if let Some(ref platform) = session.user_platform()? {
+        if let Some(ref platform) = session.user_platform() {
             // use the full path to the binary
             // ISSUE (#160): Look up the platform image bound to the user tool.
             let image = platform.checkout(session)?;
@@ -305,7 +305,7 @@ impl Tool for Node {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
+        if let Some(ref platform) = session.current_platform() {
             let image = platform.checkout(session)?;
             Ok(Self::from_components(&exe, args, &image.path()?))
         } else {
@@ -330,7 +330,7 @@ impl Tool for Yarn {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
+        if let Some(ref platform) = session.current_platform() {
             let image = platform.checkout(session)?;
             Ok(Self::from_components(&exe, args, &image.path()?))
         } else {
@@ -368,7 +368,7 @@ impl Tool for Npm {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
+        if let Some(ref platform) = session.current_platform() {
             let image = platform.checkout(session)?;
             Ok(Self::from_components(&exe, args, &image.path()?))
         } else {
@@ -417,7 +417,7 @@ impl Tool for Npx {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
+        if let Some(ref platform) = session.current_platform() {
             let image = platform.checkout(session)?;
 
             // npx was only included with Node >= 8.2.0. If less than that, we should include a helpful error message

--- a/crates/notion-core/src/toolchain/mod.rs
+++ b/crates/notion-core/src/toolchain/mod.rs
@@ -26,21 +26,27 @@ impl Toolchain {
         })
     }
 
-    pub fn get_active_node(&self) -> Option<NodeVersion> {
-        self.platform.as_ref().map(|ref p| p.node.clone())
+    pub fn platform_ref(&self) -> Option<&PlatformSpec> {
+        self.platform.as_ref()
     }
 
     pub fn set_active_node(&mut self, version: NodeVersion) -> Fallible<()> {
         let mut dirty = false;
 
         if let Some(ref mut platform) = self.platform {
-            if platform.node != version {
-                platform.node = version;
+            if platform.node_runtime != version.runtime {
+                platform.node_runtime = version.runtime;
+                dirty = true;
+            }
+
+            if platform.npm != version.npm {
+                platform.npm = version.npm;
                 dirty = true;
             }
         } else {
             self.platform = Some(PlatformSpec {
-                node: version,
+                node_runtime: version.runtime,
+                npm: version.npm,
                 yarn: None,
             });
             dirty = true;
@@ -51,12 +57,6 @@ impl Toolchain {
         }
 
         Ok(())
-    }
-
-    pub fn get_active_yarn(&self) -> Option<Version> {
-        self.platform
-            .as_ref()
-            .and_then(|ref platform| platform.yarn.clone())
     }
 
     pub fn set_active_yarn(&mut self, version: Version) -> Fallible<()> {

--- a/crates/notion-core/src/toolchain/mod.rs
+++ b/crates/notion-core/src/toolchain/mod.rs
@@ -39,14 +39,14 @@ impl Toolchain {
                 dirty = true;
             }
 
-            if platform.npm != version.npm {
-                platform.npm = version.npm;
+            if platform.npm != Some(version.npm.clone()) {
+                platform.npm = Some(version.npm);
                 dirty = true;
             }
         } else {
             self.platform = Some(PlatformSpec {
                 node_runtime: version.runtime,
-                npm: version.npm,
+                npm: Some(version.npm),
                 yarn: None,
             });
             dirty = true;

--- a/crates/notion-core/src/toolchain/serial.rs
+++ b/crates/notion-core/src/toolchain/serial.rs
@@ -8,7 +8,7 @@ use serde_json;
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct NodeVersion {
     pub runtime: String,
-    pub npm: String,
+    pub npm: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -24,7 +24,11 @@ impl Platform {
         Ok(match self.node {
             Some(NodeVersion { runtime, npm }) => {
                 let node_runtime = Version::parse(&runtime).unknown()?;
-                let npm = Version::parse(&npm).unknown()?;
+                let npm = if let Some(npm_version) = npm {
+                    Some(Version::parse(&npm_version).unknown()?)
+                } else {
+                    None
+                };
                 let yarn = if let Some(yarn) = self.yarn {
                     Some(Version::parse(&yarn).unknown()?)
                 } else {
@@ -57,7 +61,7 @@ impl PlatformSpec {
         Platform {
             node: Some(NodeVersion {
                 runtime: self.node_runtime.to_string(),
-                npm: self.npm.to_string(),
+                npm: self.npm.as_ref().map(|npm| npm.to_string()),
             }),
             yarn: self.yarn.as_ref().map(|yarn| yarn.to_string()),
         }
@@ -91,7 +95,7 @@ pub mod tests {
             yarn: Some("1.2.3".to_string()),
             node: Some(NodeVersion {
                 runtime: "4.5.6".to_string(),
-                npm: "7.8.9".to_string(),
+                npm: Some("7.8.9".to_string()),
             }),
         };
         assert_eq!(platform, expected_platform);
@@ -113,7 +117,7 @@ pub mod tests {
         let platform = platform::PlatformSpec {
             yarn: Some(semver::Version::parse("1.2.3").expect("could not parse semver version")),
             node_runtime: semver::Version::parse("4.5.6").expect("could not parse semver version"),
-            npm: semver::Version::parse("7.8.9").expect("could not parse semver version"),
+            npm: Some(semver::Version::parse("7.8.9").expect("could not parse semver version")),
         };
         let json_str = platform.to_serial().to_json().expect("could not serialize platform to JSON");
         let expected_json_str = BASIC_JSON_STR.to_string();

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -67,7 +67,7 @@ Options:
                 Help::Command(CommandName::Current).run(session)?;
                 true
             }
-            Current::Project => project_node_version(&session)?
+            Current::Project => project_node_version(&session)
                 .map(|version| {
                     println!("v{}", version);
                 })
@@ -79,7 +79,7 @@ Options:
                 .is_some(),
             Current::All => {
                 let (project, user) = (
-                    project_node_version(&session)?,
+                    project_node_version(&session),
                     user_node_version(&session),
                 );
 
@@ -109,13 +109,10 @@ Options:
     }
 }
 
-fn project_node_version(session: &Session) -> Fallible<Option<String>> {
-    if let Some(ref image) = session.project_platform() {
-        return Ok(Some(image.node.runtime.to_string()));
-    }
-    Ok(None)
+fn project_node_version(session: &Session) -> Option<String> {
+    session.project_platform().map(|platform| platform.node_runtime.to_string())
 }
 
 fn user_node_version(session: &Session) -> Option<String> {
-    session.user_node().clone().map(|nv| nv.runtime.to_string())
+    session.user_platform().map(|platform| platform.node_runtime.to_string())
 }

--- a/tests/acceptance/notion_pin.rs
+++ b/tests/acceptance/notion_pin.rs
@@ -8,6 +8,18 @@ const BASIC_PACKAGE_JSON: &'static str = r#"{
   "name": "test-package"
 }"#;
 
+fn package_json_with_pinned_node(node: &str) -> String {
+    format!(
+        r#"{{
+  "name": "test-package",
+  "toolchain": {{
+    "node": "{}"
+  }}
+}}"#,
+        node
+    )
+}
+
 fn package_json_with_pinned_node_npm(node: &str, npm: &str) -> String {
     format!(
         r#"{{
@@ -19,6 +31,19 @@ fn package_json_with_pinned_node_npm(node: &str, npm: &str) -> String {
 }}"#,
         node,
         npm
+    )
+}
+
+fn package_json_with_pinned_node_yarn(node_version: &str, yarn_version: &str) -> String {
+    format!(
+        r#"{{
+  "name": "test-package",
+  "toolchain": {{
+    "node": "{}",
+    "yarn": "{}"
+  }}
+}}"#,
+        node_version, yarn_version
     )
 }
 
@@ -168,7 +193,7 @@ fn pin_node() {
 
     assert_eq!(
         s.read_package_json(),
-        package_json_with_pinned_node_npm("6.19.62", "3.10.1066"),
+        package_json_with_pinned_node("6.19.62"),
     )
 }
 
@@ -189,7 +214,29 @@ fn pin_node_latest() {
 
     assert_eq!(
         s.read_package_json(),
-        package_json_with_pinned_node_npm("10.99.1040", "6.2.26"),
+        package_json_with_pinned_node("10.99.1040"),
+    )
+}
+
+#[test]
+fn pin_node_removes_npm() {
+    // Pinning Node will set the pinned version of npm to the default for that version, so it will be omitted
+    let s = sandbox()
+        .package_json(&package_json_with_pinned_node_npm("6.19.62", "3.9.1"))
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.notion("pin node 8"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Pinned node to version 8.9.10 in package.json")
+    );
+
+    assert_eq!(
+        s.read_package_json(),
+        package_json_with_pinned_node("8.9.10"),
     )
 }
 
@@ -214,7 +261,7 @@ fn pin_yarn_no_node() {
 #[test]
 fn pin_yarn() {
     let s = sandbox()
-        .package_json(&package_json_with_pinned_node_npm("1.2.3", "1.0.7"))
+        .package_json(&package_json_with_pinned_node("1.2.3"))
         .yarn_available_versions(YARN_VERSION_INFO)
         .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
         .build();
@@ -228,14 +275,14 @@ fn pin_yarn() {
 
     assert_eq!(
         s.read_package_json(),
-        package_json_with_pinned_node_npm_yarn("1.2.3", "1.0.7", "1.4.159"),
+        package_json_with_pinned_node_yarn("1.2.3", "1.4.159"),
     )
 }
 
 #[test]
 fn pin_yarn_latest() {
     let s = sandbox()
-        .package_json(&package_json_with_pinned_node_npm("1.2.3", "1.0.7"))
+        .package_json(&package_json_with_pinned_node("1.2.3"))
         .yarn_latest("1.2.42")
         .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
         .build();
@@ -249,14 +296,14 @@ fn pin_yarn_latest() {
 
     assert_eq!(
         s.read_package_json(),
-        package_json_with_pinned_node_npm_yarn("1.2.3", "1.0.7", "1.2.42"),
+        package_json_with_pinned_node_yarn("1.2.3", "1.2.42"),
     )
 }
 
 #[test]
 fn pin_yarn_missing_release() {
     let s = sandbox()
-        .package_json(&package_json_with_pinned_node_npm("1.2.3", "1.0.7"))
+        .package_json(&package_json_with_pinned_node("1.2.3"))
         .mock_not_found()
         .build();
 
@@ -269,6 +316,28 @@ fn pin_yarn_missing_release() {
 
     assert_eq!(
         s.read_package_json(),
-        package_json_with_pinned_node_npm("1.2.3", "1.0.7"),
+        package_json_with_pinned_node("1.2.3"),
     )
+}
+
+#[test]
+fn pin_yarn_leaves_npm() {
+    let s = sandbox()
+        .package_json(&package_json_with_pinned_node_npm("1.2.3", "3.4.5"))
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.notion("pin yarn 1.4"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Pinned yarn to version 1.4.159 in package.json")
+    );
+
+    assert_eq!(
+        s.read_package_json(),
+        package_json_with_pinned_node_npm_yarn("1.2.3", "3.4.5", "1.4.159"),
+    )
+
 }


### PR DESCRIPTION
Closes #208 

* Updated `PlatformSpec` to hold `node_runtime` and `npm` separately.
* Switched `PlatformSpec::npm` to be an `Option`.
* Included logic in `PlatformSpec::checkout()` that determines the default version of npm when creating an `Image`.
* Prevent writing of `npm` to `package.json` if it is the default for the selected `node` version when pinning the `node` version (currently that is always the case, so `npm` will never be written).
* Also did some minor refactors, removing a `Result` wrapper around `Session::current_platform` and related functions, since all code paths would return `Ok`