### PR TITLE
Add `notion which` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-support 0.1.0",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2094,6 +2095,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +2399,7 @@ dependencies = [
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
+"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.5"
 cfg-if = "0.1"
 mockito = { version = "0.14.0", optional = true }
 test-support = { path = "crates/test-support" }
+which = "2.0.1"
 
 [dev-dependencies]
 hamcrest2 = "0.2.3"

--- a/crates/notion-core/src/error.rs
+++ b/crates/notion-core/src/error.rs
@@ -59,8 +59,6 @@ pub enum ErrorDetails {
     /// Thrown when a user tries to pin a Yarn version before pinning a Node version.
     NoPinnedNodeVersion,
 
-    NoPlatformSpecified,
-
     NoSuchTool {
         tool: String,
     },
@@ -157,10 +155,6 @@ Consider using `notion install` to add a package to your toolchain (see `notion 
             ErrorDetails::NoPinnedNodeVersion => {
                 write!(f, "There is no pinned node version for this project")
             }
-            ErrorDetails::NoPlatformSpecified => write!(f, r"No toolchain found to resolve executable
-
-You do not appear to be in a project and you have not set a personal version of node.
-See `notion help install` for help adding Node to your personal toolchain."),
             ErrorDetails::NoSuchTool { tool } => write!(f, r#"
 No {} version selected.
 
@@ -216,7 +210,6 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::NoHomeEnvironmentVar => ExitCode::EnvironmentError,
             ErrorDetails::NoLocalDataDir => ExitCode::EnvironmentError,
             ErrorDetails::NoPinnedNodeVersion => ExitCode::ConfigurationError,
-            ErrorDetails::NoPlatformSpecified => ExitCode::ConfigurationError,
             ErrorDetails::NoSuchTool { .. } => ExitCode::NoVersionMatch,
             ErrorDetails::NotInPackage => ExitCode::ConfigurationError,
             ErrorDetails::NoToolChain { .. } => ExitCode::ExecutionFailure,

--- a/crates/notion-core/src/error.rs
+++ b/crates/notion-core/src/error.rs
@@ -59,6 +59,8 @@ pub enum ErrorDetails {
     /// Thrown when a user tries to pin a Yarn version before pinning a Node version.
     NoPinnedNodeVersion,
 
+    NoPlatformSpecified,
+
     NoSuchTool {
         tool: String,
     },
@@ -155,6 +157,10 @@ Consider using `notion install` to add a package to your toolchain (see `notion 
             ErrorDetails::NoPinnedNodeVersion => {
                 write!(f, "There is no pinned node version for this project")
             }
+            ErrorDetails::NoPlatformSpecified => write!(f, r"No toolchain found to resolve executable
+
+You do not appear to be in a project and you have not set a personal version of node.
+See `notion help install` for help adding Node to your personal toolchain."),
             ErrorDetails::NoSuchTool { tool } => write!(f, r#"
 No {} version selected.
 
@@ -210,6 +216,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::NoHomeEnvironmentVar => ExitCode::EnvironmentError,
             ErrorDetails::NoLocalDataDir => ExitCode::EnvironmentError,
             ErrorDetails::NoPinnedNodeVersion => ExitCode::ConfigurationError,
+            ErrorDetails::NoPlatformSpecified => ExitCode::ConfigurationError,
             ErrorDetails::NoSuchTool { .. } => ExitCode::NoVersionMatch,
             ErrorDetails::NotInPackage => ExitCode::ConfigurationError,
             ErrorDetails::NoToolChain { .. } => ExitCode::ExecutionFailure,

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -42,6 +42,7 @@ pub enum ActivityKind {
     Binary,
     Shim,
     Completions,
+    Which,
 }
 
 impl Display for ActivityKind {
@@ -66,6 +67,7 @@ impl Display for ActivityKind {
             &ActivityKind::Binary => "binary",
             &ActivityKind::Shim => "shim",
             &ActivityKind::Completions => "completions",
+            &ActivityKind::Which => "which",
         };
         f.write_str(s)
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,10 @@ otherwise, they will be written to `stdout`.
     )]
     Completions(command::Completions),
 
+    /// Locate the actual binary that will be called by Notion
+    #[structopt(name = "which", author = "")]
+    Which(command::Which),
+
     #[structopt(
         name = "use",
         author = "",
@@ -92,6 +96,7 @@ impl Subcommand {
             Subcommand::Deactivate(deactivate) => deactivate.run(session),
             Subcommand::Activate(activate) => activate.run(session),
             Subcommand::Completions(completions) => completions.run(session),
+            Subcommand::Which(which) => which.run(session),
             Subcommand::Use(r#use) => r#use.run(session),
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use structopt::StructOpt;
 
 use crate::command::{self, Command};
 use notion_core::session::Session;
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 #[derive(StructOpt)]
 #[structopt(
@@ -90,7 +90,7 @@ otherwise, they will be written to `stdout`.
 }
 
 impl Subcommand {
-    pub(crate) fn run(self, session: &mut Session) -> Fallible<()> {
+    pub(crate) fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         match self {
             Subcommand::Fetch(fetch) => fetch.run(session),
             Subcommand::Install(install) => install.run(session),

--- a/src/command/activate.rs
+++ b/src/command/activate.rs
@@ -11,7 +11,7 @@ use crate::command::Command;
 pub(crate) struct Activate {}
 
 impl Command for Activate {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Activate);
         let shell = CurrentShell::detect()?;
 
@@ -22,6 +22,6 @@ impl Command for Activate {
 
         shell.save_postscript(&postscript)?;
         session.add_event_end(ActivityKind::Activate, ExitCode::Success);
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/completions.rs
+++ b/src/command/completions.rs
@@ -28,7 +28,7 @@ pub(crate) struct Completions {
 }
 
 impl Command for Completions {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Completions);
 
         // If the user passed a shell, we'll use that; otherwise, we'll try to
@@ -64,6 +64,6 @@ impl Command for Completions {
         }
 
         session.add_event_end(ActivityKind::Completions, ExitCode::Success);
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/config.rs
+++ b/src/command/config.rs
@@ -25,11 +25,11 @@ pub enum Config {
 }
 
 impl Command for Config {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Version);
 
-        let result = match self {
-            Config::Get { key: _ } => Ok(()),
+        match self {
+            Config::Get { key: _ } => {}
             Config::Set { key: _, value: _ } => throw!(ErrorDetails::CommandNotImplemented {
                 command_name: "set".to_string()
             }),
@@ -45,7 +45,6 @@ impl Command for Config {
         };
 
         session.add_event_end(ActivityKind::Version, ExitCode::Success);
-
-        result
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -20,7 +20,7 @@ pub(crate) struct Current {
 }
 
 impl Command for Current {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Current);
 
         let result = match (self.project, self.user) {
@@ -72,7 +72,7 @@ impl Command for Current {
             throw!(ErrorDetails::NoVersionsFound)
         }
 
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }
 

--- a/src/command/deactivate.rs
+++ b/src/command/deactivate.rs
@@ -11,7 +11,7 @@ use crate::command::Command;
 pub(crate) struct Deactivate {}
 
 impl Command for Deactivate {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Deactivate);
         let shell = CurrentShell::detect()?;
 
@@ -22,6 +22,6 @@ impl Command for Deactivate {
 
         shell.save_postscript(&postscript)?;
         session.add_event_end(ActivityKind::Deactivate, ExitCode::Success);
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -17,7 +17,7 @@ pub(crate) struct Fetch {
 }
 
 impl Command for Fetch {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Fetch);
 
         let version = VersionSpec::parse(&self.version)?;
@@ -26,6 +26,6 @@ impl Command for Fetch {
         session.fetch(&tool)?;
 
         session.add_event_end(ActivityKind::Fetch, ExitCode::Success);
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -17,7 +17,7 @@ pub(crate) struct Install {
 }
 
 impl Command for Install {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Install);
 
         let version = match self.version {
@@ -30,6 +30,6 @@ impl Command for Install {
         session.install(&tool)?;
 
         session.add_event_end(ActivityKind::Install, ExitCode::Success);
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -22,12 +22,12 @@ pub(crate) use pin::Pin;
 pub(crate) use r#use::Use;
 
 use notion_core::session::Session;
-use notion_fail::Fallible;
+use notion_fail::{ExitCode, Fallible};
 
 /// A Notion command.
 pub(crate) trait Command: Sized {
     /// Executes the command. Returns `Ok(true)` if the process should return 0,
     /// `Ok(false)` if the process should return 1, and `Err(e)` if the process
     /// should return `e.exit_code()`.
-    fn run(self, session: &mut Session) -> Fallible<()>;
+    fn run(self, session: &mut Session) -> Fallible<ExitCode>;
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,7 +8,9 @@ pub(crate) mod install;
 pub(crate) mod pin;
 #[macro_use]
 pub(crate) mod r#use;
+pub(crate) mod which;
 
+pub(crate) use self::which::Which;
 pub(crate) use activate::Activate;
 pub(crate) use completions::Completions;
 pub(crate) use config::Config;

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -18,7 +18,7 @@ pub(crate) struct Pin {
 }
 
 impl Command for Pin {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Pin);
 
         let version = VersionSpec::parse(&self.version)?;
@@ -34,6 +34,6 @@ impl Command for Pin {
         }
 
         session.add_event_end(ActivityKind::Pin, ExitCode::Success);
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/use.rs
+++ b/src/command/use.rs
@@ -20,10 +20,10 @@ DEPRECATED:
 pub(crate) struct Use {}
 
 impl Command for Use {
-    fn run(self, session: &mut Session) -> Fallible<()> {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Help);
         eprintln!(usage!());
         session.add_event_end(ActivityKind::Help, ExitCode::Success);
-        Ok(())
+        Ok(ExitCode::Success)
     }
 }

--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -1,0 +1,46 @@
+use std::env;
+
+use structopt::StructOpt;
+use which::which_in;
+
+use notion_core::error::ErrorDetails;
+use notion_core::session::{ActivityKind, Session};
+use notion_fail::{throw, ExitCode, Fallible, ResultExt};
+
+use crate::command::Command;
+
+#[derive(StructOpt)]
+pub(crate) struct Which {
+    /// The binary to find, e.g. `node` or `npm`
+    binary: String,
+}
+
+impl Command for Which {
+    fn run(self, session: &mut Session) -> Fallible<()> {
+        session.add_event_start(ActivityKind::Which);
+
+        let platform = session.current_platform()?;
+
+        match platform {
+            Some(platform) => {
+                let image = platform.checkout(session)?;
+                let path = image.path()?;
+                let cwd = env::current_dir().unknown()?;
+
+                match which_in(&self.binary, Some(path), cwd) {
+                    Ok(result) => {
+                        println!("{}", result.to_string_lossy());
+                    }
+                    Err(_) => {
+                        // `which_in` Will return an Err if it can't find the binary in the path.
+                        // In that case, we want to do nothing, instead of showing the user an error
+                    }
+                };
+            }
+            None => throw!(ErrorDetails::NoPlatformSpecified),
+        }
+
+        session.add_event_end(ActivityKind::Which, ExitCode::Success);
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use structopt::StructOpt;
 
 use notion_core::session::{ActivityKind, Session};
 use notion_core::style::{display_error, ErrorContext};
-use notion_fail::ExitCode;
 
 /// The entry point for the `notion` CLI.
 pub fn main() {
@@ -15,14 +14,11 @@ pub fn main() {
     session.add_event_start(ActivityKind::Notion);
 
     let notion = cli::Notion::from_args();
-    let exit_code = match notion.command.run(&mut session) {
-        Ok(_) => ExitCode::Success,
-        Err(err) => {
-            display_error(ErrorContext::Notion, &err);
-            session.add_event_error(ActivityKind::Notion, &err);
-            err.exit_code()
-        }
-    };
+    let exit_code = notion.command.run(&mut session).unwrap_or_else(|err| {
+        display_error(ErrorContext::Notion, &err);
+        session.add_event_error(ActivityKind::Notion, &err);
+        err.exit_code()
+    });
 
     session.add_event_end(ActivityKind::Notion, exit_code);
     session.exit(exit_code);


### PR DESCRIPTION
Closes #167 

Info
-----
Adds a command `notion which <BINARY>` that shows the user which binary will actually be run, effectively seeing through the shims. It will also resolve any other binary that happens to be on the path, so it works as a drop-in replacement for `which`:

```bash
$ which node
/Users/me/.notion/bin/node
$ notion which node
/Users/me/.notion/tools/image/node/10.15.3/6.4.1/bin/node
$ which ls
/bin/ls
$ notion which ls
/bin/ls
```

Notes
-----
* Currently this command will use the system path (with Notion shim directory removed) as the `PATH` if there is no platform _or_ if there are any errors when attempting to retrieve the platform image. Errors with determining the system path or the current working directory will still be exposed as errors, however.
* This will likely need some updated logic to resolve package binaries from wherever they are installed, since they aren't directly on the PATH.