### PR TITLE
Package uninstall

### DIFF
--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -387,11 +387,7 @@ impl PackageVersion {
             let package_config = PackageConfig::from_file(&package_config_file)?;
 
             for bin_name in package_config.bins {
-                let shim = path::shim_file(&bin_name)?;
-                fs::remove_file(shim).with_context(file_deletion_error)?;
-                let config_file = path::user_tool_bin_config(&bin_name)?;
-                fs::remove_file(config_file).with_context(file_deletion_error)?;
-                println!("Removed executable '{}' installed by '{}'", bin_name, name);
+                PackageVersion::remove_config_and_shims(&bin_name, &name)?;
             }
 
             fs::remove_file(package_config_file).with_context(file_deletion_error)?;
@@ -401,11 +397,7 @@ impl PackageVersion {
             if user_bin_dir.exists() {
                 let orphaned_bins = binaries_from_package(&name)?;
                 for bin_name in orphaned_bins {
-                    let shim = path::shim_file(&bin_name)?;
-                    fs::remove_file(shim).with_context(file_deletion_error)?;
-                    let config_file = path::user_tool_bin_config(&bin_name)?;
-                    fs::remove_file(config_file).with_context(file_deletion_error)?;
-                    println!("Removed executable '{}' installed by '{}'", bin_name, name);
+                    PackageVersion::remove_config_and_shims(&bin_name, &name)?;
                 }
             }
         }
@@ -431,6 +423,15 @@ impl PackageVersion {
         }
 
         println!("Package '{}' uninstalled", name);
+        Ok(())
+    }
+
+    fn remove_config_and_shims(bin_name: &str, name: &str) -> Fallible<()> {
+        let shim = path::shim_file(&bin_name)?;
+        fs::remove_file(shim).with_context(file_deletion_error)?;
+        let config_file = path::user_tool_bin_config(&bin_name)?;
+        fs::remove_file(config_file).with_context(file_deletion_error)?;
+        println!("Removed executable '{}' installed by '{}'", bin_name, name);
         Ok(())
     }
 }

