### PR TITLE
Move preventing globals behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ universal-docs = ["notion-core/universal-docs"]
 mock-network = ["mockito", "notion-core/mock-network"]
 notion-dev = []
 smoke-tests = []
+intercept-globals = ["notion-core/intercept-globals"]
 
 [[bin]]
 name = "notion"

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 universal-docs = ["archive/universal-docs"]
 mock-network = ["mockito"]
+intercept-globals = []
 
 [dependencies]
 toml = "0.4"

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -207,6 +207,10 @@ Consider using `notion install` to add a package to your toolchain (see `notion 
 struct NoGlobalInstallError;
 
 fn intercept_global_installs() -> bool {
-    // We should only intercept global installs if the NOTION_UNSAFE_GLOBAL variable is not set
-    env::var_os(UNSAFE_GLOBAL).is_none()
+    if cfg!(feature = "intercept-globals") {
+        // We should only intercept global installs if the NOTION_UNSAFE_GLOBAL variable is not set
+        env::var_os(UNSAFE_GLOBAL).is_none()
+    } else {
+        false
+    }
 }

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -2,6 +2,7 @@ mod support;
 
 // test files
 
+#[cfg(feature = "intercept-globals")]
 mod intercept_global_installs;
 mod notion_current;
 mod notion_deactivate;


### PR DESCRIPTION
As noted in #272, we shouldn't intercept globals and direct the user to `notion install <package>` before the general package installs are working. Update to lock that behavior behind a feature flag (`intercept-globals`) until we get the package installs working.