### PR TITLE
Command-line parsing and output improvements

### DIFF
--- a/crates/notion-core/src/error.rs
+++ b/crates/notion-core/src/error.rs
@@ -31,6 +31,11 @@ pub enum ErrorDetails {
         error: String,
     },
 
+    DeprecatedCommandError {
+        command: String,
+        advice: String,
+    },
+
     DownloadToolNetworkError {
         tool: ToolSpec,
         from_url: String,
@@ -130,6 +135,9 @@ impl fmt::Display for ErrorDetails {
             ErrorDetails::DepPackageReadError { error } => {
                 write!(f, "Could not read dependent package info: {}", error)
             }
+            ErrorDetails::DeprecatedCommandError { command, advice } => {
+                write!(f, "The subcommand `{}` is deprecated.\n{}", command, advice)
+            }
             ErrorDetails::DownloadToolNetworkError {
                 tool,
                 from_url,
@@ -202,6 +210,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CreateDirError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DepPackageReadError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::DeprecatedCommandError { .. } => ExitCode::InvalidArguments,
             ErrorDetails::DownloadToolNetworkError { .. } => ExitCode::NetworkError,
             ErrorDetails::DownloadToolNotFound { .. } => ExitCode::NoVersionMatch,
             ErrorDetails::InvalidHookCommand { .. } => ExitCode::UnknownError,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,12 +29,15 @@ pub(crate) struct Notion {
     #[allow(dead_code)]
     pub(crate) verbose: bool,
 
-    #[structopt(short = "v", long = "version", help = "Prints the current version of Notion")]
+    #[structopt(
+        short = "v",
+        long = "version",
+        help = "Prints the current version of Notion"
+    )]
     pub(crate) version: bool,
 }
 
 impl Notion {
-
     pub(crate) fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         if self.version {
             println!("{}", env!("CARGO_PKG_VERSION"));
@@ -45,7 +48,6 @@ impl Notion {
             Notion::from_iter(["notion", "help"].iter()).run(session)
         }
     }
-
 }
 
 #[derive(StructOpt)]
@@ -118,7 +120,7 @@ otherwise, they will be written to `stdout`.
         raw(
             usage = "crate::command::r#use::USAGE",
             setting = "structopt::clap::AppSettings::Hidden"
-        ),
+        )
     )]
     Use(command::Use),
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,58 +13,88 @@ use notion_fail::{ExitCode, Fallible};
 
     To install a tool in your toolchain, use `notion install`.
     To pin your project's runtime or package manager, use `notion pin`.",
-    raw(setting = "structopt::clap::AppSettings::ArgRequiredElseHelp"),
     raw(global_setting = "structopt::clap::AppSettings::ColoredHelp"),
     raw(global_setting = "structopt::clap::AppSettings::ColorAlways"),
     raw(global_setting = "structopt::clap::AppSettings::DeriveDisplayOrder"),
