### PR TITLE
List all causes in verbose errors

### DIFF
--- a/crates/notion-core/src/error/reporter.rs
+++ b/crates/notion-core/src/error/reporter.rs
@@ -107,12 +107,11 @@ fn compose_error_details(err: &NotionError) -> Option<String> {
 
     // Walk up the tree of causes and include all of them
     loop {
-        write!(details, "{}", format_error_cause(current))
-            .expect("write! to a String doesn't fail");
+        details.push_str(&format_error_cause(current));
 
         match current.cause() {
             Some(cause) => {
-                write!(details, "\n\n").expect("write! to a String doesn't fail");
+                details.push_str("\n\n");
                 current = cause;
             }
             None => {


### PR DESCRIPTION
Info
-----
* The verbose error output (and error logs) currently only shows the first level underlying cause of a given error. If the error is more deeply nested, with multiple wrapper `Error`s, then only the first will be listed.

Changes
-----
* Updated the `compose_error_details` method to traverse the entire tree of `.cause()` calls, outputting all of the causes.
* Also refactored the code a bit so `compose_error_details` returns an `Option`, instead of unwrapping the cause outside.