--- a/crates/notion-core/src/fs.rs
+++ b/crates/notion-core/src/fs.rs
@@ -77,7 +77,6 @@ pub fn files_matching(dir: &Path, re: &Regex) -> Fallible<Vec<PathBuf>> {
         .filter(|(_, metadata)| metadata.is_file())
         .filter_map(|(entry, _)| {
             if let Some(file_name) = entry.path().file_name() {
-                println!("files_matching - got file_name: {:?}", file_name);
                 if re.is_match(&file_name.to_string_lossy()) {
                     return Some(entry.path());
                 }

--- a/crates/notion-core/src/fs.rs
+++ b/crates/notion-core/src/fs.rs
@@ -7,8 +7,6 @@ use std::path::{Path, PathBuf};
 use crate::error::ErrorDetails;
 use notion_fail::{Fallible, ResultExt};
 
-use regex::Regex;
-
 pub fn touch(path: &Path) -> Fallible<File> {
     if !path.is_file() {
         let basedir = path.parent().unwrap();
@@ -68,19 +66,6 @@ pub fn read_dir_eager(dir: &Path) -> Fallible<impl Iterator<Item = (DirEntry, Me
         })
         .collect::<Fallible<Vec<(DirEntry, Metadata)>>>()?
         .into_iter())
-}
-
-/// Reads the contents of a directory and returns a Vec of all files found in
-/// the directory that match the input regex.
-pub fn files_matching(dir: &Path, re: &Regex) -> Fallible<Vec<PathBuf>> {
-    dir_entry_match(dir, |entry| {
-        if let Some(file_name) = entry.path().file_name() {
-            if re.is_match(&file_name.to_string_lossy()) {
-                return Some(entry.path());
-            }
-        }
-        None
-    })
 }
 
 /// Reads the contents of a directory and returns a Vec of the matched results

--- a/crates/notion-core/src/fs.rs
+++ b/crates/notion-core/src/fs.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use crate::error::ErrorDetails;
 use notion_fail::{Fallible, ResultExt};
 
+use regex::Regex;
+
 pub fn touch(path: &Path) -> Fallible<File> {
     if !path.is_file() {
         let basedir = path.parent().unwrap();
@@ -66,4 +68,21 @@ pub fn read_dir_eager(dir: &Path) -> Fallible<impl Iterator<Item = (DirEntry, Me
         })
         .collect::<Fallible<Vec<(DirEntry, Metadata)>>>()?
         .into_iter())
+}
+
+/// Reads the contents of a directory and returns a Vec of all files found in
+/// the directory that match the input regex.
+pub fn files_matching(dir: &Path, re: &Regex) -> Fallible<Vec<PathBuf>> {
+    Ok(read_dir_eager(dir)?
+        .filter(|(_, metadata)| metadata.is_file())
+        .filter_map(|(entry, _)| {
+            if let Some(file_name) = entry.path().file_name() {
+                println!("files_matching - got file_name: {:?}", file_name);
+                if re.is_match(&file_name.to_string_lossy()) {
+                    return Some(entry.path());
+                }
+            }
+            None
+        })
+        .collect::<Vec<PathBuf>>())
 }

--- a/crates/notion-core/src/path/mod.rs
+++ b/crates/notion-core/src/path/mod.rs
@@ -140,10 +140,12 @@ pub fn user_package_config_file(package_name: &str) -> Fallible<PathBuf> {
     Ok(user_package_dir()?.join(format!("{}.json", package_name)))
 }
 
+pub fn user_bin_dir() -> Fallible<PathBuf> {
+    Ok(user_toolchain_dir()?.join("bins"))
+}
+
 pub fn user_tool_bin_config(bin_name: &str) -> Fallible<PathBuf> {
-    Ok(user_toolchain_dir()?
-        .join("bins")
-        .join(format!("{}.json", bin_name)))
+    Ok(user_bin_dir()?.join(format!("{}.json", bin_name)))
 }
 
 pub fn node_distro_file_name(version: &str) -> String {

--- a/crates/notion-core/src/path/windows.rs
+++ b/crates/notion-core/src/path/windows.rs
@@ -36,9 +36,9 @@ cfg_if::cfg_if! {
 //                 index.json                              node_index_file
 //                 index.json.expires                      node_index_expiry_file
 //         bin\                                            shim_dir
-//             node                                        shim_file("node")
-//             npm
-//             npx
+//             node.exe                                    shim_file("node")
+//             npm.exe
+//             npx.exe
 //             ...
 //         tools\                                          tools_dir
 //             inventory\                                  inventory_dir

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -2,28 +2,24 @@
 //! execution of a Notion tool, including their current directory, Notion
 //! hook configuration, and the state of the local inventory.
 
-use std::fs;
-use std::io;
+use std::ffi::OsStr;
+use std::fmt::{self, Display, Formatter};
+use std::process::exit;
 use std::rc::Rc;
 
 use crate::distro::node::NodeVersion;
-use crate::distro::package::{PackageConfig, PackageVersion, UserTool};
+use crate::distro::package::{PackageVersion, UserTool};
 use crate::distro::Fetched;
 use crate::error::ErrorDetails;
+use crate::event::EventLog;
 use crate::hook::{HookConfig, LazyHookConfig, Publish};
 use crate::inventory::{FetchResolve, Inventory, LazyInventory};
-use crate::path;
 use crate::platform::PlatformSpec;
 use crate::project::{LazyProject, Project};
 use crate::toolchain::LazyToolchain;
 use crate::version::VersionSpec;
 
-use std::ffi::OsStr;
-use std::fmt::{self, Display, Formatter};
-use std::process::exit;
-
-use crate::event::EventLog;
-use notion_fail::{throw, ExitCode, Fallible, NotionError, ResultExt};
+use notion_fail::{throw, ExitCode, Fallible, NotionError};
 use semver::Version;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy)]
@@ -75,12 +71,6 @@ impl Display for ActivityKind {
             &ActivityKind::Which => "which",
         };
         f.write_str(s)
-    }
-}
-
-fn file_deletion_error(err: &io::Error) -> ErrorDetails {
-    ErrorDetails::FileDeletionError {
-        error: err.to_string(),
     }
 }
 
