### PR TITLE
Non-interactive installer

### DIFF
--- a/dev/unix/boot-install.sh
+++ b/dev/unix/boot-install.sh
@@ -24,13 +24,46 @@ notion_info() {
 notion_error() {
   command printf '\033[1;31mError\033[0m: ' 1>&2
   notion_eprintf "$1"
-  notion_eprintf ''
 }
 
 notion_warning() {
   command printf '\033[1;33mWarning\033[0m: ' 1>&2
   notion_eprintf "$1"
   notion_eprintf ''
+}
+
+notion_request() {
+  command printf "\033[1m$1\033[0m" 1>&2
+  notion_eprintf ''
+}
+
+notion_install_dir() {
+  printf %s "${NOTION_HOME:-"$HOME/.notion"}"
+}
+
+# Check for an existing installation that needs to be removed.
+notion_check_existing_installation() {
+  local INSTALL_DIR
+  INSTALL_DIR="$(notion_install_dir)"
+
+  local NOTION_BIN
+  NOTION_BIN="${INSTALL_DIR}/notion"
+
+  if [[ -n "$INSTALL_DIR" && -x "$NOTION_BIN" ]]; then
+    local PREV_NOTION_VERSION    
+    # Some 0.1.* builds would eagerly validate package.json even for benign commands,
+    # so just to be safe we'll ignore errors and consider those to be 0.1 as well.
+    PREV_NOTION_VERSION="$($NOTION_BIN version 2>/dev/null || echo 0.1)"
+    if [[ "$PREV_NOTION_VERSION" == 0.1* ]]; then
+      notion_eprintf ""
+      notion_error "Your Notion installation is out of date and can't be automatically upgraded."
+      notion_request "       Please delete or move $(notion_install_dir) and try again."
+      notion_eprintf ""
+      notion_eprintf "(We plan to implement automatic upgrades in the future. Thanks for bearing with us!)"
+      notion_eprintf ""
+      exit 1
+    fi
+  fi
 }
 
 # determines the major and minor version of OpenSSL on the system
@@ -48,7 +81,8 @@ notion_get_openssl_version() {
 
   if [[ "$LIBNAME" != "OpenSSL" ]]; then
     notion_error "Your system SSL library ($LIBNAME) is not currently supported on this OS."
-    #exit 1
+    notion_eprintf ""
+    exit 1
   fi
 
   FULLVERSION="$(echo $LIB | awk '{print $2;}')"
@@ -56,6 +90,9 @@ notion_get_openssl_version() {
   MINOR="$(echo ${FULLVERSION} | cut -d. -f2)"
   echo "${MAJOR}.${MINOR}"
 }
+
+notion_info 'Checking' "for existing Notion installation"
+notion_check_existing_installation
 
 NOTION_LATEST_VERSION=$(notion_get_latest_release)
 
@@ -74,6 +111,7 @@ case $(uname) in
         ;;
     *)
         notion_error "The current operating system does not appear to be supported by Notion."
+        notion_eprintf ""
         exit 1
 esac
 

--- a/dev/unix/install.sh.in
+++ b/dev/unix/install.sh.in
@@ -88,43 +88,6 @@ notion_create_tree() {
   mkdir -p "${INSTALL_DIR}"/tmp
 }
 
-# Safely handle an existing installation by removing it given user permission to
-# do so. If the user has no existing installation, this is a no-op.
-notion_check_existing_installation() {
-  local INSTALL_DIR
-  INSTALL_DIR="$(notion_install_dir)"
-
-  local NOTION_BIN
-  NOTION_BIN="${INSTALL_DIR}/notion"
-
-  if [[ -n "$INSTALL_DIR" && -x "$NOTION_BIN" ]]; then
-    local PREV_NOTION_VERSION    
-    # Some 0.1.* builds would eagerly validate package.json even for benign commands,
-    # so just to be safe we'll ignore errors and consider those to be 0.1 as well.
-    PREV_NOTION_VERSION="$($NOTION_BIN version 2>/dev/null || echo 0.1)"
-    if [[ "$PREV_NOTION_VERSION" == 0.1* ]]; then
-      echo ""
-      notion_warning "Your Notion installation is out of date and needs to be replaced."
-      notion_warning "(We will work to stop requiring this as Notion stabilizes! Thanks"
-      notion_warning "for bearing with us.)"
-      echo ""
-      read -rp "Remove existing installation and continue? [Y/n] " input
-
-      # Empty input is the default/"yes" choice; if the user inputs *nothing* or
-      # inputs anything starting with "Y" or "y", proceed; otherwise, stop.
-      if [[ -n "$input" ]] && [[ ! "$input" =~ ^[Yy] ]]; then
-        notion_info 'Cancelling' "installation of Notion"
-        exit 0
-      else
-        # This is safe because we checked that `INSTALL_DIR` was set above, and
-        # because if it were empty it would simply print an error here.
-        notion_info 'Removing' "previous installation of Notion"
-        rm -r "$INSTALL_DIR"
-      fi
-    fi
-  fi
-}
-
 notion_create_binaries() {
   local INSTALL_DIR
 
@@ -214,14 +177,11 @@ notion_warning() {
 }
 
 notion_install() {
-  if [ -n "${NOTION_HOME-}" ] && ! [ -d "${NOTION_HOME}" ]; then
+  if [ -n "${NOTION_HOME-}" ] && [ -e "${NOTION_HOME}" ] && ! [ -d "${NOTION_HOME}" ]; then
     notion_error "\$NOTION_HOME is set but is not a directory (${NOTION_HOME})."
     notion_eprintf "Please check your profile scripts and environment."
     exit 1
   fi
-
-  notion_info 'Checking' "for existing Notion installation"
-  notion_check_existing_installation
 
   notion_info 'Creating' "Notion directory tree ($(notion_install_dir))"
   notion_create_tree
@@ -252,9 +212,9 @@ notion_install() {
     if ! command grep -qc 'NOTION_HOME' "$NOTION_PROFILE"; then
       command printf "${PATH_STR}" >> "$NOTION_PROFILE"
     else
-      echo ''
+      notion_eprintf ''
       notion_warning "Your profile (${NOTION_PROFILE}) already mentions Notion and has not been changed."
-      echo ''
+      notion_eprintf ''
     fi
   fi
 


### PR DESCRIPTION
The installer can't be interactive since it's piped from curl. And it's not a good idea to be trying to get too clever about uninstalling (`rm` is scary).

So this PR changes the installer to make it a hard error if an old Notion installation is found. The check is moved into the bootstrap script to avoid users having to download the (quite big) installer twice.