-    raw(global_setting = "structopt::clap::AppSettings::DontCollapseArgsInUsage")
+    raw(global_setting = "structopt::clap::AppSettings::DisableVersion"),
+    raw(global_setting = "structopt::clap::AppSettings::DontCollapseArgsInUsage"),
+    raw(global_setting = "structopt::clap::AppSettings::VersionlessSubcommands")
 )]
 pub(crate) struct Notion {
     #[structopt(subcommand)]
-    pub(crate) command: Subcommand,
+    pub(crate) command: Option<Subcommand>,
 
     // not yet implemented!
-    #[structopt(long = "verbose", help = "switch on verbosity", global = true)]
+    #[structopt(long = "verbose", help = "Enables verbose diagnostics", global = true)]
     #[allow(dead_code)]
     pub(crate) verbose: bool,
+
+    #[structopt(short = "v", long = "version", help = "Prints the current version of Notion")]
+    pub(crate) version: bool,
+}
+
+impl Notion {
+
+    pub(crate) fn run(self, session: &mut Session) -> Fallible<ExitCode> {
+        if self.version {
+            println!("{}", env!("CARGO_PKG_VERSION"));
+            Ok(ExitCode::Success)
+        } else if let Some(command) = self.command {
+            command.run(session)
+        } else {
+            Notion::from_iter(["notion", "help"].iter()).run(session)
+        }
+    }
+
 }
 
 #[derive(StructOpt)]
 pub(crate) enum Subcommand {
-    /// Fetch a tool to the local machine
-    #[structopt(name = "fetch", author = "")]
+    /// Fetches a tool to the local machine
+    #[structopt(name = "fetch", author = "", version = "")]
     Fetch(command::Fetch),
 
-    /// Install a tool in your toolchain.
-    #[structopt(name = "install", author = "")]
+    /// Installs a tool in your toolchain
+    #[structopt(name = "install", author = "", version = "")]
     Install(command::Install),
 
-    /// Pin your project's runtime or package manager.
-    #[structopt(name = "pin", author = "")]
+    /// Pins your project's runtime or package manager
+    #[structopt(name = "pin", author = "", version = "")]
     Pin(command::Pin),
 
-    /// Get or set configuration values
-    #[structopt(name = "config", author = "")]
+    /// Gets or sets configuration values
+    #[structopt(name = "config", author = "", version = "")]
     Config(command::Config),
 
-    /// Display the currently activated Node version
-    #[structopt(name = "current", author = "")]
+    /// Displays the currently activated Node version
+    #[structopt(name = "current", author = "", version = "")]
     Current(command::Current),
 
-    /// Disable Notion in the current shell
-    #[structopt(name = "deactivate", author = "")]
+    /// Disables Notion in the current shell
+    #[structopt(
+        name = "deactivate",
+        author = "",
+        version = "",
+        raw(setting = "structopt::clap::AppSettings::Hidden")
+    )]
     Deactivate(command::Deactivate),
 
-    /// Re-enable Notion in the current shell
-    #[structopt(name = "activate", author = "")]
+    /// Re-enables Notion in the current shell
+    #[structopt(
+        name = "activate",
+        author = "",
+        version = "",
+        raw(setting = "structopt::clap::AppSettings::Hidden")
+    )]
     Activate(command::Activate),
 
-    /// Generate Notion completions.
+    /// Generates Notion completions
     #[structopt(
         name = "completions",
         author = "",
+        version = "",
         raw(setting = "structopt::clap::AppSettings::ArgRequiredElseHelp"),
-        long_about = "Generate Notion completions.
+        long_about = "Generates Notion completions
 
 By default, completions will be generated for the value of your current shell,
 shell, i.e. the value of `SHELL`. If you set the `<shell>` option, completions
@@ -76,15 +106,19 @@ otherwise, they will be written to `stdout`.
     )]
     Completions(command::Completions),
 
-    /// Locate the actual binary that will be called by Notion
-    #[structopt(name = "which", author = "")]
+    /// Locates the actual binary that will be called by Notion
+    #[structopt(name = "which", author = "", version = "")]
     Which(command::Which),
 
     #[structopt(
         name = "use",
         author = "",
+        version = "",
         template = "{usage}",
-        raw(usage = "usage!()", setting = "structopt::clap::AppSettings::Hidden")
+        raw(
+            usage = "crate::command::r#use::USAGE",
+            setting = "structopt::clap::AppSettings::Hidden"
+        ),
     )]
     Use(command::Use),
 }

--- a/src/command/use.rs
+++ b/src/command/use.rs
@@ -22,7 +22,7 @@ const ADVICE: &'static str = "
 #[derive(StructOpt)]
 pub(crate) struct Use {
     #[allow(dead_code)]
-    anything: Vec<String>,
+    anything: Vec<String>, // Prevent StructOpt argument errors when invoking e.g. `notion use node`
 }
 
 impl Command for Use {

--- a/src/command/use.rs
+++ b/src/command/use.rs
@@ -31,7 +31,8 @@ impl Command for Use {
         let result = Err(ErrorDetails::DeprecatedCommandError {
             command: "use".to_string(),
             advice: ADVICE.to_string(),
-        }.into());
+        }
+        .into());
         session.add_event_end(ActivityKind::Help, ExitCode::InvalidArguments);
         result
     }

