### PR TITLE
Allow Commands to run even if configuration is invalid

### DIFF
--- a/crates/notion-core/src/event.rs
+++ b/crates/notion-core/src/event.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use monitor::LazyMonitor;
-use notion_fail::{ExitCode, Fallible, NotionError};
+use notion_fail::{ExitCode, NotionError};
 use plugin::Publish;
 use session::ActivityKind;
 
@@ -95,11 +95,11 @@ pub struct EventLog {
 
 impl EventLog {
     /// Constructs a new 'EventLog'
-    pub fn new() -> Fallible<EventLog> {
-        Ok(EventLog {
+    pub fn new() -> Self {
+        EventLog {
             events: Vec::new(),
             monitor: LazyMonitor::new(),
-        })
+        }
     }
 
     pub fn add_event_start(&mut self, activity_kind: ActivityKind) {
@@ -149,7 +149,7 @@ pub mod tests {
 
     #[test]
     fn test_adding_events() {
-        let mut event_log = EventLog::new().expect("Could not create event log");
+        let mut event_log = EventLog::new();
         assert_eq!(event_log.events.len(), 0);
 
         event_log.add_event_start(ActivityKind::Current);

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 use lazycell::LazyCell;
 
 use distro::node::NodeVersion;
-use manifest::Manifest;
 use manifest::serial;
+use manifest::Manifest;
 use notion_fail::{ExitCode, Fallible, NotionError, NotionFail, ResultExt};
 use platform::PlatformSpec;
 use semver::Version;
@@ -92,7 +92,9 @@ impl LazyProject {
     }
 
     pub fn get(&self) -> Fallible<Option<Rc<Project>>> {
-        let project = self.project.try_borrow_with(|| Project::for_current_dir())?;
+        let project = self
+            .project
+            .try_borrow_with(|| Project::for_current_dir())?;
         Ok(project.clone())
     }
 }
@@ -251,9 +253,13 @@ impl Project {
         let toolchain = serial::Image::new(
             node_version.runtime.to_string(),
             node_version.npm.to_string(),
-            self.manifest().yarn_str().clone());
+            self.manifest().yarn_str().clone(),
+        );
         Manifest::update_toolchain(toolchain, self.package_file())?;
-        println!("Pinned node to version {} in package.json", node_version.runtime);
+        println!(
+            "Pinned node to version {} in package.json",
+            node_version.runtime
+        );
         Ok(())
     }
 
@@ -261,8 +267,11 @@ impl Project {
     pub fn pin_yarn_in_toolchain(&self, yarn_version: Version) -> Fallible<()> {
         // update the toolchain yarn version
         if let Some(image) = self.manifest().platform() {
-            let toolchain =
-                serial::Image::new(image.node.runtime.to_string(), image.node.npm.to_string(), Some(yarn_version.to_string()));
+            let toolchain = serial::Image::new(
+                image.node.runtime.to_string(),
+                image.node.npm.to_string(),
+                Some(yarn_version.to_string()),
+            );
             Manifest::update_toolchain(toolchain, self.package_file())?;
             println!("Pinned yarn to version {} in package.json", yarn_version);
         } else {

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -104,7 +104,7 @@ impl Session {
             inventory: LazyInventory::new(),
             toolchain: LazyToolchain::new(),
             project: LazyProject::new(),
-            event_log: EventLog::new()?,
+            event_log: EventLog::new(),
         })
     }
 

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -98,14 +98,14 @@ pub struct Session {
 
 impl Session {
     /// Constructs a new `Session`.
-    pub fn new() -> Fallible<Session> {
-        Ok(Session {
+    pub fn new() -> Session {
+        Session {
             config: LazyConfig::new(),
             inventory: LazyInventory::new(),
             toolchain: LazyToolchain::new(),
             project: LazyProject::new(),
             event_log: EventLog::new(),
-        })
+        }
     }
 
     /// Produces a reference to the current Node project, if any.
@@ -322,13 +322,13 @@ pub mod tests {
     fn test_in_pinned_project() {
         let project_pinned = fixture_path("basic");
         env::set_current_dir(&project_pinned).expect("Could not set current directory");
-        let pinned_session = Session::new().expect("Couldn't create new Session");
+        let pinned_session = Session::new();
         let pinned_platform = pinned_session.project_platform().expect("Couldn't create Project");
         assert_eq!(pinned_platform.is_some(), true);
 
         let project_unpinned = fixture_path("no_toolchain");
         env::set_current_dir(&project_unpinned).expect("Could not set current directory");
-        let unpinned_session = Session::new().expect("Couldn't create new Session");
+        let unpinned_session = Session::new();
         let unpinned_platform = unpinned_session.project_platform().expect("Couldn't create Project");
         assert_eq!(unpinned_platform.is_none(), true);
     }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -4,10 +4,10 @@
 
 use std::rc::Rc;
 
-use inventory::{Inventory, LazyInventory};
 use config::{Config, LazyConfig};
-use distro::Fetched;
 use distro::node::NodeVersion;
+use distro::Fetched;
+use inventory::{Inventory, LazyInventory};
 use platform::PlatformSpec;
 use plugin::Publish;
 use project::{LazyProject, Project};
@@ -134,10 +134,7 @@ impl Session {
                 })));
             }
 
-            return Ok(Some(Rc::new(PlatformSpec {
-                node,
-                yarn: None,
-            })));
+            return Ok(Some(Rc::new(PlatformSpec { node, yarn: None })));
         }
         Ok(None)
     }
@@ -323,13 +320,17 @@ pub mod tests {
         let project_pinned = fixture_path("basic");
         env::set_current_dir(&project_pinned).expect("Could not set current directory");
         let pinned_session = Session::new();
-        let pinned_platform = pinned_session.project_platform().expect("Couldn't create Project");
+        let pinned_platform = pinned_session
+            .project_platform()
+            .expect("Couldn't create Project");
         assert_eq!(pinned_platform.is_some(), true);
 
         let project_unpinned = fixture_path("no_toolchain");
         env::set_current_dir(&project_unpinned).expect("Could not set current directory");
         let unpinned_session = Session::new();
-        let unpinned_platform = unpinned_session.project_platform().expect("Couldn't create Project");
+        let unpinned_platform = unpinned_session
+            .project_platform()
+            .expect("Couldn't create Project");
         assert_eq!(unpinned_platform.is_none(), true);
     }
 }

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -56,13 +56,7 @@ impl ToolUnimplementedError {
 /// Represents a command-line tool that Notion shims delegate to.
 pub trait Tool: Sized {
     fn launch() -> ! {
-        let mut session = match Session::new() {
-            Ok(session) => session,
-            Err(err) => {
-                display_error(&err);
-                ExitCode::ExecutionFailure.exit();
-            }
-        };
+        let mut session = Session::new();
 
         session.add_event_start(ActivityKind::Tool);
 

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -203,7 +203,7 @@ impl Tool for Binary {
         let exe = arg0(&mut args)?;
 
         // first try to use the project toolchain
-        if let Some(project) = session.project() {
+        if let Some(project) = session.project()? {
             // check if the executable is a direct dependency
             if project.has_direct_bin(&exe)? {
                 // use the full path to the file
@@ -211,7 +211,7 @@ impl Tool for Binary {
                 path_to_bin.push(&exe);
 
                 // if we're in a pinned project, use the project's platform.
-                if let Some(ref platform) = session.project_platform() {
+                if let Some(ref platform) = session.project_platform()? {
                     let image = platform.checkout(session)?;
                     return Ok(Self::from_components(
                         &path_to_bin.as_os_str(),
@@ -351,7 +351,7 @@ impl Tool for Yarn {
     /// Perform any tasks which must be run after the tool runs but before exiting.
     fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
         if let Ok(_) = maybe_status {
-            if let Some(project) = session.project() {
+            if let Ok(Some(project)) = session.project() {
                 let errors = project.autoshim();
 
                 for error in errors {
@@ -390,7 +390,7 @@ impl Tool for Npm {
 
     fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
         if let Ok(_) = maybe_status {
-            if let Some(project) = session.project() {
+            if let Ok(Some(project)) = session.project() {
                 let errors = project.autoshim();
 
                 for error in errors {

--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -281,13 +281,15 @@ fn arg0(args: &mut ArgsOs) -> Fallible<OsString> {
 }
 
 #[derive(Debug, Fail, NotionFail)]
-#[fail(display = r#"
+#[fail(
+    display = r#"
 No {} version selected.
 
 See `notion help pin` for help adding {} to a project toolchain.
 
 See `notion help install` for help adding {} to your personal toolchain."#,
-       tool, tool, tool)]
+    tool, tool, tool
+)]
 #[notion_fail(code = "NoVersionMatch")]
 struct NoSuchToolError {
     tool: String,
@@ -396,10 +398,13 @@ impl Tool for Npm {
 }
 
 #[derive(Debug, Fail, NotionFail)]
-#[fail(display = r#"
+#[fail(
+    display = r#"
 'npx' is only available with npm >= 5.2.0
 
-This project is configured to use version {} of npm."#, version)]
+This project is configured to use version {} of npm."#,
+    version
+)]
 #[notion_fail(code = "ExecutableNotFound")]
 struct NpxNotAvailableError {
     version: String,

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -258,7 +258,7 @@ impl Tool for Binary {
                 }
 
                 // otherwise use the user platform.
-                if let Some(ref platform) = session.user_platform() {
+                if let Some(ref platform) = session.user_platform()? {
                     let image = platform.checkout(session)?;
                     return Ok(Self::from_components(
                         &path_to_bin.as_os_str(),
@@ -275,7 +275,7 @@ impl Tool for Binary {
         }
 
         // next try to use the user toolchain
-        if let Some(ref platform) = session.user_platform() {
+        if let Some(ref platform) = session.user_platform()? {
             // use the full path to the binary
             // ISSUE (#160): Look up the platform image bound to the user tool.
             let image = platform.checkout(session)?;
@@ -344,7 +344,7 @@ impl Tool for Node {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform() {
+        if let Some(ref platform) = session.current_platform()? {
             let image = platform.checkout(session)?;
             Ok(Self::from_components(&exe, args, &image.path()?))
         } else {
@@ -369,7 +369,7 @@ impl Tool for Yarn {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform() {
+        if let Some(ref platform) = session.current_platform()? {
             let image = platform.checkout(session)?;
             Ok(Self::from_components(&exe, args, &image.path()?))
         } else {
@@ -407,7 +407,7 @@ impl Tool for Npm {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform() {
+        if let Some(ref platform) = session.current_platform()? {
             let image = platform.checkout(session)?;
             Ok(Self::from_components(&exe, args, &image.path()?))
         } else {
@@ -459,7 +459,7 @@ impl Tool for Npx {
 
         let mut args = args_os();
         let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform() {
+        if let Some(ref platform) = session.current_platform()? {
             let image = platform.checkout(session)?;
 
             // npx was only included with Node >= 8.2.0. If less than that, we should include a helpful error message

--- a/crates/notion-core/src/toolchain/mod.rs
+++ b/crates/notion-core/src/toolchain/mod.rs
@@ -116,4 +116,3 @@ impl Toolchain {
         Ok(())
     }
 }
-

--- a/crates/notion-core/src/toolchain/mod.rs
+++ b/crates/notion-core/src/toolchain/mod.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::Write;
 
+use lazycell::LazyCell;
 use readext::ReadExt;
 use semver::Version;
 
@@ -13,12 +14,36 @@ use notion_fail::{Fallible, ResultExt};
 
 pub(crate) mod serial;
 
+/// Lazily loaded toolchain
+pub struct LazyToolchain {
+    toolchain: LazyCell<Toolchain>,
+}
+
+impl LazyToolchain {
+    /// Creates a new `LazyToolchain`
+    pub fn new() -> Self {
+        LazyToolchain {
+            toolchain: LazyCell::new(),
+        }
+    }
+
+    /// Forces loading of the toolchain and returns an immutable reference to it
+    pub fn get(&self) -> Fallible<&Toolchain> {
+        self.toolchain.try_borrow_with(|| Toolchain::current())
+    }
+
+    /// Forces loading of the toolchain and returns a mutable reference to it
+    pub fn get_mut(&mut self) -> Fallible<&mut Toolchain> {
+        self.toolchain.try_borrow_mut_with(|| Toolchain::current())
+    }
+}
+
 pub struct Toolchain {
     platform: Option<PlatformSpec>,
 }
 
 impl Toolchain {
-    pub fn current() -> Fallible<Toolchain> {
+    fn current() -> Fallible<Toolchain> {
         let path = user_platform_file()?;
         let src = touch(&path)?.read_into_string().unknown()?;
         Ok(Toolchain {

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -67,7 +67,7 @@ Options:
                 Help::Command(CommandName::Current).run(session)?;
                 true
             }
-            Current::Project => project_node_version(&session)
+            Current::Project => project_node_version(&session)?
                 .map(|version| {
                     println!("v{}", version);
                 })
@@ -79,8 +79,8 @@ Options:
                 .is_some(),
             Current::All => {
                 let (project, user) = (
-                    project_node_version(&session),
-                    user_node_version(&session),
+                    project_node_version(&session)?,
+                    user_node_version(&session)?,
                 );
 
                 let user_active = project.is_none() && user.is_some();
@@ -109,10 +109,14 @@ Options:
     }
 }
 
-fn project_node_version(session: &Session) -> Option<String> {
-    session.project_platform().map(|platform| platform.node_runtime.to_string())
+fn project_node_version(session: &Session) -> Fallible<Option<String>> {
+    Ok(session
+        .project_platform()?
+        .map(|platform| platform.node_runtime.to_string()))
 }
 
-fn user_node_version(session: &Session) -> Option<String> {
-    session.user_platform().map(|platform| platform.node_runtime.to_string())
+fn user_node_version(session: &Session) -> Fallible<Option<String>> {
+    Ok(session
+        .user_platform()?
+        .map(|platform| platform.node_runtime.to_string()))
 }

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -110,7 +110,7 @@ Options:
 }
 
 fn project_node_version(session: &Session) -> Fallible<Option<String>> {
-    if let Some(ref image) = session.project_platform() {
+    if let Some(ref image) = session.project_platform()? {
         return Ok(Some(image.node.runtime.to_string()));
     }
     Ok(None)

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -3,8 +3,8 @@ use std::string::ToString;
 use notion_core::session::{ActivityKind, Session};
 use notion_fail::{ExitCode, Fallible, NotionFail};
 
-use Notion;
 use command::{Command, CommandName, Help};
+use Notion;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
@@ -117,5 +117,8 @@ fn project_node_version(session: &Session) -> Fallible<Option<String>> {
 }
 
 fn user_node_version(session: &Session) -> Fallible<Option<String>> {
-    Ok(session.user_node()?.clone().map(|nv| nv.runtime.to_string()))
+    Ok(session
+        .user_node()?
+        .clone()
+        .map(|nv| nv.runtime.to_string()))
 }

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -72,7 +72,7 @@ Options:
                     println!("v{}", version);
                 })
                 .is_some(),
-            Current::User => user_node_version(session)
+            Current::User => user_node_version(session)?
                 .map(|version| {
                     println!("v{}", version);
                 })
@@ -80,7 +80,7 @@ Options:
             Current::All => {
                 let (project, user) = (
                     project_node_version(&session)?,
-                    user_node_version(&session),
+                    user_node_version(&session)?,
                 );
 
                 let user_active = project.is_none() && user.is_some();
@@ -116,6 +116,6 @@ fn project_node_version(session: &Session) -> Fallible<Option<String>> {
     Ok(None)
 }
 
-fn user_node_version(session: &Session) -> Option<String> {
-    session.user_node().clone().map(|nv| nv.runtime.to_string())
+fn user_node_version(session: &Session) -> Fallible<Option<String>> {
+    Ok(session.user_node()?.clone().map(|nv| nv.runtime.to_string()))
 }

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -3,8 +3,8 @@ use notion_core::style::{display_error, display_unknown_error, ErrorContext};
 use notion_core::version::VersionSpec;
 use notion_fail::{ExitCode, Fallible, NotionFail};
 
-use Notion;
 use command::{Command, CommandName, Help};
+use Notion;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Args {
@@ -14,8 +14,10 @@ pub(crate) struct Args {
 
 // error message for using tools that are not node|yarn
 #[derive(Debug, Fail, NotionFail)]
-#[fail(display = "pinning tool '{}' not yet implemented - for now you can manually edit package.json",
-       name)]
+#[fail(
+    display = "pinning tool '{}' not yet implemented - for now you can manually edit package.json",
+    name
+)]
 #[notion_fail(code = "NotYetImplemented")]
 pub(crate) struct NoCustomPinError {
     pub(crate) name: String,

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -82,7 +82,7 @@ Options:
             Pin::Yarn(spec) => session.pin_yarn_version(&spec)?,
             Pin::Other { name, .. } => throw!(NoCustomPinError::new(name)),
         };
-        if let Some(project) = session.project() {
+        if let Some(project) = session.project()? {
             let errors = project.autoshim();
 
             for error in errors {

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -26,8 +26,10 @@ use notion_fail::{ExitCode, FailExt, Fallible, NotionError};
 
 #[cfg(feature = "notion-dev")]
 use command::Shim;
-use command::{Activate, Command, CommandName, Config, Current, Deactivate, Fetch, Help, Install,
-              Pin, Use, Version};
+use command::{
+    Activate, Command, CommandName, Config, Current, Deactivate, Fetch, Help, Install, Pin, Use,
+    Version,
+};
 use error::{CliParseError, CommandUnimplementedError, DocoptExt, NotionErrorExt};
 
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/src/notion.rs
+++ b/src/notion.rs
@@ -205,13 +205,7 @@ fn display_error_and_usage(err: &NotionError) {
 
 /// The entry point for the `notion` CLI.
 pub fn main() {
-    let mut session = match Session::new() {
-        Ok(session) => session,
-        Err(err) => {
-            display_error_and_usage(&err);
-            ExitCode::UnknownError.exit();
-        }
-    };
+    let mut session = Session::new();
 
     session.add_event_start(ActivityKind::Notion);
 


### PR DESCRIPTION
Closes #236 

Description
-----
Some commands that didn't need to know anything about the platform or configuration (e.g. `notion activate` and `notion deactivate`) were failing when being run from a folder where there was a malformed `toolchain` entry. Additionally, these commands would fail if there was something wrong with the user toolchain, despite the fact that they didn't use that toolchain in any way.

The root cause of this was that `Session::new()` was `Fallible`, and all commands required a `Session` to start processing. If creating the `Session` failed, then the entire command would fail.

Changed
-----
* Removed unnecessary `Fallible` return type for `EventLog`, as it could never fail and wasn't calling anything that could fail.
* Added Lazy Loading pattern to `Project` and `Toolchain`, so that they will only fail when they are accessed, instead of when they are created.
* Updated `Session::new()` to always return a Session, filled with Lazy Loaded members that will only fail when they are needed.

Tested
-----
* Verified that running `notion deactivate` and `notion activate` from within a project that had a malformed `toolchain` entry would still work as expected.