### PR TITLE
First pass at auditing existing error messages

### DIFF
--- a/crates/notion-core/src/distro/mod.rs
+++ b/crates/notion-core/src/distro/mod.rs
@@ -8,9 +8,7 @@ use crate::error::ErrorDetails;
 use crate::hook::ToolHooks;
 use crate::inventory::Collection;
 use crate::tool::ToolSpec;
-use archive::HttpError;
 use notion_fail::Fallible;
-use reqwest::StatusCode;
 use semver::Version;
 
 /// The result of a requested installation.
@@ -58,18 +56,9 @@ pub trait Distro: Sized {
 }
 
 fn download_tool_error(
-    toolspec: ToolSpec,
+    tool: ToolSpec,
     from_url: impl AsRef<str>,
 ) -> impl FnOnce(&failure::Error) -> ErrorDetails {
     let from_url = from_url.as_ref().to_string();
-    move |error| match error.downcast_ref::<HttpError>() {
-        Some(HttpError {
-            code: StatusCode::NOT_FOUND,
-        }) => ErrorDetails::DownloadToolNotFound { tool: toolspec },
-        Some(_) | None => ErrorDetails::DownloadToolNetworkError {
-            tool: toolspec,
-            error: error.to_string(),
-            from_url,
-        },
-    }
+    |_| ErrorDetails::DownloadToolNetworkError { tool, from_url }
 }

--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -364,7 +364,8 @@ impl PackageVersion {
                 PackageVersion::remove_config_and_shims(&bin_name, &name)?;
             }
 
