### PR TITLE
Allow version to be optional in 'notion pin'

### DIFF
--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -14,14 +14,18 @@ pub(crate) struct Pin {
     tool: String,
 
     /// The version of the tool to install, e.g. `1.2.3` or `latest`
-    version: String,
+    version: Option<String>,
 }
 
 impl Command for Pin {
     fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Pin);
 
-        let version = VersionSpec::parse(&self.version)?;
+        let version = match self.version {
+            Some(version_string) => VersionSpec::parse(&version_string)?,
+            None => VersionSpec::default(),
+        };
+
         let tool = ToolSpec::from_str_and_version(&self.tool, version);
         session.pin(&tool)?;
 


### PR DESCRIPTION
Fixes #312 

`notion pin` was requiring the `version` argument to be specified, instead of defaulting to "latest" like `notion install`. Update the `pin` command to match the `install` command with an Optional `version` argument and resolving the latest if the version is not specified.