### PR TITLE
Multiple Linux builds

### DIFF
--- a/dev/unix/boot-install.sh
+++ b/dev/unix/boot-install.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# This is the bootstrap Unix installer served by `https://get.notionjs.com`.
+# Its responsibility is to query the system to determine what OS (and in the
+# case of Linux, what OpenSSL version) the system has, and then proceed to
+# fetch and install the appropriate build of Notion.
+
 notion_get_latest_release() {
   curl --silent https://www.notionjs.com/latest-version
 }
@@ -28,20 +33,29 @@ notion_warning() {
   notion_eprintf ''
 }
 
-notion_exit() {
-  notion_cleanup
-  exit $1
-}
-
-notion_cleanup() {
-  unset -f notion_get_latest_release notion_eprintf notion_info notion_error notion_warning notion_exit notion_cleanup
+# determines the major and minor version of OpenSSL on the system
+notion_get_openssl_version() {
+  local LIB
+  local FULLVERSION
+  local MAJOR
+  local MINOR
+  # By default, we'll guess OpenSSL 1.0.1.
+  LIB="$(openssl version 2>/dev/null || echo 'OpenSSL 1.0.1')"
+  FULLVERSION="$(echo $LIB | awk '{print $2;}')"
+  MAJOR="$(echo ${FULLVERSION} | cut -d. -f1)"
+  MINOR="$(echo ${FULLVERSION} | cut -d. -f2)"
+  echo "${MAJOR}.${MINOR}"
 }
 
 NOTION_LATEST_VERSION=$(notion_get_latest_release)
 
 case $(uname) in
     Linux)
-        NOTION_OS=linux
+        if [[ "$NOTION_LATEST_VERSION" == 0.1* ]]; then
+          NOTION_OS=linux
+        else
+          NOTION_OS="linux-openssl-$(notion_get_openssl_version)"
+        fi
         NOTION_PRETTY_OS=Linux
         ;;
     Darwin)
@@ -50,7 +64,7 @@ case $(uname) in
         ;;
     *)
         notion_error "The current operating system does not appear to be supported by Notion."
-        notion_exit 1
+        exit 1
 esac
 
 NOTION_INSTALLER="https://github.com/notion-cli/notion/releases/download/v${NOTION_LATEST_VERSION}/notion-${NOTION_LATEST_VERSION}-${NOTION_OS}.sh"
@@ -60,4 +74,4 @@ notion_info 'Fetching' "${NOTION_PRETTY_OS} installer"
 curl -sSLf ${NOTION_INSTALLER} | bash
 STATUS=$?
 
-notion_exit $STATUS
+exit $STATUS

--- a/dev/unix/boot-install.sh
+++ b/dev/unix/boot-install.sh
@@ -36,11 +36,21 @@ notion_warning() {
 # determines the major and minor version of OpenSSL on the system
 notion_get_openssl_version() {
   local LIB
+  local LIBNAME
   local FULLVERSION
   local MAJOR
   local MINOR
+
   # By default, we'll guess OpenSSL 1.0.1.
   LIB="$(openssl version 2>/dev/null || echo 'OpenSSL 1.0.1')"
+
+  LIBNAME="$(echo $LIB | awk '{print $1;}')"
+
+  if [[ "$LIBNAME" != "OpenSSL" ]]; then
+    notion_error "Your system SSL library ($LIBNAME) is not currently supported on this OS."
+    #exit 1
+  fi
+
   FULLVERSION="$(echo $LIB | awk '{print $2;}')"
   MAJOR="$(echo ${FULLVERSION} | cut -d. -f1)"
   MINOR="$(echo ${FULLVERSION} | cut -d. -f2)"


### PR DESCRIPTION
Update the bootstrap installer (ie the https://get.notionjs.com script) to choose between multiple Linux builds for Notion >= 0.2, for different versions of OpenSSL.