### PR TITLE
Intercept Global Installs from npm and Yarn

### DIFF
--- a/crates/notion-core/src/env.rs
+++ b/crates/notion-core/src/env.rs
@@ -3,6 +3,8 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
+pub const UNSAFE_GLOBAL: &'static str = "NOTION_UNSAFE_GLOBAL";
+
 pub(crate) fn shell_name() -> Option<String> {
     env::var_os("NOTION_SHELL").map(|s| s.to_string_lossy().into_owned())
 }

--- a/crates/notion-core/src/tool/binary.rs
+++ b/crates/notion-core/src/tool/binary.rs
@@ -1,0 +1,99 @@
+use std::env::{args_os, ArgsOs};
+use std::ffi::OsStr;
+use std::process::Command;
+
+use super::{arg0, command_for, NoSuchToolError, Tool};
+use path;
+use session::{ActivityKind, Session};
+
+use notion_fail::{ExitCode, Fallible, NotionFail};
+
+/// Represents a delegated binary executable.
+pub struct Binary(Command);
+
+impl Tool for Binary {
+    fn new(session: &mut Session) -> Fallible<Self> {
+        session.add_event_start(ActivityKind::Binary);
+
+        let mut args = args_os();
+        let exe = arg0(&mut args)?;
+
+        // first try to use the project toolchain
+        if let Some(project) = session.project()? {
+            // check if the executable is a direct dependency
+            if project.has_direct_bin(&exe)? {
+                // use the full path to the file
+                let mut path_to_bin = project.local_bin_dir();
+                path_to_bin.push(&exe);
+
+                // if we're in a pinned project, use the project's platform.
+                if let Some(ref platform) = session.project_platform()? {
+                    let image = platform.checkout(session)?;
+                    return Ok(Self::from_components(
+                        &path_to_bin.as_os_str(),
+                        args,
+                        &image.path()?,
+                    ));
+                }
+
+                // otherwise use the user platform.
+                if let Some(ref platform) = session.user_platform()? {
+                    let image = platform.checkout(session)?;
+                    return Ok(Self::from_components(
+                        &path_to_bin.as_os_str(),
+                        args,
+                        &image.path()?,
+                    ));
+                }
+
+                // if there's no user platform selected, fail.
+                throw!(NoSuchToolError {
+                    tool: "Node".to_string()
+                });
+            }
+        }
+
+        // next try to use the user toolchain
+        if let Some(ref platform) = session.user_platform()? {
+            // use the full path to the binary
+            // ISSUE (#160): Look up the platform image bound to the user tool.
+            let image = platform.checkout(session)?;
+            let node_str = image.node.runtime.to_string();
+            let npm_str = image.node.npm.to_string();
+            let mut third_p_bin_dir = path::node_image_3p_bin_dir(&node_str, &npm_str)?;
+            third_p_bin_dir.push(&exe);
+            return Ok(Self::from_components(
+                &third_p_bin_dir.as_os_str(),
+                args,
+                &image.path()?,
+            ));
+        };
+
+        // at this point, there is no project or user toolchain
+        // the user is executing a Notion shim that doesn't have a way to execute it
+        throw!(NoToolChainError::for_shim(
+            exe.to_string_lossy().to_string()
+        ));
+    }
+
+    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
+        Binary(command_for(exe, args, path_var))
+    }
+
+    fn command(self) -> Command {
+        self.0
+    }
+}
+
+#[derive(Debug, Fail, NotionFail)]
+#[fail(display = "No toolchain available to run shim {}", shim_name)]
+#[notion_fail(code = "ExecutionFailure")]
+pub(crate) struct NoToolChainError {
+    shim_name: String,
+}
+
+impl NoToolChainError {
+    pub(crate) fn for_shim(shim_name: String) -> NoToolChainError {
+        NoToolChainError { shim_name }
+    }
+}

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -8,6 +8,7 @@ use std::marker::Sized;
 use std::path::Path;
 use std::process::{Command, ExitStatus};
 
+use env::UNSAFE_GLOBAL;
 use notion_fail::{ExitCode, FailExt, Fallible, NotionError, NotionFail};
 use session::{ActivityKind, Session};
 use style;
