### PR TITLE
Merge user platform with bin platform when invoking packages

### DIFF
--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -396,9 +396,24 @@ impl UserTool {
         // canonicalize because path is relative, and sometimes uses '.' char
         let bin_path = image_dir.join(bin_config.path).canonicalize().unknown()?;
 
+        // If the user does not have yarn set in the platform for this binary, use the default
+        // This is necessary because some tools (e.g. ember-cli with the --yarn option) invoke `yarn`
+        let platform = match bin_config.platform.yarn {
+            Some(_) => bin_config.platform,
+            None => {
+                let yarn = session
+                    .user_platform()?
+                    .and_then(|ref plat| plat.yarn.clone());
+                PlatformSpec {
+                    yarn,
+                    ..bin_config.platform
+                }
+            }
+        };
+
         Ok(UserTool {
             bin_path,
-            image: bin_config.platform.checkout(session)?,
+            image: platform.checkout(session)?,
         })
     }
 


### PR DESCRIPTION
Closes #325 

Info
-----
* Some user tools (e.g. `ember-cli`) can invoke `yarn` as part of their execution.
* We currently aren't saving a `yarn` version in the user tool config file.
* This means that the user tool is executed with a `PATH` that doesn't include `yarn`, meaning any invocations of `yarn` will fail.
* In these cases, we should include the user default yarn (if any) in the platform.

Changes
-----
* Added logic to check if the bin config has `yarn` set (which won't currently happen, but could in the future with `notion install` options).
* If `yarn` is not set, pull the user platform and copy the `yarn` version from there.

Tested
-----
* Executed `ember new my-project --yarn` and confirmed that it successfully installed using `yarn`, instead of failing to find yarn as it did without these changes.