### PR TITLE
Remove autoshimming

### DIFF
--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -5,7 +5,7 @@
 use std::rc::Rc;
 
 use crate::distro::node::NodeVersion;
-use crate::distro::package::{self, PackageVersion, UserTool};
+use crate::distro::package::{PackageVersion, UserTool};
 use crate::distro::Fetched;
 use crate::error::ErrorDetails;
 use crate::hook::{HookConfig, LazyHookConfig, Publish};

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -130,14 +130,10 @@ pub trait Tool: Sized {
     /// Extracts the `Command` from this tool.
     fn command(self) -> Command;
 
-    /// Perform any tasks which must be run after the tool runs but before exiting.
-    fn finalize(_session: &Session, _maybe_status: &io::Result<ExitStatus>) {}
-
     /// Delegates the current process to this tool.
     fn exec(self, session: &Session) -> Fallible<ExitStatus> {
         let mut command = self.command();
         let status = command.status();
-        Self::finalize(session, &status);
         status.with_context(binary_exec_error)
     }
 }

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -102,10 +102,10 @@ pub fn execute_tool(session: &mut Session) -> Fallible<ExitStatus> {
     // all the possible `Tool` implementations and fill it dynamically,
     // as they have different sizes and associated types.
     match &exe.to_str() {
-        Some("node") => Node::new(args, session)?.exec(session),
-        Some("npm") => Npm::new(args, session)?.exec(session),
-        Some("npx") => Npx::new(args, session)?.exec(session),
-        Some("yarn") => Yarn::new(args, session)?.exec(session),
+        Some("node") => Node::new(args, session)?.exec(),
+        Some("npm") => Npm::new(args, session)?.exec(),
+        Some("npx") => Npx::new(args, session)?.exec(),
+        Some("yarn") => Yarn::new(args, session)?.exec(),
         _ => Binary::new(
             BinaryArgs {
                 executable: exe,
@@ -113,7 +113,7 @@ pub fn execute_tool(session: &mut Session) -> Fallible<ExitStatus> {
             },
             session,
         )?
-        .exec(session),
+        .exec(),
     }
 }
 
@@ -131,7 +131,7 @@ pub trait Tool: Sized {
     fn command(self) -> Command;
 
     /// Delegates the current process to this tool.
-    fn exec(self, session: &Session) -> Fallible<ExitStatus> {
+    fn exec(self) -> Fallible<ExitStatus> {
         let mut command = self.command();
         let status = command.status();
         status.with_context(binary_exec_error)

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -11,9 +11,8 @@ use std::process::{Command, ExitStatus};
 use crate::env::UNSAFE_GLOBAL;
 use crate::error::ErrorDetails;
 use crate::session::Session;
-use crate::style;
 use crate::version::VersionSpec;
-use notion_fail::{Fallible, NotionError, ResultExt};
+use notion_fail::{Fallible, ResultExt};
 
 mod binary;
 mod node;
@@ -26,10 +25,6 @@ use self::node::Node;
 use self::npm::Npm;
 use self::npx::Npx;
 use self::yarn::Yarn;
-
-fn display_tool_error(err: &NotionError) {
-    style::display_error(style::ErrorContext::Shim, err);
-}
 
 pub enum ToolSpec {
     Node(VersionSpec),

--- a/crates/notion-core/src/tool/npm.rs
+++ b/crates/notion-core/src/tool/npm.rs
@@ -1,9 +1,8 @@
 use std::env::{args_os, ArgsOs};
 use std::ffi::{OsStr, OsString};
-use std::io;
-use std::process::{Command, ExitStatus};
+use std::process::Command;
 
-use super::{command_for, display_tool_error, intercept_global_installs, Tool};
+use super::{command_for, intercept_global_installs, Tool};
 use crate::error::ErrorDetails;
 use crate::session::{ActivityKind, Session};
 
@@ -45,18 +44,6 @@ impl Tool for Npm {
 
     fn command(self) -> Command {
         self.0
-    }
-
-    fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
-        if let Ok(_) = maybe_status {
-            if let Ok(Some(project)) = session.project() {
-                let errors = project.autoshim();
-
-                for error in errors {
-                    display_tool_error(&error);
-                }
-            }
-        }
     }
 }
 

--- a/crates/notion-core/src/tool/yarn.rs
+++ b/crates/notion-core/src/tool/yarn.rs
@@ -1,9 +1,8 @@
 use std::env::{args_os, ArgsOs};
 use std::ffi::OsStr;
-use std::io;
-use std::process::{Command, ExitStatus};
+use std::process::Command;
 
-use super::{command_for, display_tool_error, intercept_global_installs, Tool};
+use super::{command_for, intercept_global_installs, Tool};
 use crate::error::ErrorDetails;
 use crate::session::{ActivityKind, Session};
 
@@ -42,19 +41,6 @@ impl Tool for Yarn {
 
     fn command(self) -> Command {
         self.0
-    }
-
-    /// Perform any tasks which must be run after the tool runs but before exiting.
-    fn finalize(session: &Session, maybe_status: &io::Result<ExitStatus>) {
-        if let Ok(_) = maybe_status {
-            if let Ok(Some(project)) = session.project() {
-                let errors = project.autoshim();
-
-                for error in errors {
-                    display_tool_error(&error);
-                }
-            }
-        }
     }
 }
 

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -2,7 +2,6 @@ use structopt::StructOpt;
 
 use notion_core::error::ErrorDetails;
 use notion_core::session::{ActivityKind, Session};
-use notion_core::style::{display_error, ErrorContext};
 use notion_core::tool::ToolSpec;
 use notion_core::version::VersionSpec;
 use notion_fail::{throw, ExitCode, Fallible};
@@ -35,14 +34,6 @@ impl Command for Pin {
             // ISSUE(#292): Implement install for npm
             ToolSpec::Npm(_version) => unimplemented!("Pinning npm is not supported yet"),
             ToolSpec::Package(_name, _version) => throw!(ErrorDetails::CannotPinPackage),
-        }
-
-        if let Some(project) = session.project()? {
-            let errors = project.autoshim();
-
-            for error in errors {
-                display_error(ErrorContext::Notion, &error);
-            }
         }
 
         session.add_event_end(ActivityKind::Pin, ExitCode::Success);


### PR DESCRIPTION
Closes #235 

Info
-----
Now that #247 has landed, we can remove the autoshimming to prevent cluttering the user's path with shims to JS binaries.

Changes
-----
* Removed the calls to `autoshim`.
* Removed the `finalize` method on the `Tool` trait, as it was only being used to support autoshimming.
* Removed the `autoshim` and `dependent_binary_names_fault_tolerant` methods from `Project`.

Tested
-----
* Verified locally that running `yarn` in a project with many dependencies doesn't result in any shims being created.