-            fs::remove_file(package_config_file).with_context(file_deletion_error)?;
+            fs::remove_file(&package_config_file)
+                .with_context(delete_file_error(&package_config_file))?;
         } else {
             // there is no package config - check for orphaned binaries
             let user_bin_dir = path::user_bin_dir()?;
@@ -379,7 +380,8 @@ impl PackageVersion {
         // if any unpacked and initialized packages exists, remove them
         let package_image_dir = path::package_image_root_dir()?.join(&name);
         if package_image_dir.exists() {
-            fs::remove_dir_all(package_image_dir).with_context(file_deletion_error)?;
+            fs::remove_dir_all(&package_image_dir)
+                .with_context(delete_dir_error(&package_image_dir))?;
         }
 
         println!("Package '{}' uninstalled", name);
@@ -388,18 +390,22 @@ impl PackageVersion {
 
     fn remove_config_and_shims(bin_name: &str, name: &str) -> Fallible<()> {
         let shim = path::shim_file(&bin_name)?;
-        fs::remove_file(shim).with_context(file_deletion_error)?;
+        fs::remove_file(&shim).with_context(delete_file_error(&shim))?;
         let config_file = path::user_tool_bin_config(&bin_name)?;
-        fs::remove_file(config_file).with_context(file_deletion_error)?;
+        fs::remove_file(&config_file).with_context(delete_file_error(&config_file))?;
         println!("Removed executable '{}' installed by '{}'", bin_name, name);
         Ok(())
     }
 }
 
-fn file_deletion_error(err: &io::Error) -> ErrorDetails {
-    ErrorDetails::FileDeletionError {
-        error: err.to_string(),
-    }
+fn delete_file_error(file: &PathBuf) -> impl FnOnce(&io::Error) -> ErrorDetails {
+    let file = file.to_string_lossy().to_string();
+    |_| ErrorDetails::DeleteFileError { file }
+}
+
+fn delete_dir_error(directory: &PathBuf) -> impl FnOnce(&io::Error) -> ErrorDetails {
+    let directory = directory.to_string_lossy().to_string();
+    |_| ErrorDetails::DeleteDirectoryError { directory }
 }
 
 /// Reads the contents of a directory and returns a Vec containing the names of

--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -172,11 +172,7 @@ impl Distro for PackageDistro {
         f.write_all(self.shasum.as_bytes()).unknown()?;
         f.sync_all().unknown()?;
 
-        let pkg_info = Manifest::for_dir(&self.image_dir).with_context(|error| {
-            ErrorDetails::DepPackageReadError {
-                error: error.to_string(),
-            }
-        })?;
+        let pkg_info = Manifest::for_dir(&self.image_dir)?;
         let bin_map = pkg_info.bin;
         if bin_map.is_empty() {
             throw!(ErrorDetails::NoPackageExecutables);

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -26,8 +26,6 @@ pub enum ErrorDetails {
     /// Thrown when a user tries to `notion pin` something other than node/yarn/npm.
     CannotPinPackage,
 
-    CliParseError,
-
     CommandNotImplemented {
         command_name: String,
     },
@@ -36,7 +34,6 @@ pub enum ErrorDetails {
 
     CreateDirError {
         dir: String,
-        error: String,
     },
 
     /// Thrown when reading dependency package info fails
@@ -193,15 +190,14 @@ Use `notion install` to add a package to your toolchain (see `notion help instal
             ErrorDetails::CannotPinPackage => {
                 write!(f, "Only node, yarn, and npm can be pinned in a project")
             }
-            ErrorDetails::CliParseError => {
-                write!(f, "There was a problem parsing the command line input")
-            }
             ErrorDetails::CommandNotImplemented { command_name } => {
                 write!(f, "command `{}` is not yet implemented", command_name)
             }
             ErrorDetails::CouldNotDetermineTool => write!(f, "Tool name could not be determined"),
-            ErrorDetails::CreateDirError { dir, error } => {
-                write!(f, "Could not create directory {}: {}", dir, error)
+            ErrorDetails::CreateDirError { dir } => {
+                write!(f, "Could not create directory {}
+
+Please ensure that you have the correct permissions.", dir)
             }
             ErrorDetails::DepPackageReadError => {
                 write!(f, "Could not read package info for dependencies.
@@ -366,7 +362,6 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::BinaryExecError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::BinaryNotFound { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::CannotPinPackage => ExitCode::InvalidArguments,
-            ErrorDetails::CliParseError => ExitCode::UnknownError,
             ErrorDetails::CommandNotImplemented { .. } => ExitCode::NotYetImplemented,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CreateDirError { .. } => ExitCode::FileSystemError,

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -34,6 +34,16 @@ pub enum ErrorDetails {
         dir: String,
     },
 
+    /// Thrown when deleting a directory fails
+    DeleteDirectoryError {
+        directory: String,
+    },
+
+    /// Thrown when deleting a file fails
+    DeleteFileError {
+        file: String,
+    },
+
     /// Thrown when reading dependency package info fails
     DepPackageReadError,
 
@@ -45,10 +55,6 @@ pub enum ErrorDetails {
     DownloadToolNetworkError {
         tool: ToolSpec,
         from_url: String,
-    },
-
-    FileDeletionError {
-        error: String,
     },
 
     InvalidHookCommand {
@@ -203,6 +209,14 @@ Use `notion install` to add a package to your toolchain (see `notion help instal
 
 Please ensure that you have the correct permissions.", dir)
             }
+            ErrorDetails::DeleteDirectoryError { directory } => write!(f, "Could not remove directory
+at {}
+
+Please ensure you have correct permissions to the Notion directory.", directory),
+            ErrorDetails::DeleteFileError { file } => write!(f, "Could not remove file
+at {}
+
+Please ensure you have correct permissions to the Notion directory.", file),
             ErrorDetails::DepPackageReadError => {
                 write!(f, "Could not read package info for dependencies.
 
@@ -219,7 +233,6 @@ from {}
 Please verify your internet connection and ensure the correct version is specified.",
                 tool, from_url
             ),
-            ErrorDetails::FileDeletionError { error } => write!(f, "Error deleting file: {}", error),
             ErrorDetails::InvalidHookCommand { command } => write!(f, "Invalid hook command: '{}'", command),
             ErrorDetails::NoBinPlatform { binary } => {
                 write!(f, "Platform info for executable `{}` is missing", binary)
@@ -368,10 +381,11 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::CommandNotImplemented { .. } => ExitCode::NotYetImplemented,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CreateDirError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::DeleteDirectoryError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::DeleteFileError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DepPackageReadError => ExitCode::FileSystemError,
             ErrorDetails::DeprecatedCommandError { .. } => ExitCode::InvalidArguments,
             ErrorDetails::DownloadToolNetworkError { .. } => ExitCode::NetworkError,
-            ErrorDetails::FileDeletionError { .. } => ExitCode::FileSystemError,
             ErrorDetails::InvalidHookCommand { .. } => ExitCode::UnknownError,
             ErrorDetails::NoBinPlatform { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::NodeVersionNotFound { .. } => ExitCode::NoVersionMatch,

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -14,9 +14,7 @@ pub enum ErrorDetails {
         version: String,
     },
 
-    BinaryExecError {
-        error: String,
-    },
+    BinaryExecError,
 
     /// Thrown when a binary could not be found in the local inventory
     BinaryNotFound {
@@ -183,7 +181,9 @@ impl fmt::Display for ErrorDetails {
                 "Conflict with bin '{}' already installed by '{}' version {}",
                 bin_name, package, version
             ),
-            ErrorDetails::BinaryExecError { error } => write!(f, "{}", error),
+            ErrorDetails::BinaryExecError => write!(f, "Could not execute command.
+
+See `notion help install` and `notion help pin` for info about making tools available."),
             ErrorDetails::BinaryNotFound { name } => write!(f, r#"Could not find executable "{}"
 
 Use `notion install` to add a package to your toolchain (see `notion help install` for more info)."#, name),
@@ -359,7 +359,7 @@ impl NotionFail for ErrorDetails {
     fn exit_code(&self) -> ExitCode {
         match self {
             ErrorDetails::BinaryAlreadyInstalled { .. } => ExitCode::FileSystemError,
-            ErrorDetails::BinaryExecError { .. } => ExitCode::ExecutionFailure,
+            ErrorDetails::BinaryExecError => ExitCode::ExecutionFailure,
             ErrorDetails::BinaryNotFound { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::CannotPinPackage => ExitCode::InvalidArguments,
             ErrorDetails::CommandNotImplemented { .. } => ExitCode::NotYetImplemented,

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::process::ExitStatus;
 
 use failure::Fail;
 use notion_fail::{ExitCode, NotionFail};
@@ -99,15 +98,7 @@ pub enum ErrorDetails {
     },
 
     /// Thrown when package install command is not successful.
-    PackageInstallFailed {
-        cmd: String,
-        status: ExitStatus,
-    },
-
-    /// Thrown when package install command fails to execute.
-    PackageInstallIoError {
-        error: String,
-    },
+    PackageInstallFailed,
 
     /// Thrown when there is an error fetching package metadata
     PackageMetadataFetchError {
@@ -281,12 +272,10 @@ Use `notion install yarn` to select a default version (see `notion help install 
 This project is configured to use version {} of npm.",
                 version
             ),
-            ErrorDetails::PackageInstallFailed { cmd, status } => {
-                write!(f, "Command `{}` failed with status {}", cmd, status)
-            }
-            ErrorDetails::PackageInstallIoError { error } => {
-                write!(f, "Error executing package install command: {}", error)
-            }
+            // Confirming permissions is a Weak CTA in this case, but it seems the most likely error vector
+            ErrorDetails::PackageInstallFailed => write!(f, "Could not install package dependencies.
+
+Please ensure you have correct permissions to the Notion directory."),
             ErrorDetails::PackageMetadataFetchError { from_url } => write!(
                 f,
                 "Could not download package metadata
@@ -385,8 +374,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::NoUserYarn => ExitCode::ConfigurationError,
             ErrorDetails::NoVersionsFound => ExitCode::NoVersionMatch,
             ErrorDetails::NpxNotAvailable { .. } => ExitCode::ExecutableNotFound,
-            ErrorDetails::PackageInstallFailed { .. } => ExitCode::FileSystemError,
-            ErrorDetails::PackageInstallIoError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::PackageInstallFailed => ExitCode::FileSystemError,
             ErrorDetails::PackageMetadataFetchError { .. } => ExitCode::NetworkError,
             ErrorDetails::PackageReadError { .. } => ExitCode::FileSystemError,
             ErrorDetails::PackageUnpackError => ExitCode::ConfigurationError,

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -153,7 +153,7 @@ pub enum ErrorDetails {
     UnspecifiedShell,
 
     VersionParseError {
-        error: String,
+        version: String,
     },
 
     /// Thrown when there is an error fetching the latest version of Yarn
@@ -314,7 +314,9 @@ Please verify your internet connection.",
                 write!(f, "Notion postscript file not specified")
             }
             ErrorDetails::UnspecifiedShell => write!(f, "Notion shell not specified"),
-            ErrorDetails::VersionParseError { error } => write!(f, "{}", error),
+            ErrorDetails::VersionParseError { version } => write!(f, r#"Could not parse version "{}"
+
+Please verify the intended version."#, version),
             ErrorDetails::YarnLatestFetchError { from_url } => write!(
                 f,
                 "Could not fetch latest version of Yarn

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -115,7 +115,7 @@ pub enum ErrorDetails {
     },
 
     PackageReadError {
-        error: String,
+        file: String,
     },
 
     /// Thrown when a package has been unpacked but is not formed correctly.
@@ -295,8 +295,11 @@ from {}
 Please verify your internet connection.",
                 from_url
             ),
-            ErrorDetails::PackageReadError { error } => {
-                write!(f, "Could not read package info: {}", error)
+            ErrorDetails::PackageReadError { file } => {
+                write!(f, "Could not read project manifest
+from {}
+
+Please ensure that the file exists and is correctly formatted.", file)
             }
             ErrorDetails::PackageUnpackError => write!(
                 f,

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -39,9 +39,8 @@ pub enum ErrorDetails {
         error: String,
     },
 
-    DepPackageReadError {
-        error: String,
-    },
+    /// Thrown when reading dependency package info fails
+    DepPackageReadError,
 
     DeprecatedCommandError {
         command: String,
@@ -105,6 +104,12 @@ pub enum ErrorDetails {
         from_url: String,
     },
 
+    /// Thrown when parsing a package manifest fails
+    PackageParseError {
+        file: String,
+    },
+
+    /// Thrown when reading a package manifest fails
     PackageReadError {
         file: String,
     },
@@ -198,8 +203,10 @@ Use `notion install` to add a package to your toolchain (see `notion help instal
             ErrorDetails::CreateDirError { dir, error } => {
                 write!(f, "Could not create directory {}: {}", dir, error)
             }
-            ErrorDetails::DepPackageReadError { error } => {
-                write!(f, "Could not read dependent package info: {}", error)
+            ErrorDetails::DepPackageReadError => {
+                write!(f, "Could not read package info for dependencies.
+
+Please ensure that all dependencies have been installed.")
             }
             ErrorDetails::DeprecatedCommandError { command, advice } => {
                 write!(f, "The subcommand `{}` is deprecated.\n{}", command, advice)
@@ -284,11 +291,17 @@ from {}
 Please verify your internet connection.",
                 from_url
             ),
+            ErrorDetails::PackageParseError { file } => {
+                write!(f, "Could not parse project manifest
+at {}
+
+Please ensure that the file is correctly formatted.", file)
+            },
             ErrorDetails::PackageReadError { file } => {
                 write!(f, "Could not read project manifest
 from {}
 
-Please ensure that the file exists and is correctly formatted.", file)
+Please ensure that the file exists.", file)
             }
             ErrorDetails::PackageUnpackError => write!(
                 f,
@@ -357,7 +370,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::CommandNotImplemented { .. } => ExitCode::NotYetImplemented,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CreateDirError { .. } => ExitCode::FileSystemError,
-            ErrorDetails::DepPackageReadError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::DepPackageReadError => ExitCode::FileSystemError,
             ErrorDetails::DeprecatedCommandError { .. } => ExitCode::InvalidArguments,
             ErrorDetails::DownloadToolNetworkError { .. } => ExitCode::NetworkError,
             ErrorDetails::InvalidHookCommand { .. } => ExitCode::UnknownError,
@@ -376,6 +389,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::NpxNotAvailable { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::PackageInstallFailed => ExitCode::FileSystemError,
             ErrorDetails::PackageMetadataFetchError { .. } => ExitCode::NetworkError,
+            ErrorDetails::PackageParseError { .. } => ExitCode::ConfigurationError,
             ErrorDetails::PackageReadError { .. } => ExitCode::FileSystemError,
             ErrorDetails::PackageUnpackError => ExitCode::ConfigurationError,
             ErrorDetails::PackageVersionNotFound { .. } => ExitCode::NoVersionMatch,

--- a/crates/notion-core/src/fs.rs
+++ b/crates/notion-core/src/fs.rs
@@ -16,20 +16,15 @@ pub fn touch(path: &Path) -> Fallible<File> {
     File::open(path).unknown()
 }
 
-fn error_for_dir(dir: String) -> impl FnOnce(&io::Error) -> ErrorDetails {
-    move |error| ErrorDetails::CreateDirError {
-        dir,
-        error: error.to_string(),
-    }
-}
-
 /// This creates the parent directory of the input path, assuming the input path is a file.
 pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Fallible<()> {
     path.as_ref()
         .parent()
         .ok_or(ErrorDetails::PathError.into())
         .and_then(|dir| {
-            fs::create_dir_all(dir).with_context(error_for_dir(dir.to_string_lossy().to_string()))
+            fs::create_dir_all(dir).with_context(|_| ErrorDetails::CreateDirError {
+                dir: dir.to_string_lossy().to_string(),
+            })
         })
 }
 

--- a/crates/notion-core/src/inventory/mod.rs
+++ b/crates/notion-core/src/inventory/mod.rs
@@ -214,7 +214,7 @@ impl FetchResolve<NodeDistro> for NodeCollection {
         hooks: Option<&ToolHooks<NodeDistro>>,
     ) -> Fallible<Fetched<NodeVersion>> {
         let distro = self.resolve(name, matching, hooks)?;
-        let fetched = distro.fetch(&self).unknown()?;
+        let fetched = distro.fetch(&self)?;
 
         if let &Fetched::Now(NodeVersion {
             runtime: ref version,
@@ -301,7 +301,7 @@ impl FetchResolve<YarnDistro> for YarnCollection {
         hooks: Option<&ToolHooks<YarnDistro>>,
     ) -> Fallible<Fetched<Self::FetchedVersion>> {
         let distro = self.resolve(name, &matching, hooks)?;
-        let fetched = distro.fetch(&self).unknown()?;
+        let fetched = distro.fetch(&self)?;
 
         if let &Fetched::Now(ref version) = &fetched {
             self.versions.insert(version.clone());
@@ -405,7 +405,7 @@ impl FetchResolve<PackageDistro> for PackageCollection {
         hooks: Option<&ToolHooks<PackageDistro>>,
     ) -> Fallible<Fetched<Self::FetchedVersion>> {
         let distro = self.resolve(name, &matching, hooks)?;
-        let fetched = distro.fetch(&self).unknown()?;
+        let fetched = distro.fetch(&self)?;
 
         if let &Fetched::Now(PackageVersion { ref version, .. }) = &fetched {
             self.versions.insert(version.clone());

--- a/crates/notion-core/src/inventory/mod.rs
+++ b/crates/notion-core/src/inventory/mod.rs
@@ -286,7 +286,7 @@ impl FetchResolve<NodeDistro> for NodeCollection {
         version: Version,
         _hooks: Option<&ToolHooks<NodeDistro>>,
     ) -> Fallible<Version> {
-        Ok(version.clone())
+        Ok(version)
     }
 }
 
@@ -365,7 +365,7 @@ impl FetchResolve<YarnDistro> for YarnCollection {
         version: Version,
         _hooks: Option<&ToolHooks<YarnDistro>>,
     ) -> Fallible<Version> {
-        Ok(version.clone())
+        Ok(version)
     }
 }
 
@@ -438,9 +438,9 @@ impl FetchResolve<PackageDistro> for PackageCollection {
         if let Some(entry) = entry_opt {
             Ok(entry)
         } else {
-            throw!(ErrorDetails::NoPackageFound {
+            throw!(ErrorDetails::PackageVersionNotFound {
                 name: name.to_string(),
-                matching: VersionSpec::Latest,
+                matching: String::from("latest"),
             })
         }
     }
@@ -469,9 +469,9 @@ impl FetchResolve<PackageDistro> for PackageCollection {
         if let Some(entry) = entry_opt {
             Ok(entry)
         } else {
-            throw!(ErrorDetails::NoPackageFound {
+            throw!(ErrorDetails::PackageVersionNotFound {
                 name: name.to_string(),
-                matching: VersionSpec::Latest,
+                matching: matching.to_string(),
             })
         }
     }
@@ -500,9 +500,9 @@ impl FetchResolve<PackageDistro> for PackageCollection {
         if let Some(entry) = entry_opt {
             Ok(entry)
         } else {
-            throw!(ErrorDetails::NoPackageFound {
+            throw!(ErrorDetails::PackageVersionNotFound {
                 name: name.to_string(),
-                matching: VersionSpec::Latest,
+                matching: exact_version.to_string(),
             })
         }
     }

--- a/crates/notion-core/src/manifest/mod.rs
+++ b/crates/notion-core/src/manifest/mod.rs
@@ -38,7 +38,11 @@ impl Manifest {
             file: package_file.to_string_lossy().to_string(),
         })?;
 
-        let serial: serial::Manifest = serde_json::de::from_reader(file).unknown()?;
+        let serial: serial::Manifest = serde_json::de::from_reader(file).with_context(|_| {
+            ErrorDetails::PackageParseError {
+                file: package_file.to_string_lossy().to_string(),
+            }
+        })?;
         serial.into_manifest()
     }
 

--- a/crates/notion-core/src/manifest/mod.rs
+++ b/crates/notion-core/src/manifest/mod.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use crate::error::ErrorDetails;
 use crate::platform::PlatformSpec;
 use detect_indent;
-use notion_fail::{throw, Fallible, ResultExt};
+use notion_fail::{Fallible, ResultExt};
 use semver::Version;
 use serde::Serialize;
 use serde_json;
@@ -33,28 +33,13 @@ pub struct Manifest {
 impl Manifest {
     /// Loads and parses a Node manifest for the project rooted at the specified path.
     pub fn for_dir(project_root: &Path) -> Fallible<Manifest> {
-        let maybe_file = File::open(project_root.join("package.json"));
+        let package_file = project_root.join("package.json");
+        let file = File::open(&package_file).with_context(|_| ErrorDetails::PackageReadError {
+            file: package_file.to_string_lossy().to_string(),
+        })?;
 
-        match maybe_file {
-            Ok(file) => {
-                let serial: serial::Manifest = serde_json::de::from_reader(file).unknown()?;
-                serial.into_manifest()
-            }
-            Err(error) => {
-                if project_root.is_dir() {
-                    throw!(ErrorDetails::PackageReadError {
-                        error: error.to_string(),
-                    });
-                }
-
-                throw!(ErrorDetails::PackageReadError {
-                    error: format!(
-                        "directory does not exist: {}",
-                        project_root.to_string_lossy().into_owned()
-                    ),
-                });
-            }
-        }
+        let serial: serial::Manifest = serde_json::de::from_reader(file).unknown()?;
+        serial.into_manifest()
     }
 
     /// Returns a reference to the platform image specified by manifest, if any.

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -46,8 +46,7 @@ impl LazyDependentBins {
 
     /// Forces creating the dependent bins and returns an immutable reference to it.
     pub fn get(&self, project: &Project) -> Fallible<&HashMap<String, String>> {
-        self.bins
-            .try_borrow_with(|| Ok(project.dependent_binaries()?))
+        self.bins.try_borrow_with(|| project.dependent_binaries())
     }
 }
 

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -150,11 +150,8 @@ impl Project {
 
         // use those project paths to get the "bin" info for each project
         for pkg_path in all_dep_paths {
-            let pkg_info = Manifest::for_dir(&pkg_path).with_context(|error| {
-                ErrorDetails::DepPackageReadError {
-                    error: error.to_string(),
-                }
-            })?;
+            let pkg_info =
+                Manifest::for_dir(&pkg_path).with_context(|_| ErrorDetails::DepPackageReadError)?;
             let bin_map = pkg_info.bin;
             for (name, path) in bin_map.iter() {
                 dependent_bins.insert(name.clone(), path.clone());

--- a/crates/notion-core/src/tool/binary.rs
+++ b/crates/notion-core/src/tool/binary.rs
@@ -33,7 +33,7 @@ impl Tool for Binary {
                 path_to_bin.push(&params.executable);
 
                 // if we're in a pinned project, use the project's platform.
-                if let Some(ref platform) = session.project_platform()? {
+                if let Some(ref platform) = project.platform() {
                     let image = platform.checkout(session)?;
                     return Ok(Self::from_components(
                         &path_to_bin.as_os_str(),
@@ -53,9 +53,7 @@ impl Tool for Binary {
                 }
 
                 // if there's no user platform selected, fail.
-                throw!(ErrorDetails::NoSuchTool {
-                    tool: "Node".to_string()
-                });
+                throw!(ErrorDetails::NoPlatform);
             }
         }
 
@@ -70,8 +68,8 @@ impl Tool for Binary {
 
         // at this point, there is no project or user toolchain
         // the user is executing a Notion shim that doesn't have a way to execute it
-        throw!(ErrorDetails::NoToolChain {
-            shim_name: params.executable.to_string_lossy().to_string(),
+        throw!(ErrorDetails::BinaryNotFound {
+            name: params.executable.to_string_lossy().to_string(),
         });
     }
 

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -3,7 +3,6 @@
 use std::env::{self, args_os, ArgsOs};
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Debug, Display, Formatter};
-use std::io;
 use std::marker::Sized;
 use std::path::Path;
 use std::process::{Command, ExitStatus};
@@ -81,18 +80,6 @@ impl Display for ToolSpec {
     }
 }
 
-fn binary_exec_error(error: &io::Error) -> ErrorDetails {
-    if let Some(inner_err) = error.get_ref() {
-        ErrorDetails::BinaryExecError {
-            error: inner_err.to_string(),
-        }
-    } else {
-        ErrorDetails::BinaryExecError {
-            error: error.to_string(),
-        }
-    }
-}
-
 pub fn execute_tool(session: &mut Session) -> Fallible<ExitStatus> {
     let mut args = args_os();
     let exe = get_tool_name(&mut args)?;
@@ -134,7 +121,7 @@ pub trait Tool: Sized {
     fn exec(self) -> Fallible<ExitStatus> {
         let mut command = self.command();
         let status = command.status();
-        status.with_context(binary_exec_error)
+        status.with_context(|_| ErrorDetails::BinaryExecError)
     }
 }
 

--- a/crates/notion-core/src/tool/node.rs
+++ b/crates/notion-core/src/tool/node.rs
@@ -25,9 +25,7 @@ impl Tool for Node {
                 &image.path()?,
             ))
         } else {
-            throw!(ErrorDetails::NoSuchTool {
-                tool: "Node".to_string()
-            });
+            throw!(ErrorDetails::NoPlatform);
         }
     }
 

--- a/crates/notion-core/src/tool/npm.rs
+++ b/crates/notion-core/src/tool/npm.rs
@@ -29,11 +29,7 @@ impl Tool for Npm {
                 &image.path()?,
             ))
         } else {
-            // Using 'Node' as the tool name since the npm version is derived from the Node version
-            // This way the error message will prompt the user to add 'Node' to their toolchain, instead of 'npm'
-            throw!(ErrorDetails::NoSuchTool {
-                tool: "Node".to_string()
-            });
+            throw!(ErrorDetails::NoPlatform);
         }
     }
 

--- a/crates/notion-core/src/tool/npx.rs
+++ b/crates/notion-core/src/tool/npx.rs
@@ -36,11 +36,7 @@ impl Tool for Npx {
                 });
             }
         } else {
-            // Using 'Node' as the tool name since the npx version is derived from the Node version
-            // This way the error message will prompt the user to add 'Node' to their toolchain, instead of 'npx'
-            throw!(ErrorDetails::NoSuchTool {
-                tool: "Node".to_string()
-            });
+            throw!(ErrorDetails::NoPlatform);
         }
     }
 

--- a/crates/notion-core/src/tool/yarn.rs
+++ b/crates/notion-core/src/tool/yarn.rs
@@ -1,9 +1,11 @@
 use std::env::{args_os, ArgsOs};
 use std::ffi::OsStr;
 use std::process::Command;
+use std::rc::Rc;
 
 use super::{command_for, intercept_global_installs, Tool};
 use crate::error::ErrorDetails;
+use crate::platform::PlatformSpec;
 use crate::session::{ActivityKind, Session};
 
 use notion_fail::{throw, Fallible};
@@ -21,18 +23,14 @@ impl Tool for Yarn {
             throw!(ErrorDetails::NoGlobalInstalls);
         }
 
-        if let Some(ref platform) = session.current_platform()? {
-            let image = platform.checkout(session)?;
-            Ok(Self::from_components(
-                OsStr::new("yarn"),
-                args,
-                &image.path()?,
-            ))
-        } else {
-            throw!(ErrorDetails::NoSuchTool {
-                tool: "Yarn".to_string()
-            });
-        }
+        let platform = get_yarn_platform(session)?;
+        let image = platform.checkout(session)?;
+
+        Ok(Self::from_components(
+            OsStr::new("yarn"),
+            args,
+            &image.path()?,
+        ))
     }
 
     fn from_components(exe: &OsStr, args: ArgsOs, path_var: &OsStr) -> Self {
@@ -42,6 +40,27 @@ impl Tool for Yarn {
     fn command(self) -> Command {
         self.0
     }
+}
+
+/// Determine the correct platform (project or user) and check if yarn is set for that platform
+fn get_yarn_platform(session: &mut Session) -> Fallible<Rc<PlatformSpec>> {
+    // First check if we are in a pinned project
+    if let Some(platform) = session.project_platform()? {
+        return match platform.yarn {
+            Some(_) => Ok(platform),
+            None => Err(ErrorDetails::NoProjectYarn.into()),
+        };
+    }
+
+    // If not, fall back to the user platform
+    if let Some(platform) = session.user_platform()? {
+        return match platform.yarn {
+            Some(_) => Ok(platform),
+            None => Err(ErrorDetails::NoUserYarn.into()),
+        };
+    }
+
+    throw!(ErrorDetails::NoPlatform);
 }
 
 fn is_global_yarn_add() -> bool {

--- a/crates/notion-core/src/version/mod.rs
+++ b/crates/notion-core/src/version/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod serial;
 use std::fmt;
 use std::str::FromStr;
 
-use semver::{ReqParseError, SemVerError, Version, VersionReq};
+use semver::{ReqParseError, Version, VersionReq};
 
 use crate::error::ErrorDetails;
 use notion_fail::{Fallible, ResultExt};
@@ -40,15 +40,15 @@ impl VersionSpec {
 
     pub fn parse(s: impl AsRef<str>) -> Fallible<Self> {
         let s = s.as_ref();
-        s.parse().with_context(version_req_parse_error)
+        s.parse().with_context(version_parse_error(s))
     }
 
     pub fn parse_requirements(s: impl AsRef<str>) -> Fallible<VersionReq> {
-        parse_requirements(s.as_ref()).with_context(version_req_parse_error)
+        parse_requirements(s.as_ref()).with_context(version_parse_error(s))
     }
 
     pub fn parse_version(s: impl AsRef<str>) -> Fallible<Version> {
-        Version::parse(s.as_ref()).with_context(version_parse_error)
+        Version::parse(s.as_ref()).with_context(version_parse_error(s))
     }
 }
 
@@ -68,16 +68,13 @@ impl FromStr for VersionSpec {
     }
 }
 
-fn version_req_parse_error(error: &ReqParseError) -> ErrorDetails {
-    ErrorDetails::VersionParseError {
-        error: error.to_string(),
-    }
-}
-
-fn version_parse_error(error: &SemVerError) -> ErrorDetails {
-    ErrorDetails::VersionParseError {
-        error: error.to_string(),
-    }
+fn version_parse_error<E, S>(version: S) -> impl FnOnce(&E) -> ErrorDetails
+where
+    E: std::error::Error,
+    S: AsRef<str>,
+{
+    let version = version.as_ref().to_string();
+    |_error: &E| ErrorDetails::VersionParseError { version }
 }
 
 // remove the leading 'v' from the version string, if present

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -21,7 +21,7 @@ impl Command for Install {
         session.add_event_start(ActivityKind::Install);
 
         let version = match self.version {
-            Some(version_string) => VersionSpec::parse(version_string).unwrap_or_default(),
+            Some(version_string) => VersionSpec::parse(version_string)?,
             None => VersionSpec::default(),
         };
         let tool = ToolSpec::from_str_and_version(&self.tool, version);

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -14,49 +14,49 @@ fn npm_prevents_global_install() {
         s.npm("install ember-cli --global"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.npm("i ember-cli --global"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.npm("install ember-cli -g"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.npm("i -g ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.npm("-g i ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.npm("add ember-cli --global"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.npm("isntall --global ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 }
 
@@ -70,8 +70,8 @@ fn npm_allows_global_install_with_env_variable() {
         s.npm("i -g ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_does_not_contain("Global package installs are not recommended.")
-            .with_stderr_contains("No Node version selected.")
+            .with_stderr_does_not_contain("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Could not determine Node version.")
     );
 }
 
@@ -83,21 +83,21 @@ fn yarn_prevents_global_add() {
         s.yarn("global add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.yarn("--verbose global add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 
     assert_that!(
         s.yarn("global --verbose add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not recommended.")
     );
 }
 
@@ -111,7 +111,7 @@ fn yarn_allows_global_add_with_env_variable() {
         s.yarn("global add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_does_not_contain("Global package installs are not recommended.")
-            .with_stderr_contains("No Yarn version selected.")
+            .with_stderr_does_not_contain("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Could not determine Node version.")
     );
 }

--- a/tests/acceptance/notion_pin.rs
+++ b/tests/acceptance/notion_pin.rs
@@ -203,9 +203,11 @@ fn pin_node() {
 
     assert_that!(
         s.notion("pin node 6"),
-        execs().with_status(0).with_stdout_contains(
-            "Pinned node version 6.19.62 (with npm 3.10.1066) in package.json"
-        )
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains(
+                "Pinned node version 6.19.62 (with npm 3.10.1066) in package.json"
+            )
     );
 
     assert_eq!(
@@ -224,9 +226,11 @@ fn pin_node_latest() {
 
     assert_that!(
         s.notion("pin node latest"),
-        execs().with_status(0).with_stdout_contains(
-            "Pinned node version 10.99.1040 (with npm 6.2.26) in package.json"
-        )
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains(
+                "Pinned node version 10.99.1040 (with npm 6.2.26) in package.json"
+            )
     );
 
     assert_eq!(
@@ -245,9 +249,11 @@ fn pin_node_no_version() {
 
     assert_that!(
         s.notion("pin node"),
-        execs().with_status(0).with_stdout_contains(
-            "Pinned node version 10.99.1040 (with npm 6.2.26) in package.json"
-        )
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains(
+                "Pinned node version 10.99.1040 (with npm 6.2.26) in package.json"
+            )
     );
 
     assert_eq!(
@@ -268,7 +274,7 @@ fn pin_node_removes_npm() {
     assert_that!(
         s.notion("pin node 8"),
         execs()
-            .with_status(0)
+            .with_status(ExitCode::Success as i32)
             .with_stdout_contains("Pinned node version 8.9.10 (with npm 5.6.7) in package.json")
     );
 
@@ -290,7 +296,9 @@ fn pin_yarn_no_node() {
         s.notion("pin yarn 1.4"),
         execs()
             .with_status(ExitCode::ConfigurationError as i32)
-            .with_stderr_contains("error: There is no pinned node version for this project")
+            .with_stderr_contains(
+                "[..]Cannot pin Yarn because the Node version is not pinned in this project."
+            )
     );
 
     assert_eq!(s.read_package_json(), BASIC_PACKAGE_JSON,)
@@ -307,7 +315,7 @@ fn pin_yarn() {
     assert_that!(
         s.notion("pin yarn 1.4"),
         execs()
-            .with_status(0)
+            .with_status(ExitCode::Success as i32)
             .with_stdout_contains("Pinned yarn version 1.4.159 in package.json")
     );
 
@@ -328,7 +336,7 @@ fn pin_yarn_latest() {
     assert_that!(
         s.notion("pin yarn latest"),
         execs()
-            .with_status(0)
+            .with_status(ExitCode::Success as i32)
             .with_stdout_contains("Pinned yarn version 1.2.42 in package.json")
     );
 
@@ -349,7 +357,7 @@ fn pin_yarn_no_version() {
     assert_that!(
         s.notion("pin yarn"),
         execs()
-            .with_status(0)
+            .with_status(ExitCode::Success as i32)
             .with_stdout_contains("Pinned yarn version 1.2.42 in package.json")
     );
 
@@ -369,8 +377,8 @@ fn pin_yarn_missing_release() {
     assert_that!(
         s.notion("pin yarn 1.3.1"),
         execs()
-            .with_status(4)
-            .with_stderr_contains("error: yarn version 1.3.1 not found")
+            .with_status(ExitCode::NetworkError as i32)
+            .with_stderr_contains("[..]Could not download yarn version 1.3.1")
     );
 
     assert_eq!(
@@ -390,7 +398,7 @@ fn pin_yarn_leaves_npm() {
     assert_that!(
         s.notion("pin yarn 1.4"),
         execs()
-            .with_status(0)
+            .with_status(ExitCode::Success as i32)
             .with_stdout_contains("Pinned yarn version 1.4.159 in package.json")
     );
 
@@ -412,7 +420,7 @@ fn pin_npm() {
     assert_that!(
         s.notion("pin npm 5.10"),
         execs()
-            .with_status(0)
+            .with_status(ExitCode::Success as i32)
             .with_stdout_contains("Pinned npm version 5.10.12 in package.json")
     );
 


### PR DESCRIPTION
See #295 

Info
-----
* With the ability to provide verbose error messages in place, we can start to actually tackle improving the error messages.
* To start, we want to audit the existing error messages and update them to be more helpful.
* There are many error messages in the program currently, so to start I focused on two areas:
    1. Informational error messages thrown by the Tool shims, indicating a problem with the users' configuration (platform or project).
    2. Errors that included the text of an underlying error inside of them (via an `error` property on the `ErrorDetails` variant).

Changes
-----
* Updated error messages in `error/details.rs` to match the new style, including CTAs to help guide the user to the correct action.
* Updated all call sites to correctly reference the new `ErrorDetails` variants, providing the correct context to the error message.
* Minor refactors in functionality to provide more granular errors.
* Updated tests to reflect the new error output.