### PR TITLE
Check user platform as well as project for npm

### DIFF
--- a/crates/notion-core/src/tool/npm.rs
+++ b/crates/notion-core/src/tool/npm.rs
@@ -21,8 +21,7 @@ impl Tool for Npm {
             throw!(ErrorDetails::NoGlobalInstalls);
         }
 
-        // if we're in a pinned project, use npm from that platform
-        if let Some(ref platform) = session.project_platform()? {
+        if let Some(ref platform) = session.current_platform()? {
             let image = platform.checkout(session)?;
             Ok(Self::from_components(
                 OsStr::new("npm"),


### PR DESCRIPTION
Somewhere in the mix of several of the sweeping changes that have been made recently, we inadvertently set `npm` to only look at the `project_platform`, not the `current_platform` (which also checks for a user platform).

This caused calls to `npm` to fail if you weren't inside of a project, because it was only looking for a `package.json` and failing if it didn't find one.

Updated to use `session.current_platform()`, instead of `session.project_platform()`.