--- a/src/command/use.rs
+++ b/src/command/use.rs
@@ -1,29 +1,38 @@
 use structopt::StructOpt;
 
 use crate::command::Command;
+use notion_core::error::ErrorDetails;
 use notion_core::session::{ActivityKind, Session};
 use notion_fail::{ExitCode, Fallible};
 
-#[macro_export]
-macro_rules! usage {
-    () => {
-        "notion-use
+// NOTE: These use the same text as the `long_about` in crate::cli.
+//       It's hard to abstract since it's in an attribute string.
 
-DEPRECATED:
+pub(crate) const USAGE: &'static str = "The subcommand `use` is deprecated.
+
     To install a tool in your toolchain, use `notion install`.
     To pin your project's runtime or package manager, use `notion pin`.
-"
-    };
-}
+";
+
+const ADVICE: &'static str = "
+    To install a tool in your toolchain, use `notion install`.
+    To pin your project's runtime or package manager, use `notion pin`.
+";
 
 #[derive(StructOpt)]
-pub(crate) struct Use {}
+pub(crate) struct Use {
+    #[allow(dead_code)]
+    anything: Vec<String>,
+}
 
 impl Command for Use {
     fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Help);
-        eprintln!(usage!());
-        session.add_event_end(ActivityKind::Help, ExitCode::Success);
-        Ok(ExitCode::Success)
+        let result = Err(ErrorDetails::DeprecatedCommandError {
+            command: "use".to_string(),
+            advice: ADVICE.to_string(),
+        }.into());
+        session.add_event_end(ActivityKind::Help, ExitCode::InvalidArguments);
+        result
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ pub fn main() {
 
     session.add_event_start(ActivityKind::Notion);
 
-    let notion = cli::Notion::from_args();
-    let exit_code = notion.command.run(&mut session).unwrap_or_else(|err| {
+    let notion: cli::Notion = cli::Notion::from_args();
+    let exit_code = notion.run(&mut session).unwrap_or_else(|err| {
         display_error(ErrorContext::Notion, &err);
         session.add_event_error(ActivityKind::Notion, &err);
         err.exit_code()

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ pub fn main() {
 
     session.add_event_start(ActivityKind::Notion);
 
-    let notion: cli::Notion = cli::Notion::from_args();
+    let notion = cli::Notion::from_args();
     let exit_code = notion.run(&mut session).unwrap_or_else(|err| {
         display_error(ErrorContext::Notion, &err);
         session.add_event_error(ActivityKind::Notion, &err);


### PR DESCRIPTION
A number of fairly minor changes to the command-line logic and formatting:
- `notion --version` prints just the version number
- consistent prose style in usage
- `notion use` fails as an error
- hide `activate`/`deactivate` from main help information

<details>
<summary>Main help messages</summary>
<img width="551" alt="image" src="https://user-images.githubusercontent.com/307871/54806547-8f252800-4c37-11e9-9328-71191a902d30.png">
</details>

<details>
<summary>Subcommand help pages don't include a version number</summary>
<img width="545" alt="image" src="https://user-images.githubusercontent.com/307871/54806893-a4e71d00-4c38-11e9-8ee5-cc98f9283247.png">
</details>

<details>
<summary>Error message for "notion use"</summary>
<img width="510" alt="image" src="https://user-images.githubusercontent.com/307871/54806602-bb40a900-4c37-11e9-8ba0-23fb2f09a0ce.png">
</details>

<details>
<summary>Error message if "notion use" gets passed any flags</summary>

(I couldn't figure out how to get StructOpt/Clap to just stop parsing anything after `use`, so it barfs if you have any flags.)

<img width="628" alt="image" src="https://user-images.githubusercontent.com/307871/54806654-e7f4c080-4c37-11e9-962c-12872ab353cb.png">
</details>

<details>
<summary>Help page for "notion deactivate"</summary>

<img width="367" alt="image" src="https://user-images.githubusercontent.com/307871/54806852-8aad3f00-4c38-11e9-9479-aec4d7f5c523.png">
</details>