@@ -198,13 +199,11 @@ struct NoSuchToolError {
 #[fail(display = r#"
 Global package installs are not recommended.
 
-Consider using `notion install` to add a package to your toolchain (see `notion help install for more info).
-
-Set the NOTION_ALLOW_GLOBAL environment variable to install anyway."#)]
+Consider using `notion install` to add a package to your toolchain (see `notion help install` for more info)."#)]
 #[notion_fail(code = "InvalidArguments")]
 struct NoGlobalInstallError;
 
 fn intercept_global_installs() -> bool {
-    // We should only intercept global installs if the NOTION_ALLOW_GLOBAL variable is not set
-    env::var_os("NOTION_ALLOW_GLOBAL").is_none()
+    // We should only intercept global installs if the NOTION_UNSAFE_GLOBAL variable is not set
+    env::var_os(UNSAFE_GLOBAL).is_none()
 }

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -1,6 +1,6 @@
 //! Traits and types for executing command-line tools.
 
-use std::env::{args_os, ArgsOs};
+use std::env::ArgsOs;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io;
@@ -9,10 +9,23 @@ use std::path::Path;
 use std::process::{Command, ExitStatus};
 
 use notion_fail::{ExitCode, FailExt, Fallible, NotionError, NotionFail};
-use path;
 use session::{ActivityKind, Session};
 use style;
 use version::VersionSpec;
+
+mod binary;
+mod node;
+mod npm;
+mod npx;
+mod script;
+mod yarn;
+
+pub use self::binary::Binary;
+pub use self::node::Node;
+pub use self::npm::Npm;
+pub use self::npx::Npx;
+pub use self::script::Script;
+pub use self::yarn::Yarn;
 
 fn display_error(err: &NotionError) {
     if err.is_user_friendly() {
@@ -85,17 +98,6 @@ impl BinaryExecError {
     }
 }
 
-#[derive(Debug, Fail, NotionFail)]
-#[fail(display = "this tool is not yet implemented")]
-#[notion_fail(code = "ExecutableNotFound")]
-pub(crate) struct ToolUnimplementedError;
-
-impl ToolUnimplementedError {
-    pub(crate) fn new() -> Self {
-        ToolUnimplementedError
-    }
-}
-
 /// Represents a command-line tool that Notion shims delegate to.
 pub trait Tool: Sized {
     fn launch() -> ! {
@@ -153,157 +155,11 @@ pub trait Tool: Sized {
     }
 }
 
-/// Represents a delegated script.
-pub struct Script(Command);
-
-/// Represents a delegated binary executable.
-pub struct Binary(Command);
-
-/// Represents a Node executable.
-pub struct Node(Command);
-
-/// Represents a `npm` executable.
-pub struct Npm(Command);
-
-/// Represents a `npx` executable.
-pub struct Npx(Command);
-
-/// Represents a Yarn executable.
-pub struct Yarn(Command);
-
-#[cfg(windows)]
-impl Tool for Script {
-    fn new(_session: &mut Session) -> Fallible<Self> {
-        throw!(ToolUnimplementedError::new())
-    }
-
-    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
-        // The best way to launch a script in Windows is to use `cmd.exe`
-        // as the executable and pass `"/C"` followed by the name of the
-        // script and then its arguments. Unfortunately, the docs aren't
-        // super clear about this, but see the discussion at:
-        //
-        //     https://github.com/rust-lang/rust/issues/42791
-        let mut command = Command::new("cmd.exe");
-        command.arg("/C");
-        command.arg(exe);
-        command.args(args);
-        command.env("PATH", path_var);
-        Script(command)
-    }
-
-    fn command(self) -> Command {
-        self.0
-    }
-}
-
 fn command_for(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Command {
     let mut command = Command::new(exe);
     command.args(args);
     command.env("PATH", path_var);
     command
-}
-
-#[cfg(unix)]
-impl Tool for Script {
-    fn new(_session: &mut Session) -> Fallible<Self> {
-        throw!(ToolUnimplementedError::new())
-    }
-
-    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
-        Script(command_for(exe, args, path_var))
-    }
-
-    fn command(self) -> Command {
-        self.0
-    }
-}
-
-#[derive(Debug, Fail, NotionFail)]
-#[fail(display = "No toolchain available to run shim {}", shim_name)]
-#[notion_fail(code = "ExecutionFailure")]
-pub(crate) struct NoToolChainError {
-    shim_name: String,
-}
-
-impl NoToolChainError {
-    pub(crate) fn for_shim(shim_name: String) -> NoToolChainError {
-        NoToolChainError { shim_name }
-    }
-}
-
-impl Tool for Binary {
-    fn new(session: &mut Session) -> Fallible<Self> {
-        session.add_event_start(ActivityKind::Binary);
-
-        let mut args = args_os();
-        let exe = arg0(&mut args)?;
-
-        // first try to use the project toolchain
-        if let Some(project) = session.project()? {
-            // check if the executable is a direct dependency
-            if project.has_direct_bin(&exe)? {
-                // use the full path to the file
-                let mut path_to_bin = project.local_bin_dir();
-                path_to_bin.push(&exe);
-
-                // if we're in a pinned project, use the project's platform.
-                if let Some(ref platform) = session.project_platform()? {
-                    let image = platform.checkout(session)?;
-                    return Ok(Self::from_components(
-                        &path_to_bin.as_os_str(),
-                        args,
-                        &image.path()?,
-                    ));
-                }
-
-                // otherwise use the user platform.
-                if let Some(ref platform) = session.user_platform()? {
-                    let image = platform.checkout(session)?;
-                    return Ok(Self::from_components(
-                        &path_to_bin.as_os_str(),
-                        args,
-                        &image.path()?,
-                    ));
-                }
-
-                // if there's no user platform selected, fail.
-                throw!(NoSuchToolError {
-                    tool: "Node".to_string()
-                });
-            }
-        }
-
-        // next try to use the user toolchain
-        if let Some(ref platform) = session.user_platform()? {
-            // use the full path to the binary
-            // ISSUE (#160): Look up the platform image bound to the user tool.
-            let image = platform.checkout(session)?;
-            let node_str = image.node.runtime.to_string();
-            let npm_str = image.node.npm.to_string();
-            let mut third_p_bin_dir = path::node_image_3p_bin_dir(&node_str, &npm_str)?;
-            third_p_bin_dir.push(&exe);
-            return Ok(Self::from_components(
-                &third_p_bin_dir.as_os_str(),
-                args,
-                &image.path()?,
-            ));
-        };
-
-        // at this point, there is no project or user toolchain
-        // the user is executing a Notion shim that doesn't have a way to execute it
-        throw!(NoToolChainError::for_shim(
-            exe.to_string_lossy().to_string()
-        ));
-    }
-
-    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
-        Binary(command_for(exe, args, path_var))
-    }
-
-    fn command(self) -> Command {
-        self.0
-    }
 }
 
 #[derive(Fail, Debug)]
@@ -336,155 +192,4 @@ See `notion help install` for help adding {} to your personal toolchain."#,
 #[notion_fail(code = "NoVersionMatch")]
 struct NoSuchToolError {
     tool: String,
-}
-
-impl Tool for Node {
-    fn new(session: &mut Session) -> Fallible<Self> {
-        session.add_event_start(ActivityKind::Node);
-
-        let mut args = args_os();
-        let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
-            let image = platform.checkout(session)?;
-            Ok(Self::from_components(&exe, args, &image.path()?))
-        } else {
-            throw!(NoSuchToolError {
-                tool: "Node".to_string()
-            });
-        }
-    }
-
-    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
-        Node(command_for(exe, args, path_var))
-    }
-
-    fn command(self) -> Command {
-        self.0
-    }
-}
-
-impl Tool for Yarn {
-    fn new(session: &mut Session) -> Fallible<Self> {
-        session.add_event_start(ActivityKind::Yarn);
-
-        let mut args = args_os();
-        let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
-            let image = platform.checkout(session)?;
-            Ok(Self::from_components(&exe, args, &image.path()?))
-        } else {
-            throw!(NoSuchToolError {
-                tool: "Yarn".to_string()
-            });
-        }
-    }
-
-    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
-        Yarn(command_for(exe, args, path_var))
-    }
-
-    fn command(self) -> Command {
-        self.0
-    }
-
-    /// Perform any tasks which must be run after the tool runs but before exiting.
-    fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
-        if let Ok(_) = maybe_status {
-            if let Ok(Some(project)) = session.project() {
-                let errors = project.autoshim();
-
-                for error in errors {
-                    display_error(&error);
-                }
-            }
-        }
-    }
-}
-
-impl Tool for Npm {
-    fn new(session: &mut Session) -> Fallible<Self> {
-        session.add_event_start(ActivityKind::Npm);
-
-        let mut args = args_os();
-        let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
-            let image = platform.checkout(session)?;
-            Ok(Self::from_components(&exe, args, &image.path()?))
-        } else {
-            // Using 'Node' as the tool name since the npm version is derived from the Node version
-            // This way the error message will prompt the user to add 'Node' to their toolchain, instead of 'npm'
-            throw!(NoSuchToolError {
-                tool: "Node".to_string()
-            });
-        }
-    }
-
-    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
-        Npm(command_for(exe, args, path_var))
-    }
-
-    fn command(self) -> Command {
-        self.0
-    }
-
-    fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
-        if let Ok(_) = maybe_status {
-            if let Ok(Some(project)) = session.project() {
-                let errors = project.autoshim();
-
-                for error in errors {
-                    display_error(&error);
-                }
-            }
-        }
-    }
-}
-
-#[derive(Debug, Fail, NotionFail)]
-#[fail(
-    display = r#"
-'npx' is only available with npm >= 5.2.0
-
-This project is configured to use version {} of npm."#,
-    version
-)]
-#[notion_fail(code = "ExecutableNotFound")]
-struct NpxNotAvailableError {
-    version: String,
-}
-
-impl Tool for Npx {
-    fn new(session: &mut Session) -> Fallible<Self> {
-        session.add_event_start(ActivityKind::Npx);
-
-        let mut args = args_os();
-        let exe = arg0(&mut args)?;
-        if let Some(ref platform) = session.current_platform()? {
-            let image = platform.checkout(session)?;
-
-            // npx was only included with Node >= 8.2.0. If less than that, we should include a helpful error message
-            let required_node = VersionSpec::parse_requirements(">= 5.2.0")?;
-            if required_node.matches(&image.node.npm) {
-                Ok(Self::from_components(&exe, args, &image.path()?))
-            } else {
-                throw!(NpxNotAvailableError {
-                    version: image.node.npm.to_string()
-                });
-            }
-        } else {
-            // Using 'Node' as the tool name since the npx version is derived from the Node version
-            // This way the error message will prompt the user to add 'Node' to their toolchain, instead of 'npx'
-            throw!(NoSuchToolError {
-                tool: "Node".to_string()
-            });
-        }
-    }
-
-    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
-        Npx(command_for(exe, args, path_var))
-    }
-
-    fn command(self) -> Command {
-        self.0
-    }
 }

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -1,6 +1,6 @@
 //! Traits and types for executing command-line tools.
 
-use std::env::ArgsOs;
+use std::env::{self, ArgsOs};
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io;
@@ -192,4 +192,19 @@ See `notion help install` for help adding {} to your personal toolchain."#,
 #[notion_fail(code = "NoVersionMatch")]
 struct NoSuchToolError {
     tool: String,
+}
+
+#[derive(Debug, Fail, NotionFail)]
+#[fail(display = r#"
+Global package installs are not recommended.
+
+Consider using `notion install` to add a package to your toolchain (see `notion help install for more info).
+
+Set the NOTION_ALLOW_GLOBAL environment variable to install anyway."#)]
+#[notion_fail(code = "NoVersionMatch")]
+struct NoGlobalInstallError;
+
+fn intercept_global_installs() -> bool {
+    // We should only intercept global installs if the NOTION_ALLOW_GLOBAL variable is not set
+    env::var_os("NOTION_ALLOW_GLOBAL").is_none()
 }

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -201,7 +201,7 @@ Global package installs are not recommended.
 Consider using `notion install` to add a package to your toolchain (see `notion help install for more info).
 
 Set the NOTION_ALLOW_GLOBAL environment variable to install anyway."#)]
-#[notion_fail(code = "NoVersionMatch")]
+#[notion_fail(code = "InvalidArguments")]
 struct NoGlobalInstallError;
 
 fn intercept_global_installs() -> bool {

--- a/crates/notion-core/src/tool/node.rs
+++ b/crates/notion-core/src/tool/node.rs
@@ -1,0 +1,36 @@
+use std::env::{args_os, ArgsOs};
+use std::ffi::OsStr;
+use std::process::Command;
+
+use super::{arg0, command_for, NoSuchToolError, Tool};
+use session::{ActivityKind, Session};
+
+use notion_fail::Fallible;
+
+/// Represents a Node executable.
+pub struct Node(Command);
+
+impl Tool for Node {
+    fn new(session: &mut Session) -> Fallible<Self> {
+        session.add_event_start(ActivityKind::Node);
+
+        let mut args = args_os();
+        let exe = arg0(&mut args)?;
+        if let Some(ref platform) = session.current_platform()? {
+            let image = platform.checkout(session)?;
+            Ok(Self::from_components(&exe, args, &image.path()?))
+        } else {
+            throw!(NoSuchToolError {
+                tool: "Node".to_string()
+            });
+        }
+    }
+
+    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
+        Node(command_for(exe, args, path_var))
+    }
+
+    fn command(self) -> Command {
+        self.0
+    }
+}

--- a/crates/notion-core/src/tool/npm.rs
+++ b/crates/notion-core/src/tool/npm.rs
@@ -1,0 +1,51 @@
+use std::env::{args_os, ArgsOs};
+use std::ffi::OsStr;
+use std::io;
+use std::process::{Command, ExitStatus};
+
+use super::{arg0, command_for, display_error, NoSuchToolError, Tool};
+use session::{ActivityKind, Session};
+
+use notion_fail::Fallible;
+
+/// Represents a `npm` executable.
+pub struct Npm(Command);
+
+impl Tool for Npm {
+    fn new(session: &mut Session) -> Fallible<Self> {
+        session.add_event_start(ActivityKind::Npm);
+
+        let mut args = args_os();
+        let exe = arg0(&mut args)?;
+        if let Some(ref platform) = session.current_platform()? {
+            let image = platform.checkout(session)?;
+            Ok(Self::from_components(&exe, args, &image.path()?))
+        } else {
+            // Using 'Node' as the tool name since the npm version is derived from the Node version
+            // This way the error message will prompt the user to add 'Node' to their toolchain, instead of 'npm'
+            throw!(NoSuchToolError {
+                tool: "Node".to_string()
+            });
+        }
+    }
+
+    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
+        Npm(command_for(exe, args, path_var))
+    }
+
+    fn command(self) -> Command {
+        self.0
+    }
+
+    fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
+        if let Ok(_) = maybe_status {
+            if let Ok(Some(project)) = session.project() {
+                let errors = project.autoshim();
+
+                for error in errors {
+                    display_error(&error);
+                }
+            }
+        }
+    }
+}

--- a/crates/notion-core/src/tool/npx.rs
+++ b/crates/notion-core/src/tool/npx.rs
@@ -1,0 +1,61 @@
+use std::env::{args_os, ArgsOs};
+use std::ffi::OsStr;
+use std::process::Command;
+
+use super::{arg0, command_for, NoSuchToolError, Tool};
+use session::{ActivityKind, Session};
+use version::VersionSpec;
+
+use notion_fail::{ExitCode, Fallible, NotionFail};
+
+/// Represents a `npx` executable.
+pub struct Npx(Command);
+
+#[derive(Debug, Fail, NotionFail)]
+#[fail(
+    display = r#"
+'npx' is only available with npm >= 5.2.0
+
+This project is configured to use version {} of npm."#,
+    version
+)]
+#[notion_fail(code = "ExecutableNotFound")]
+struct NpxNotAvailableError {
+    version: String,
+}
+
+impl Tool for Npx {
+    fn new(session: &mut Session) -> Fallible<Self> {
+        session.add_event_start(ActivityKind::Npx);
+
+        let mut args = args_os();
+        let exe = arg0(&mut args)?;
+        if let Some(ref platform) = session.current_platform()? {
+            let image = platform.checkout(session)?;
+
+            // npx was only included with Node >= 8.2.0. If less than that, we should include a helpful error message
+            let required_node = VersionSpec::parse_requirements(">= 5.2.0")?;
+            if required_node.matches(&image.node.npm) {
+                Ok(Self::from_components(&exe, args, &image.path()?))
+            } else {
+                throw!(NpxNotAvailableError {
+                    version: image.node.npm.to_string()
+                });
+            }
+        } else {
+            // Using 'Node' as the tool name since the npx version is derived from the Node version
+            // This way the error message will prompt the user to add 'Node' to their toolchain, instead of 'npx'
+            throw!(NoSuchToolError {
+                tool: "Node".to_string()
+            });
+        }
+    }
+
+    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
+        Npx(command_for(exe, args, path_var))
+    }
+
+    fn command(self) -> Command {
+        self.0
+    }
+}

--- a/crates/notion-core/src/tool/script.rs
+++ b/crates/notion-core/src/tool/script.rs
@@ -1,0 +1,63 @@
+use std::env::ArgsOs;
+use std::ffi::OsStr;
+use std::process::Command;
+
+use super::{command_for, Tool};
+use session::Session;
+
+use notion_fail::{ExitCode, Fallible, NotionFail};
+
+/// Represents a delegated script.
+pub struct Script(Command);
+
+#[cfg(windows)]
+impl Tool for Script {
+    fn new(_session: &mut Session) -> Fallible<Self> {
+        throw!(ToolUnimplementedError::new())
+    }
+
+    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
+        // The best way to launch a script in Windows is to use `cmd.exe`
+        // as the executable and pass `"/C"` followed by the name of the
+        // script and then its arguments. Unfortunately, the docs aren't
+        // super clear about this, but see the discussion at:
+        //
+        //     https://github.com/rust-lang/rust/issues/42791
+        let mut command = Command::new("cmd.exe");
+        command.arg("/C");
+        command.arg(exe);
+        command.args(args);
+        command.env("PATH", path_var);
+        Script(command)
+    }
+
+    fn command(self) -> Command {
+        self.0
+    }
+}
+
+#[cfg(unix)]
+impl Tool for Script {
+    fn new(_session: &mut Session) -> Fallible<Self> {
+        throw!(ToolUnimplementedError::new())
+    }
+
+    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
+        Script(command_for(exe, args, path_var))
+    }
+
+    fn command(self) -> Command {
+        self.0
+    }
+}
+
+#[derive(Debug, Fail, NotionFail)]
+#[fail(display = "this tool is not yet implemented")]
+#[notion_fail(code = "ExecutableNotFound")]
+pub(crate) struct ToolUnimplementedError;
+
+impl ToolUnimplementedError {
+    pub(crate) fn new() -> Self {
+        ToolUnimplementedError
+    }
+}

--- a/crates/notion-core/src/tool/yarn.rs
+++ b/crates/notion-core/src/tool/yarn.rs
@@ -1,0 +1,50 @@
+use std::env::{args_os, ArgsOs};
+use std::ffi::OsStr;
+use std::io;
+use std::process::{Command, ExitStatus};
+
+use super::{arg0, command_for, display_error, NoSuchToolError, Tool};
+use session::{ActivityKind, Session};
+
+use notion_fail::Fallible;
+
+/// Represents a Yarn executable.
+pub struct Yarn(Command);
+
+impl Tool for Yarn {
+    fn new(session: &mut Session) -> Fallible<Self> {
+        session.add_event_start(ActivityKind::Yarn);
+
+        let mut args = args_os();
+        let exe = arg0(&mut args)?;
+        if let Some(ref platform) = session.current_platform()? {
+            let image = platform.checkout(session)?;
+            Ok(Self::from_components(&exe, args, &image.path()?))
+        } else {
+            throw!(NoSuchToolError {
+                tool: "Yarn".to_string()
+            });
+        }
+    }
+
+    fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
+        Yarn(command_for(exe, args, path_var))
+    }
+
+    fn command(self) -> Command {
+        self.0
+    }
+
+    /// Perform any tasks which must be run after the tool runs but before exiting.
+    fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
+        if let Ok(_) = maybe_status {
+            if let Ok(Some(project)) = session.project() {
+                let errors = project.autoshim();
+
+                for error in errors {
+                    display_error(&error);
+                }
+            }
+        }
+    }
+}

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -2,6 +2,7 @@ use hamcrest2::core::Matcher;
 use support::sandbox::{sandbox, DistroMetadata, NodeFixture, YarnFixture};
 use test_support::matchers::execs;
 
+use notion_core::env::UNSAFE_GLOBAL;
 use notion_fail::ExitCode;
 
 cfg_if! {
@@ -81,6 +82,27 @@ fn npm_prevents_global_install() {
             .with_status(ExitCode::ExecutionFailure as i32)
             .with_stderr_contains("Global package installs are not recommended.")
     );
+
+    assert_that!(
+        s.npm("-g i ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+
+    assert_that!(
+        s.npm("add ember-cli --global"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+
+    assert_that!(
+        s.npm("isntall --global ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
 }
 
 #[test]
@@ -88,7 +110,7 @@ fn npm_allows_global_install_with_env_variable() {
     let s = sandbox()
         .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"}}"#)
         .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
-        .env("NOTION_ALLOW_GLOBAL", "1")
+        .env(UNSAFE_GLOBAL, "1")
         .build();
 
     // Since we are using a fixture for the Node version, the execution will still fail
@@ -115,6 +137,20 @@ fn yarn_prevents_global_add() {
             .with_status(ExitCode::ExecutionFailure as i32)
             .with_stderr_contains("Global package installs are not recommended.")
     );
+
+    assert_that!(
+        s.yarn("--verbose global add ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+
+    assert_that!(
+        s.yarn("global --verbose add ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
 }
 
 #[test]
@@ -123,7 +159,7 @@ fn yarn_allows_global_add_with_env_variable() {
         .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"},"yarn":"1.12.99"}"#)
         .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
         .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
-        .env("NOTION_ALLOW_GLOBAL", "1")
+        .env(UNSAFE_GLOBAL, "1")
         .build();
 
     // Since we are using a fixture for the Yarn version, the execution will still fail

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -5,7 +5,11 @@ use test_support::matchers::execs;
 use notion_fail::ExitCode;
 
 cfg_if! {
+    // Note: Windows and Unix appear to handle a missing executable differently
+    // On Unix, it results in the Command::status() method returning an Err Result
+    // On Windows, it results in the Command::status() method returning Ok(3221225495)
     if #[cfg(target_os = "macos")] {
+        const MISSING_EXECUTABLE_EXIT_CODE: i32 = ExitCode::ExecutionFailure as i32;
         const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
             DistroMetadata {
                 version: "10.99.1040",
@@ -14,6 +18,7 @@ cfg_if! {
             },
         ];
     } else if #[cfg(target_os = "linux")] {
+        const MISSING_EXECUTABLE_EXIT_CODE: i32 = ExitCode::ExecutionFailure as i32;
         const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
             DistroMetadata {
                 version: "10.99.1040",
@@ -22,6 +27,7 @@ cfg_if! {
             },
         ];
     } else if #[cfg(target_os = "windows")] {
+        const MISSING_EXECUTABLE_EXIT_CODE: i32 = 3221225495;
         const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
             DistroMetadata {
                 version: "10.99.1040",
@@ -89,7 +95,7 @@ fn npm_allows_global_install_with_env_variable() {
     assert_that!(
         s.npm("i -g ember-cli"),
         execs()
-            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_status(MISSING_EXECUTABLE_EXIT_CODE)
             .with_stderr_does_not_contain("Global package installs are not recommended.")
     );
 }
@@ -124,7 +130,7 @@ fn yarn_allows_global_add_with_env_variable() {
     assert_that!(
         s.yarn("global add ember-cli"),
         execs()
-            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_status(MISSING_EXECUTABLE_EXIT_CODE)
             .with_stderr_does_not_contain("Global package installs are not recommended.")
     );
 }

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -27,7 +27,8 @@ cfg_if! {
             },
         ];
     } else if #[cfg(target_os = "windows")] {
-        const MISSING_EXECUTABLE_EXIT_CODE: i32 = 3221225495;
+        // Exit Code 3221225495 overflows to -1073741801 when comparing i32 codes
+        const MISSING_EXECUTABLE_EXIT_CODE: i32 = -1073741801;
         const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
             DistroMetadata {
                 version: "10.99.1040",

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -1,0 +1,130 @@
+use hamcrest2::core::Matcher;
+use support::sandbox::{sandbox, DistroMetadata, NodeFixture, YarnFixture};
+use test_support::matchers::execs;
+
+use notion_fail::ExitCode;
+
+cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x00280000),
+            },
+        ];
+    } else if #[cfg(target_os = "linux")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x00280000),
+            },
+        ];
+    } else if #[cfg(target_os = "windows")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 1096,
+                uncompressed_size: None,
+            },
+        ];
+    } else {
+        compile_error!("Unsupported target_os for tests (expected 'macos', 'linux', or 'windows').");
+    }
+}
+
+const YARN_VERSION_FIXTURES: [DistroMetadata; 1] = [DistroMetadata {
+    version: "1.12.99",
+    compressed_size: 178,
+    uncompressed_size: Some(0x00280000),
+}];
+
+#[test]
+fn npm_prevents_global_install() {
+    let s = sandbox()
+        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"}}"#)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.npm("install ember-cli --global"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+
+    assert_that!(
+        s.npm("i ember-cli --global"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+
+    assert_that!(
+        s.npm("install ember-cli -g"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+
+    assert_that!(
+        s.npm("i -g ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+}
+
+#[test]
+fn npm_allows_global_install_with_env_variable() {
+    let s = sandbox()
+        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"}}"#)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .env("NOTION_ALLOW_GLOBAL", "1")
+        .build();
+
+    // Since we are using a fixture for the Node version, the execution will still fail
+    // We just want to check that we didn't get the Global install error
+    assert_that!(
+        s.npm("i -g ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_does_not_contain("Global package installs are not recommended.")
+    );
+}
+
+#[test]
+fn yarn_prevents_global_add() {
+    let s = sandbox()
+        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"},"yarn":"1.12.99"}"#)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.yarn("global add ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("Global package installs are not recommended.")
+    );
+}
+
+#[test]
+fn yarn_allows_global_add_with_env_variable() {
+    let s = sandbox()
+        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"},"yarn":"1.12.99"}"#)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .env("NOTION_ALLOW_GLOBAL", "1")
+        .build();
+
+    // Since we are using a fixture for the Yarn version, the execution will still fail
+    // We just want to check that we didn't get the Global install error
+    assert_that!(
+        s.yarn("global add ember-cli"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_does_not_contain("Global package installs are not recommended.")
+    );
+}

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -17,6 +17,7 @@ mod support;
 
 // test files
 
+mod intercept_global_installs;
 mod notion_current;
 mod notion_deactivate;
 mod notion_pin;

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -477,6 +477,26 @@ impl Sandbox {
         p
     }
 
+    /// Create a `ProcessBuilder` to run the notion npm shim.
+    /// Arguments can be separated by spaces.
+    /// Example:
+    ///     assert_that(p.npm("install ember-cli"), execs());
+    pub fn npm(&self, cmd: &str) -> ProcessBuilder {
+        let mut p = self.process(&npm_exe());
+        split_and_add_args(&mut p, cmd);
+        p
+    }
+
+    /// Create a `ProcessBuilder` to run the notion yarn shim.
+    /// Arguments can be separated by spaces.
+    /// Example:
+    ///     assert_that(p.yarn("add ember-cli"), execs());
+    pub fn yarn(&self, cmd: &str) -> ProcessBuilder {
+        let mut p = self.process(&yarn_exe());
+        split_and_add_args(&mut p, cmd);
+        p
+    }
+
     pub fn read_package_json(&self) -> String {
         let package_file = package_json_file(self.root());
         read_file_to_string(package_file)
@@ -511,6 +531,14 @@ pub fn cargo_dir() -> PathBuf {
 
 fn notion_exe() -> PathBuf {
     cargo_dir().join(format!("notion{}", env::consts::EXE_SUFFIX))
+}
+
+fn npm_exe() -> PathBuf {
+    cargo_dir().join(format!("npm{}", env::consts::EXE_SUFFIX))
+}
+
+fn yarn_exe() -> PathBuf {
+    cargo_dir().join(format!("yarn{}", env::consts::EXE_SUFFIX))
 }
 
 fn split_and_add_args(p: &mut ProcessBuilder, s: &str) {


### PR DESCRIPTION
Closes #154 

Changes
-----
* Added checks to `npm` and `yarn` to intercept global installs and show an error message guiding the user to `notion install` for global packages.
* Allowed this behavior to be overridden by the `NOTION_ALLOW_GLOBAL` environment variable.
* Refactored the `Tool` implementations into their own files within the `tool` subdirectory, but re-exported them from the `tool` module so they can be accessed in the same manner as they were previously.

Notes
-----
* Yarn global installs will always start with `yarn global add`, since `global` is a separate command that must be the first argument, then `add` is the command to install a package.
* npm global installs have a few variations. The command, which is the first argument, can be either `install` or `i`, while the global argument can be anywhere in the argument list and can be either `-g` or `--global`.

Tested
-----
* Installed locally and verified that global installs are intercepted, unless the `NOTION_ALLOW_GLOBAL` environment variable is set.
* Added acceptance tests to verify the interception and non-interception when the env variable is set.