### PR TITLE
Bug fix in installer

### DIFF
--- a/dev/unix/install.sh.in
+++ b/dev/unix/install.sh.in
@@ -114,7 +114,7 @@ notion_check_existing_installation() {
       # inputs anything starting with "Y" or "y", proceed; otherwise, stop.
       if [[ -n "$input" ]] && [[ ! "$input" =~ ^[Yy] ]]; then
         notion_info 'Cancelling' "installation of Notion"
-        notion_exit 0
+        exit 0
       else
         # This is safe because we checked that `INSTALL_DIR` was set above, and
         # because if it were empty it would simply print an error here.
@@ -213,16 +213,11 @@ notion_warning() {
   notion_eprintf "$1"
 }
 
-notion_exit() {
-  notion_cleanup
-  exit "$1"
-}
-
 notion_install() {
   if [ -n "${NOTION_HOME-}" ] && ! [ -d "${NOTION_HOME}" ]; then
     notion_error "\$NOTION_HOME is set but is not a directory (${NOTION_HOME})."
     notion_eprintf "Please check your profile scripts and environment."
-    notion_exit 1
+    exit 1
   fi
 
   notion_info 'Checking' "for existing Notion installation"
@@ -252,25 +247,19 @@ notion_install() {
     notion_eprintf ''
     notion_eprintf "You can either create one of these and try again or add this to the appropriate file:"
     notion_eprintf "${PATH_STR}"
-    notion_exit 1
+    exit 1
   else
     if ! command grep -qc 'NOTION_HOME' "$NOTION_PROFILE"; then
       command printf "${PATH_STR}" >> "$NOTION_PROFILE"
     else
+      echo ''
       notion_warning "Your profile (${NOTION_PROFILE}) already mentions Notion and has not been changed."
       echo ''
     fi
   fi
 
   notion_info "Finished" 'installation. Open a new terminal to start using Notion!'
-  notion_exit 0
-}
-
-notion_cleanup() {
-  unset -f notion_unpack_notion notion_unpack_node notion_unpack_yarn notion_unpack_launchbin notion_unpack_launchscript notion_unpack_bash_launcher \
-    notion_install_dir notion_create_tree notion_create_binaries notion_try_profile notion_detect_profile \
-    notion_eprintf notion_info notion_error notion_warning \
-    notion_exit notion_install notion_cleanup
+  exit 0
 }
 
 notion_install

--- a/dev/unix/install.sh.in
+++ b/dev/unix/install.sh.in
@@ -99,7 +99,9 @@ notion_check_existing_installation() {
 
   if [[ -n "$INSTALL_DIR" && -x "$NOTION_BIN" ]]; then
     local PREV_NOTION_VERSION    
-    PREV_NOTION_VERSION="$($NOTION_BIN version)"
+    # Some 0.1.* builds would eagerly validate package.json even for benign commands,
+    # so just to be safe we'll ignore errors and consider those to be 0.1 as well.
+    PREV_NOTION_VERSION="$($NOTION_BIN version 2>/dev/null || echo 0.1)"
     if [[ "$PREV_NOTION_VERSION" == 0.1* ]]; then
       echo "        You have an earlier version of Notion installed, and the version"
       echo "        you are installing requires a fresh installation. (We will work"

--- a/dev/unix/install.sh.in
+++ b/dev/unix/install.sh.in
@@ -103,12 +103,12 @@ notion_check_existing_installation() {
     # so just to be safe we'll ignore errors and consider those to be 0.1 as well.
     PREV_NOTION_VERSION="$($NOTION_BIN version 2>/dev/null || echo 0.1)"
     if [[ "$PREV_NOTION_VERSION" == 0.1* ]]; then
-      echo "        You have an earlier version of Notion installed, and the version"
-      echo "        you are installing requires a fresh installation. (We will work"
-      echo "        to eventually eliminate the need for reinstallations as Notion"
-      echo "        stabilizes! Thanks for bearing with us.)"
       echo ""
-      read -rp "        Remove existing installation and continue? [Y/n] " input
+      notion_warning "Your Notion installation is out of date and needs to be replaced."
+      notion_warning "(We will work to stop requiring this as Notion stabilizes! Thanks"
+      notion_warning "for bearing with us.)"
+      echo ""
+      read -rp "Remove existing installation and continue? [Y/n] " input
 
       # Empty input is the default/"yes" choice; if the user inputs *nothing* or
       # inputs anything starting with "Y" or "y", proceed; otherwise, stop.
@@ -211,7 +211,6 @@ notion_error() {
 notion_warning() {
   command printf '\033[1;33mWarning\033[0m: ' 1>&2
   notion_eprintf "$1"
-  notion_eprintf ''
 }
 
 notion_exit() {
@@ -259,6 +258,7 @@ notion_install() {
       command printf "${PATH_STR}" >> "$NOTION_PROFILE"
     else
       notion_warning "Your profile (${NOTION_PROFILE}) already mentions Notion and has not been changed."
+      echo ''
     fi
   fi
 


### PR DESCRIPTION
- Hide any failures during the `notion version` check and treat those as 0.1*.
- Also improved the reinstallation message style and copy: <img width="531" alt="image" src="https://user-images.githubusercontent.com/307871/52512855-fb822580-2bbb-11e9-9703-2e51f3f3ae02.png">
- Remove pointless cleanup logic from install script
