### PR TITLE
Rework unknown errors in project module

### DIFF
--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -40,6 +40,8 @@ pub enum ErrorDetails {
         dir: String,
     },
 
+    CurrentDirError,
+
     /// Thrown when deleting a directory fails
     DeleteDirectoryError {
         directory: String,
@@ -224,6 +226,9 @@ Please ensure you have correct permissions to the Notion directory.", path)
 
 Please ensure that you have the correct permissions.", dir)
             }
+            ErrorDetails::CurrentDirError => write!(f, "Could not determine current directory
+
+Please ensure that you have the correct permissions."),
             ErrorDetails::DeleteDirectoryError { directory } => write!(f, "Could not remove directory
 at {}
 
@@ -414,6 +419,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::ContainingDirError { .. } => ExitCode::FileSystemError,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CreateDirError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::CurrentDirError => ExitCode::EnvironmentError,
             ErrorDetails::DeleteDirectoryError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DeleteFileError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DepPackageReadError => ExitCode::FileSystemError,

--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -81,7 +81,8 @@ impl Project {
     /// Returns the Node project containing the current working directory,
     /// if any.
     fn for_current_dir() -> Fallible<Option<Rc<Project>>> {
-        let current_dir: &Path = &env::current_dir().unknown()?;
+        let current_dir: &Path =
+            &env::current_dir().with_context(|_| ErrorDetails::CurrentDirError)?;
         Self::for_dir(&current_dir)
     }
 

--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -3,6 +3,7 @@ use std::env;
 use structopt::StructOpt;
 use which::which_in;
 
+use notion_core::error::ErrorDetails;
 use notion_core::platform::System;
 use notion_core::session::{ActivityKind, Session};
 use notion_fail::{ExitCode, Fallible, ResultExt};
@@ -22,7 +23,7 @@ impl Command for Which {
         // Treat any error with obtaining the current platform image as if the image doesn't exist
         // However, errors in obtaining the current working directory or the System path should
         // still be treated as errors.
-        let cwd = env::current_dir().unknown()?;
+        let cwd = env::current_dir().with_context(|_| ErrorDetails::CurrentDirError)?;
         let path = match session
             .current_platform()
             .unwrap_or(None)


### PR DESCRIPTION
Closes #303 

Add a `CurrentDirError` to `ErrorDetails` for when determining the current directory fails.