### PR TITLE
Show progress bar when downloading Notion installer

### DIFF
--- a/dev/unix/boot-install.sh
+++ b/dev/unix/boot-install.sh
@@ -119,7 +119,7 @@ NOTION_INSTALLER="https://github.com/notion-cli/notion/releases/download/v${NOTI
 
 notion_info 'Fetching' "${NOTION_PRETTY_OS} installer"
 
-curl -sSLf ${NOTION_INSTALLER} | bash
+curl -#SLf ${NOTION_INSTALLER} | bash
 STATUS=$?
 
 exit $STATUS


### PR DESCRIPTION
Closes #278 

Update the bootstrap installer (served by `get.notionjs.com`) to download the actual Notion installer using the `-#` option (Progress bar) instead of the `-s` option (Silent). This gives some feedback on the process of downloading the Installer, which can take a while as it is currently quite large.