### PR TITLE
Remove feature flag around intercepting global installs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ universal-docs = ["notion-core/universal-docs"]
 mock-network = ["mockito", "notion-core/mock-network"]
 notion-dev = []
 smoke-tests = []
-intercept-globals = ["notion-core/intercept-globals"]
 
 [[bin]]
 name = "shim"

--- a/crates/notion-core/Cargo.toml
+++ b/crates/notion-core/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [features]
 universal-docs = ["archive/universal-docs"]
 mock-network = ["mockito"]
-intercept-globals = []
 
 [dependencies]
 toml = "0.4"

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -176,10 +176,6 @@ fn command_for(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Command {
 }
 
 fn intercept_global_installs() -> bool {
-    if cfg!(feature = "intercept-globals") {
-        // We should only intercept global installs if the NOTION_UNSAFE_GLOBAL variable is not set
-        env::var_os(UNSAFE_GLOBAL).is_none()
-    } else {
-        false
-    }
+    // We should only intercept global installs if the NOTION_UNSAFE_GLOBAL variable is not set
+    env::var_os(UNSAFE_GLOBAL).is_none()
 }

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -119,7 +119,7 @@ fn npm_allows_global_install_with_env_variable() {
     assert_that!(
         s.npm("i -g ember-cli"),
         execs()
-            .with_status(MISSING_EXECUTABLE_EXIT_CODE)
+            .with_status(ExitCode::ExecutionFailure as i32)
             .with_stderr_does_not_contain("Global package installs are not recommended.")
     );
 }

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -1,4 +1,4 @@
-use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, YarnFixture};
+use crate::support::sandbox::sandbox;
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
@@ -6,55 +6,9 @@ use test_support::matchers::execs;
 use notion_core::env::UNSAFE_GLOBAL;
 use notion_fail::ExitCode;
 
-cfg_if::cfg_if! {
-    // Note: Windows and Unix appear to handle a missing executable differently
-    // On Unix, it results in the Command::status() method returning an Err Result
-    // On Windows, it results in the Command::status() method returning Ok(3221225495)
-    if #[cfg(target_os = "macos")] {
-        const MISSING_EXECUTABLE_EXIT_CODE: i32 = ExitCode::ExecutionFailure as i32;
-        const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
-            DistroMetadata {
-                version: "10.99.1040",
-                compressed_size: 273,
-                uncompressed_size: Some(0x00280000),
-            },
-        ];
-    } else if #[cfg(target_os = "linux")] {
-        const MISSING_EXECUTABLE_EXIT_CODE: i32 = ExitCode::ExecutionFailure as i32;
-        const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
-            DistroMetadata {
-                version: "10.99.1040",
-                compressed_size: 273,
-                uncompressed_size: Some(0x00280000),
-            },
-        ];
-    } else if #[cfg(target_os = "windows")] {
-        // Exit Code 3221225495 overflows to -1073741801 when comparing i32 codes
-        const MISSING_EXECUTABLE_EXIT_CODE: i32 = -1073741801;
-        const NODE_VERSION_FIXTURES: [DistroMetadata; 1] = [
-            DistroMetadata {
-                version: "10.99.1040",
-                compressed_size: 1096,
-                uncompressed_size: None,
-            },
-        ];
-    } else {
-        compile_error!("Unsupported target_os for tests (expected 'macos', 'linux', or 'windows').");
-    }
-}
-
-const YARN_VERSION_FIXTURES: [DistroMetadata; 1] = [DistroMetadata {
-    version: "1.12.99",
-    compressed_size: 178,
-    uncompressed_size: Some(0x00280000),
-}];
-
 #[test]
 fn npm_prevents_global_install() {
-    let s = sandbox()
-        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"}}"#)
-        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
-        .build();
+    let s = sandbox().build();
 
     assert_that!(
         s.npm("install ember-cli --global"),
@@ -108,11 +62,7 @@ fn npm_prevents_global_install() {
 
 #[test]
 fn npm_allows_global_install_with_env_variable() {
-    let s = sandbox()
-        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"}}"#)
-        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
-        .env(UNSAFE_GLOBAL, "1")
-        .build();
+    let s = sandbox().env(UNSAFE_GLOBAL, "1").build();
 
     // Since we are using a fixture for the Node version, the execution will still fail
     // We just want to check that we didn't get the Global install error
@@ -121,16 +71,13 @@ fn npm_allows_global_install_with_env_variable() {
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
             .with_stderr_does_not_contain("Global package installs are not recommended.")
+            .with_stderr_contains("No Node version selected.")
     );
 }
 
 #[test]
 fn yarn_prevents_global_add() {
-    let s = sandbox()
-        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"},"yarn":"1.12.99"}"#)
-        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
-        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
-        .build();
+    let s = sandbox().build();
 
     assert_that!(
         s.yarn("global add ember-cli"),
@@ -156,19 +103,15 @@ fn yarn_prevents_global_add() {
 
 #[test]
 fn yarn_allows_global_add_with_env_variable() {
-    let s = sandbox()
-        .platform(r#"{"node":{"runtime":"10.99.1040","npm":"6.2.26"},"yarn":"1.12.99"}"#)
-        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
-        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
-        .env(UNSAFE_GLOBAL, "1")
-        .build();
+    let s = sandbox().env(UNSAFE_GLOBAL, "1").build();
 
     // Since we are using a fixture for the Yarn version, the execution will still fail
     // We just want to check that we didn't get the Global install error
     assert_that!(
         s.yarn("global add ember-cli"),
         execs()
-            .with_status(MISSING_EXECUTABLE_EXIT_CODE)
+            .with_status(ExitCode::ExecutionFailure as i32)
             .with_stderr_does_not_contain("Global package installs are not recommended.")
+            .with_stderr_contains("No Yarn version selected.")
     );
 }

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -2,7 +2,6 @@ mod support;
 
 // test files
 
-#[cfg(feature = "intercept-globals")]
 mod intercept_global_installs;
 mod notion_current;
 mod notion_deactivate;


### PR DESCRIPTION
Now that #247 has landed, we want to re-enable the interception of global installs by default. This will push the users to the new feature and the recommended workflow for Notion.