### PR TITLE
Ensure prerelease npm still allow npx usage

### DIFF
--- a/crates/notion-core/src/tool.rs
+++ b/crates/notion-core/src/tool.rs
@@ -420,9 +420,10 @@ impl Tool for Npx {
         if let Some(ref platform) = session.current_platform()? {
             let image = platform.checkout(session)?;
 
-            // npx was only included with Node >= 8.2.0. If less than that, we should include a helpful error message
-            let required_node = VersionSpec::parse_requirements(">= 5.2.0")?;
-            if required_node.matches(&image.node.npm) {
+            // npx was only with npm 5.2.0 and higher. If the npm version is less than that, we
+            // should include a helpful error message
+            let required_npm = VersionSpec::parse_version("5.2.0")?;
+            if image.node.npm >= required_npm {
                 Ok(Self::from_components(&exe, args, &image.path()?))
             } else {
                 throw!(NpxNotAvailableError {


### PR DESCRIPTION
Using `VersionReq::matches` will (intentionally) not match prerelease versions. Instead you must compare via `>=`.

Fixes https://github.com/notion-cli/notion/issues/238