### PR TITLE
Rework unknown errors in platform module

### DIFF
--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -21,6 +21,9 @@ pub enum ErrorDetails {
         name: String,
     },
 
+    /// Thrown when building the virtual environment path fails
+    BuildPathError,
+
     /// Thrown when a user tries to `notion pin` something other than node/yarn/npm.
     CannotPinPackage {
         package: String,
@@ -201,6 +204,11 @@ See `notion help install` and `notion help pin` for info about making tools avai
             ErrorDetails::BinaryNotFound { name } => write!(f, r#"Could not find executable "{}"
 
 Use `notion install` to add a package to your toolchain (see `notion help install` for more info)."#, name),
+            ErrorDetails::BuildPathError => {
+                write!(f, "Could not create execution environment.
+
+Please ensure your PATH is valid.")
+            }
             ErrorDetails::CannotPinPackage { package } => {
                 write!(f, "Only node and yarn can be pinned in a project
 
@@ -409,6 +417,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::BinaryAlreadyInstalled { .. } => ExitCode::FileSystemError,
             ErrorDetails::BinaryExecError => ExitCode::ExecutionFailure,
             ErrorDetails::BinaryNotFound { .. } => ExitCode::ExecutableNotFound,
+            ErrorDetails::BuildPathError => ExitCode::EnvironmentError,
             ErrorDetails::CannotPinPackage { .. } => ExitCode::InvalidArguments,
             ErrorDetails::CompletionsOutDirError => ExitCode::InvalidArguments,
             ErrorDetails::ContainingDirError { .. } => ExitCode::FileSystemError,


### PR DESCRIPTION
Closes #302 

Add `BuildPathError` to `ErrorDetails`, representing being unable to join the paths when creating a virtual environment in the `platform` module.