### PR TITLE
Migrate from result crate's `invert` to std's `transpose`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,6 @@ dependencies = [
  "notion-fail-derive 0.1.0",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "result 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1512,11 +1511,6 @@ dependencies = [
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "result"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-demangle"
@@ -2270,7 +2264,6 @@ dependencies = [
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "09d6e187a58d923ee132fcda141c94e716bcfe301c2ea2bef5c81536e0085376"
-"checksum result 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ notion-fail = { path = "crates/notion-fail" }
 notion-fail-derive = { path = "crates/notion-fail-derive" }
 reqwest = { version = "0.9.9", features = ["hyper-011"] }
 semver = "0.9.0"
-result = "1.0.0"
 rand = "0.5"
 cfg-if = "0.1"
 mockito = { version = "0.14.0", optional = true }

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -5,8 +5,6 @@ use notion_core::tool::ToolSpec;
 use notion_core::version::VersionSpec;
 use notion_fail::{ExitCode, Fallible};
 
-use result::ResultOptionExt;
-
 use crate::command::{Command, CommandName, Help};
 use crate::Notion;
 
@@ -51,7 +49,7 @@ Supported Tools:
     ) -> Fallible<Self> {
         let version = arg_version
             .map(VersionSpec::parse)
-            .invert()?
+            .transpose()?
             .unwrap_or_default();
 
         Ok(Install::Tool(ToolSpec::from_str(&arg_tool, version)))


### PR DESCRIPTION
- Bumps required Rust version to 1.33 – corresponding docs change is at notion-cli/docs#2
- Fixes #287