@@ -243,41 +233,8 @@ impl Session {
     }
 
     /// Uninstall the specified package.
-    ///
-    /// This removes:
-    /// * the json config files
-    /// * the shims
-    /// * the unpacked and initialized package
-    ///
-    /// This optionally clears the inventory for this package, removing:
-    /// * the downloaded tarball and shasum files
-    pub fn uninstall_package(&mut self, name: String, _remove_all: bool) -> Fallible<()> {
-        // read the config file to see where things are
-        let package_config_file = path::user_package_config_file(&name)?;
-        if !package_config_file.exists() {
-            throw!(ErrorDetails::PackageNotInstalled { package: name });
-        }
-        let package_config = PackageConfig::from_file(&package_config_file)?;
-
-        // remove the shims and binary config files
-        for bin_name in package_config.bins {
-            let shim = path::shim_file(&bin_name)?;
-            fs::remove_file(shim).with_context(file_deletion_error)?;
-            let config_file = path::user_tool_bin_config(&bin_name)?;
-            fs::remove_file(config_file).with_context(file_deletion_error)?;
-        }
-
-        // remove any unpacked and initialized packages
-        let package_image_dir = path::package_image_root_dir()?.join(name);
-        fs::remove_dir(package_image_dir).with_context(file_deletion_error)?;
-
-        // TODO: optionally remove from inventory
-        // let package_inv_dir = path::package_inventory_dir(&name)?;
-
-        // remove the package config file
-        fs::remove_file(package_config_file).with_context(file_deletion_error)?;
-
-        Ok(())
+    pub fn uninstall_package(&self, name: String, remove_all: bool) -> Fallible<()> {
+        PackageVersion::uninstall(name, remove_all)
     }
 
     /// Fetches a Node version matching the specified semantic versioning requirements.

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -233,6 +233,27 @@ impl Session {
         Ok(package_version.version.clone())
     }
 
+    /// Uninstall the specified package.
+    ///
+    /// This removes:
+    /// * the json config files
+    /// * the shims
+    /// * the unpacked and initialized package
+    ///
+    /// This optionally clears the inventory for this package, removing:
+    /// * the downloaded tarball and shasum files
+    pub fn uninstall_package(&mut self, name: String, remove_all: bool) -> Fallible<()> {
+        // TODO: read the config files to see where things are
+
+        // TODO: remove the shims
+
+        // TODO: remove any unpacked and initialized packages
+
+        // TODO: remove the config files
+
+        Ok(())
+    }
+
     /// Fetches a Node version matching the specified semantic versioning requirements.
     pub fn fetch_node(&mut self, version_spec: &VersionSpec) -> Fallible<Fetched<NodeVersion>> {
         let inventory = self.inventory.get_mut()?;

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -233,8 +233,8 @@ impl Session {
     }
 
     /// Uninstall the specified package.
-    pub fn uninstall_package(&self, name: String, remove_all: bool) -> Fallible<()> {
-        PackageVersion::uninstall(name, remove_all)
+    pub fn uninstall_package(&self, name: String) -> Fallible<()> {
+        PackageVersion::uninstall(name)
     }
 
     /// Fetches a Node version matching the specified semantic versioning requirements.

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -55,6 +55,19 @@ impl ToolSpec {
         }
         Ok(())
     }
+
+    pub fn uninstall(&self, _session: &mut Session) -> Fallible<()> {
+        match self {
+            ToolSpec::Node(_version) => unimplemented!("Uninstalling node not supported yet"),
+            ToolSpec::Yarn(_version) => unimplemented!("Uninstalling node not supported yet"),
+            // ISSUE(#292): Implement install for npm
+            ToolSpec::Npm(_version) => unimplemented!("Uninstalling node not supported yet"),
+            ToolSpec::Package(_name, _version) => {
+                unimplemented!("Uninstalling node not supported yet")
+            }
+        }
+        // Ok(())
+    }
 }
 
 impl Debug for ToolSpec {

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -56,17 +56,17 @@ impl ToolSpec {
         Ok(())
     }
 
-    pub fn uninstall(&self, _session: &mut Session) -> Fallible<()> {
+    pub fn uninstall(&self, session: &mut Session, remove_all: bool) -> Fallible<()> {
         match self {
             ToolSpec::Node(_version) => unimplemented!("Uninstalling node not supported yet"),
             ToolSpec::Yarn(_version) => unimplemented!("Uninstalling node not supported yet"),
             // ISSUE(#292): Implement install for npm
             ToolSpec::Npm(_version) => unimplemented!("Uninstalling node not supported yet"),
-            ToolSpec::Package(_name, _version) => {
-                unimplemented!("Uninstalling node not supported yet")
+            ToolSpec::Package(name, _version) => {
+                session.uninstall_package(name.to_string(), remove_all)?;
             }
         }
-        // Ok(())
+        Ok(())
     }
 }
 

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -56,14 +56,14 @@ impl ToolSpec {
         Ok(())
     }
 
-    pub fn uninstall(&self, session: &mut Session, remove_all: bool) -> Fallible<()> {
+    pub fn uninstall(&self, session: &mut Session) -> Fallible<()> {
         match self {
             ToolSpec::Node(_version) => unimplemented!("Uninstalling Node not supported yet"),
             ToolSpec::Yarn(_version) => unimplemented!("Uninstalling Yarn not supported yet"),
             // ISSUE(#292): Implement install for npm
             ToolSpec::Npm(_version) => unimplemented!("Uninstalling Npm not supported yet"),
             ToolSpec::Package(name, _version) => {
-                session.uninstall_package(name.to_string(), remove_all)?;
+                session.uninstall_package(name.to_string())?;
             }
         }
         Ok(())

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -58,10 +58,10 @@ impl ToolSpec {
 
     pub fn uninstall(&self, session: &mut Session, remove_all: bool) -> Fallible<()> {
         match self {
-            ToolSpec::Node(_version) => unimplemented!("Uninstalling node not supported yet"),
-            ToolSpec::Yarn(_version) => unimplemented!("Uninstalling node not supported yet"),
+            ToolSpec::Node(_version) => unimplemented!("Uninstalling Node not supported yet"),
+            ToolSpec::Yarn(_version) => unimplemented!("Uninstalling Yarn not supported yet"),
             // ISSUE(#292): Implement install for npm
-            ToolSpec::Npm(_version) => unimplemented!("Uninstalling node not supported yet"),
+            ToolSpec::Npm(_version) => unimplemented!("Uninstalling Npm not supported yet"),
             ToolSpec::Package(name, _version) => {
                 session.uninstall_package(name.to_string(), remove_all)?;
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,10 @@ pub(crate) enum Subcommand {
     #[structopt(name = "install", author = "", version = "")]
     Install(command::Install),
 
+    /// Uninstalls a tool from your toolchain
+    #[structopt(name = "uninstall", author = "", version = "")]
+    Uninstall(command::Uninstall),
+
     /// Pins your project's runtime or package manager
     #[structopt(name = "pin", author = "", version = "")]
     Pin(command::Pin),
@@ -128,6 +132,7 @@ impl Subcommand {
         match self {
             Subcommand::Fetch(fetch) => fetch.run(session),
             Subcommand::Install(install) => install.run(session),
+            Subcommand::Uninstall(uninstall) => uninstall.run(session),
             Subcommand::Pin(pin) => pin.run(session),
             Subcommand::Config(config) => config.run(session),
             Subcommand::Current(current) => current.run(session),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod deactivate;
 pub(crate) mod fetch;
 pub(crate) mod install;
 pub(crate) mod pin;
+pub(crate) mod uninstall;
 #[macro_use]
 pub(crate) mod r#use;
 pub(crate) mod which;
@@ -20,6 +21,7 @@ pub(crate) use fetch::Fetch;
 pub(crate) use install::Install;
 pub(crate) use pin::Pin;
 pub(crate) use r#use::Use;
+pub(crate) use uninstall::Uninstall;
 
 use notion_core::session::Session;
 use notion_fail::{ExitCode, Fallible};

--- a/src/command/uninstall.rs
+++ b/src/command/uninstall.rs
@@ -11,10 +11,6 @@ use crate::command::Command;
 pub(crate) struct Uninstall {
     /// The tool to uninstall, e.g. `node`, `npm`, `yarn`, or <package>
     tool: String,
-
-    /// Remove the cached tarball files
-    #[structopt(short = "f", long = "full")]
-    remove_all: bool,
 }
 
 impl Command for Uninstall {
@@ -24,7 +20,7 @@ impl Command for Uninstall {
         let version = VersionSpec::default();
         let tool = ToolSpec::from_str_and_version(&self.tool, version);
 
-        tool.uninstall(session, self.remove_all)?;
+        tool.uninstall(session)?;
 
         session.add_event_end(ActivityKind::Uninstall, ExitCode::Success);
         Ok(ExitCode::Success)

--- a/src/command/uninstall.rs
+++ b/src/command/uninstall.rs
@@ -1,0 +1,32 @@
+// TODO: all of this haha
+use structopt::StructOpt;
+
+use notion_core::session::{ActivityKind, Session};
+use notion_core::tool::ToolSpec;
+use notion_core::version::VersionSpec;
+use notion_fail::{ExitCode, Fallible};
+
+use crate::command::Command;
+
+#[derive(StructOpt)]
+pub(crate) struct Uninstall {
+    /// The tool to uninstall, e.g. `node`, `npm`, `yarn`, or <package>
+    tool: String,
+    // TODO: need this?
+    // /// The version of the tool to uninstall, e.g. `1.2.3` or `latest`
+    // version: Option<String>,
+}
+
+impl Command for Uninstall {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
+        session.add_event_start(ActivityKind::Uninstall);
+
+        let version = VersionSpec::default();
+        let tool = ToolSpec::from_str_and_version(&self.tool, version);
+
+        tool.uninstall(session)?;
+
+        session.add_event_end(ActivityKind::Uninstall, ExitCode::Success);
+        Ok(ExitCode::Success)
+    }
+}

--- a/src/command/uninstall.rs
+++ b/src/command/uninstall.rs
@@ -1,4 +1,3 @@
-// TODO: all of this haha
 use structopt::StructOpt;
 
 use notion_core::session::{ActivityKind, Session};
@@ -12,9 +11,10 @@ use crate::command::Command;
 pub(crate) struct Uninstall {
     /// The tool to uninstall, e.g. `node`, `npm`, `yarn`, or <package>
     tool: String,
-    // TODO: need this?
-    // /// The version of the tool to uninstall, e.g. `1.2.3` or `latest`
-    // version: Option<String>,
+
+    /// Remove the cached tarball files
+    #[structopt(short = "f", long = "full")]
+    remove_all: bool,
 }
 
 impl Command for Uninstall {
@@ -24,7 +24,7 @@ impl Command for Uninstall {
         let version = VersionSpec::default();
         let tool = ToolSpec::from_str_and_version(&self.tool, version);
 
-        tool.uninstall(session)?;
+        tool.uninstall(session, self.remove_all)?;
 
         session.add_event_end(ActivityKind::Uninstall, ExitCode::Success);
         Ok(ExitCode::Success)

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -6,4 +6,5 @@ mod intercept_global_installs;
 mod notion_current;
 mod notion_deactivate;
 mod notion_pin;
+mod notion_uninstall;
 mod verbose_errors;

--- a/tests/acceptance/notion_uninstall.rs
+++ b/tests/acceptance/notion_uninstall.rs
@@ -1,15 +1,250 @@
-use crate::support::sandbox::sandbox;
+use crate::support::sandbox::{sandbox, Sandbox};
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
 
+const PKG_CONFIG_BASIC: &'static str = r#"{
+  "name": "cowsay",
+  "version": "1.4.0",
+  "platform": {
+    "node": {
+      "runtime": "11.10.1",
+      "npm": "6.7.0"
+    },
+    "yarn": null
+  },
+  "bins": [
+    "cowsay",
+    "cowthink"
+  ]
+}"#;
+
+const PKG_CONFIG_NO_BINS: &'static str = r#"{
+  "name": "cowsay",
+  "version": "1.4.0",
+  "platform": {
+    "node": {
+      "runtime": "11.10.1",
+      "npm": "6.7.0"
+    },
+    "yarn": null
+  },
+  "bins": []
+}"#;
+
+fn bin_config(name: &str) -> String {
+    format!(
+        r#"{{
+  "name": "{}",
+  "package": "cowsay",
+  "version": "1.4.0",
+  "path": "./cli.js",
+  "platform": {{
+    "node": {{
+      "runtime": "11.10.1",
+      "npm": "6.7.0"
+    }},
+    "yarn": null
+  }}
+}}"#,
+        name
+    )
+}
+
 #[test]
 fn uninstall_nonexistent_pkg() {
+    // if the package doesn't exist, it should just inform the user but not throw an error
     let s = sandbox().build();
+
     assert_that!(
         s.notion("uninstall cowsay"),
         execs()
-            .with_status(4)
-            .with_stderr_contains("error: Package `cowsay` is not installed")
+            .with_status(0)
+            .with_stdout_contains("Package 'cowsay' uninstalled")
     );
+}
+
+#[test]
+fn uninstall_package_basic() {
+    // basic uninstall - everything exists, and everything except the cached
+    // inventory files should be deleted
+    let s = sandbox()
+        .package_config("cowsay", PKG_CONFIG_BASIC)
+        .binary_config("cowsay", &bin_config("cowsay"))
+        .binary_config("cowthink", &bin_config("cowthink"))
+        .shim("cowsay")
+        .shim("cowthink")
+        .package_image("cowsay", "1.4.0")
+        .package_inventory("cowsay", "1.4.0")
+        .build();
+
+    assert_that!(
+        s.notion("uninstall cowsay"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Removed executable 'cowsay' installed by 'cowsay'")
+            .with_stdout_contains("Removed executable 'cowthink' installed by 'cowsay'")
+            .with_stdout_contains("Package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::package_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
+    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
+    // but the inventory files still exist
+    assert!(Sandbox::pkg_inventory_tarball_exists("cowsay", "1.4.0"));
+    assert!(Sandbox::pkg_inventory_shasum_exists("cowsay", "1.4.0"));
+}
+
+#[test]
+fn uninstall_package_no_bins() {
+    // the package doesn't contain any executables, it should uninstall without error
+    // (normally installing a package with no executables should not happen)
+    let s = sandbox()
+        .package_config("cowsay", PKG_CONFIG_NO_BINS)
+        .package_image("cowsay", "1.4.0")
+        .package_inventory("cowsay", "1.4.0")
+        .build();
+
+    assert_that!(
+        s.notion("uninstall cowsay"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::package_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
+    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
+    // but the inventory files still exist
+    assert!(Sandbox::pkg_inventory_tarball_exists("cowsay", "1.4.0"));
+    assert!(Sandbox::pkg_inventory_shasum_exists("cowsay", "1.4.0"));
+}
+
+#[test]
+fn uninstall_package_full() {
+    // everything exists, and it should all be removed
+    let s = sandbox()
+        .package_config("cowsay", PKG_CONFIG_BASIC)
+        .binary_config("cowsay", &bin_config("cowsay"))
+        .binary_config("cowthink", &bin_config("cowthink"))
+        .shim("cowsay")
+        .shim("cowthink")
+        .package_image("cowsay", "1.4.0")
+        .package_inventory("cowsay", "1.4.0")
+        .build();
+
+    assert_that!(
+        s.notion("uninstall cowsay --full"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Removed executable 'cowsay' installed by 'cowsay'")
+            .with_stdout_contains("Removed executable 'cowthink' installed by 'cowsay'")
+            .with_stdout_contains("Removed cached files for 'cowsay'")
+            .with_stdout_contains("Package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::package_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
+    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
+    // including the inventory files
+    assert!(!Sandbox::pkg_inventory_tarball_exists("cowsay", "1.4.0"));
+    assert!(!Sandbox::pkg_inventory_shasum_exists("cowsay", "1.4.0"));
+}
+
+#[test]
+fn uninstall_package_full_archive_only() {
+    // only the tarball and shasum files exist, and those should be removed
+    let s = sandbox().package_inventory("cowsay", "1.4.0").build();
+
+    assert_that!(
+        s.notion("uninstall cowsay --full"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Removed cached files for 'cowsay'")
+            .with_stdout_contains("Package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::package_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
+    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
+    // including the inventory files
+    assert!(!Sandbox::pkg_inventory_tarball_exists("cowsay", "1.4.0"));
+    assert!(!Sandbox::pkg_inventory_shasum_exists("cowsay", "1.4.0"));
+}
+
+#[test]
+fn uninstall_package_no_image() {
+    // there is no unpacked & initialized package, but everything should be removed
+    // (without erroring and failing to remove everything)
+    let s = sandbox()
+        .package_config("cowsay", PKG_CONFIG_BASIC)
+        .binary_config("cowsay", &bin_config("cowsay"))
+        .binary_config("cowthink", &bin_config("cowthink"))
+        .shim("cowsay")
+        .shim("cowthink")
+        .package_inventory("cowsay", "1.4.0")
+        .build();
+
+    assert_that!(
+        s.notion("uninstall cowsay"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Removed executable 'cowsay' installed by 'cowsay'")
+            .with_stdout_contains("Removed executable 'cowthink' installed by 'cowsay'")
+            .with_stdout_contains("Package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::package_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
+    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
+    // but the inventory files still exist
+    assert!(Sandbox::pkg_inventory_tarball_exists("cowsay", "1.4.0"));
+    assert!(Sandbox::pkg_inventory_shasum_exists("cowsay", "1.4.0"));
+}
+
+#[test]
+fn uninstall_package_orphaned_bins() {
+    // the package config does not exist, but for some reason there are orphaned binaries
+    // those should be removed
+    let s = sandbox()
+        .binary_config("cowsay", &bin_config("cowsay"))
+        .binary_config("cowthink", &bin_config("cowthink"))
+        .shim("cowsay")
+        .shim("cowthink")
+        .build();
+
+    assert_that!(
+        s.notion("uninstall cowsay"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("Removed executable 'cowsay' installed by 'cowsay'")
+            .with_stdout_contains("Removed executable 'cowthink' installed by 'cowsay'")
+            .with_stdout_contains("Package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
 }

--- a/tests/acceptance/notion_uninstall.rs
+++ b/tests/acceptance/notion_uninstall.rs
@@ -1,0 +1,15 @@
+use crate::support::sandbox::sandbox;
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+#[test]
+fn uninstall_nonexistent_pkg() {
+    let s = sandbox().build();
+    assert_that!(
+        s.notion("uninstall cowsay"),
+        execs()
+            .with_status(4)
+            .with_stderr_contains("error: Package `cowsay` is not installed")
+    );
+}

--- a/tests/acceptance/notion_uninstall.rs
+++ b/tests/acceptance/notion_uninstall.rs
@@ -129,66 +129,6 @@ fn uninstall_package_no_bins() {
 }
 
 #[test]
-fn uninstall_package_full() {
-    // everything exists, and it should all be removed
-    let s = sandbox()
-        .package_config("cowsay", PKG_CONFIG_BASIC)
-        .binary_config("cowsay", &bin_config("cowsay"))
-        .binary_config("cowthink", &bin_config("cowthink"))
-        .shim("cowsay")
-        .shim("cowthink")
-        .package_image("cowsay", "1.4.0")
-        .package_inventory("cowsay", "1.4.0")
-        .build();
-
-    assert_that!(
-        s.notion("uninstall cowsay --full"),
-        execs()
-            .with_status(0)
-            .with_stdout_contains("Removed executable 'cowsay' installed by 'cowsay'")
-            .with_stdout_contains("Removed executable 'cowthink' installed by 'cowsay'")
-            .with_stdout_contains("Removed cached files for 'cowsay'")
-            .with_stdout_contains("Package 'cowsay' uninstalled")
-    );
-
-    // check that everything is deleted
-    assert!(!Sandbox::package_config_exists("cowsay"));
-    assert!(!Sandbox::bin_config_exists("cowsay"));
-    assert!(!Sandbox::bin_config_exists("cowthink"));
-    assert!(!Sandbox::shim_exists("cowsay"));
-    assert!(!Sandbox::shim_exists("cowthink"));
-    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
-    // including the inventory files
-    assert!(!Sandbox::pkg_inventory_tarball_exists("cowsay", "1.4.0"));
-    assert!(!Sandbox::pkg_inventory_shasum_exists("cowsay", "1.4.0"));
-}
-
-#[test]
-fn uninstall_package_full_archive_only() {
-    // only the tarball and shasum files exist, and those should be removed
-    let s = sandbox().package_inventory("cowsay", "1.4.0").build();
-
-    assert_that!(
-        s.notion("uninstall cowsay --full"),
-        execs()
-            .with_status(0)
-            .with_stdout_contains("Removed cached files for 'cowsay'")
-            .with_stdout_contains("Package 'cowsay' uninstalled")
-    );
-
-    // check that everything is deleted
-    assert!(!Sandbox::package_config_exists("cowsay"));
-    assert!(!Sandbox::bin_config_exists("cowsay"));
-    assert!(!Sandbox::bin_config_exists("cowthink"));
-    assert!(!Sandbox::shim_exists("cowsay"));
-    assert!(!Sandbox::shim_exists("cowthink"));
-    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
-    // including the inventory files
-    assert!(!Sandbox::pkg_inventory_tarball_exists("cowsay", "1.4.0"));
-    assert!(!Sandbox::pkg_inventory_shasum_exists("cowsay", "1.4.0"));
-}
-
-#[test]
 fn uninstall_package_no_image() {
     // there is no unpacked & initialized package, but everything should be removed
     // (without erroring and failing to remove everything)

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -508,7 +508,7 @@ fn binary_config_file(name: &str) -> PathBuf {
     user_dir().join("bins").join(format!("{}.json", name))
 }
 fn shim_file(name: &str) -> PathBuf {
-    notion_bin_dir().join(name)
+    notion_bin_dir().join(format!("{}{}", name, env::consts::EXE_SUFFIX))
 }
 fn package_image_dir(name: &str, version: &str) -> PathBuf {
     image_dir().join("packages").join(name).join(version)


### PR DESCRIPTION
This implements package uninstall: #319.

```
$ ./target/debug/notion uninstall cowsay
Removed executable 'cowthink' installed by 'cowsay'
Removed executable 'cowsay' installed by 'cowsay'
Package 'cowsay' uninstalled
```

```
$ ./target/debug/notion uninstall cowsay --full
Removed cached files for 'cowsay'
Package 'cowsay' uninstalled
```

Removes:
* [x] the json config files
* [x] the shims
* [x] the unpacked and initialized package

Optionally remove (with the `--full` flag):
* [x] the downloaded tarball and shasum files

Closes #319 