### PR TITLE
Core: don't repeatedly add `~/.notion` in fish.

### DIFF
--- a/dev/unix/install.sh.in
+++ b/dev/unix/install.sh.in
@@ -148,7 +148,7 @@ notion_build_path_str() {
 
   local PATH_STR
   if [[ $PROFILE =~ \.fish$ ]]; then
-    PATH_STR="\\nset -gx NOTION_HOME \"${PROFILE_INSTALL_DIR}\"\\ntest -s \"\$NOTION_HOME/load.fish\"; and source \"\$NOTION_HOME/load.fish\"\\n\\nset -gx PATH \"\$NOTION_HOME/bin\" \$PATH"
+    PATH_STR="\\nset -gx NOTION_HOME \"${PROFILE_INSTALL_DIR}\"\\ntest -s \"\$NOTION_HOME/load.fish\"; and source \"\$NOTION_HOME/load.fish\"\\n\\nstring match -r \".notion\" \"\$PATH\" > /dev/null; or set -gx PATH \"\$NOTION_HOME/bin\" \$PATH"
   else
     PATH_STR="\\nexport NOTION_HOME=\"${PROFILE_INSTALL_DIR}\"\\n[ -s \"\$NOTION_HOME/load.sh\" ] && \\. \"\$NOTION_HOME/load.sh\"\\n\\nexport PATH=\"\${NOTION_HOME}/bin:\$PATH\""
   fi


### PR DESCRIPTION
The previous invocation was unqualifiedly adding `~/.notion` to the user's `PATH`. This would result in the path growing every time they started a new instance of their shell.

A corresponding implementation in bash would be a nice complement to this, but my bash-fu is much weaker than my fish-fu at this point. I'm happy to open an issue to track that, however.