### PR TITLE
Rework unknown errors in shell module

### DIFF
--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -44,7 +44,9 @@ pub enum ErrorDetails {
     },
 
     /// Thrown when unable to create the postscript file
-    CreatePostscriptError,
+    CreatePostscriptError {
+        in_dir: String,
+    },
 
     CurrentDirError,
 
@@ -237,9 +239,10 @@ Please ensure you have correct permissions to the Notion directory.", path)
 
 Please ensure that you have the correct permissions.", dir)
             }
-            ErrorDetails::CreatePostscriptError => write!(f, "Could not create postscript file.
+            ErrorDetails::CreatePostscriptError { in_dir } => write!(f, "Could not create postscript file
+in {}
 
-Please ensure you have correct permissions to the Notion directory."),
+Please ensure you have correct permissions to the Notion directory.", in_dir),
             ErrorDetails::CurrentDirError => write!(f, "Could not determine current directory
 
 Please ensure that you have the correct permissions."),
@@ -434,7 +437,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::ContainingDirError { .. } => ExitCode::FileSystemError,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CreateDirError { .. } => ExitCode::FileSystemError,
-            ErrorDetails::CreatePostscriptError => ExitCode::FileSystemError,
+            ErrorDetails::CreatePostscriptError { .. } => ExitCode::FileSystemError,
             ErrorDetails::CurrentDirError => ExitCode::EnvironmentError,
             ErrorDetails::DeleteDirectoryError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DeleteFileError { .. } => ExitCode::FileSystemError,

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -40,6 +40,9 @@ pub enum ErrorDetails {
         dir: String,
     },
 
+    /// Thrown when unable to create the postscript file
+    CreatePostscriptError,
+
     /// Thrown when deleting a directory fails
     DeleteDirectoryError {
         directory: String,
@@ -224,6 +227,9 @@ Please ensure you have correct permissions to the Notion directory.", path)
 
 Please ensure that you have the correct permissions.", dir)
             }
+            ErrorDetails::CreatePostscriptError => write!(f, "Could not create postscript file.
+
+Please ensure you have correct permissions to the Notion directory."),
             ErrorDetails::DeleteDirectoryError { directory } => write!(f, "Could not remove directory
 at {}
 
@@ -414,6 +420,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::ContainingDirError { .. } => ExitCode::FileSystemError,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CreateDirError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::CreatePostscriptError => ExitCode::FileSystemError,
             ErrorDetails::DeleteDirectoryError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DeleteFileError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DepPackageReadError => ExitCode::FileSystemError,

--- a/crates/notion-core/src/shell/mod.rs
+++ b/crates/notion-core/src/shell/mod.rs
@@ -28,12 +28,14 @@ pub trait Shell {
     fn compile_postscript(&self, postscript: &Postscript) -> String;
 
     fn save_postscript(&self, postscript: &Postscript) -> Fallible<()> {
-        ensure_containing_dir_exists(&self.postscript_path())?;
-        write(
-            self.postscript_path(),
-            self.compile_postscript(postscript).as_bytes(),
-        )
-        .with_context(|_| ErrorDetails::CreatePostscriptError)
+        let path = self.postscript_path();
+        ensure_containing_dir_exists(&path)?;
+        write(path, self.compile_postscript(postscript).as_bytes()).with_context(|_| {
+            let in_dir = path.parent().map_or(String::from("Unknown path"), |p| {
+                p.to_string_lossy().to_string()
+            });
+            ErrorDetails::CreatePostscriptError { in_dir }
+        })
     }
 }
 

--- a/crates/notion-core/src/shell/mod.rs
+++ b/crates/notion-core/src/shell/mod.rs
@@ -1,5 +1,4 @@
-use std::fs::File;
-use std::io::Write;
+use std::fs::write;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -30,10 +29,11 @@ pub trait Shell {
 
     fn save_postscript(&self, postscript: &Postscript) -> Fallible<()> {
         ensure_containing_dir_exists(&self.postscript_path())?;
-        let mut file = File::create(self.postscript_path()).unknown()?;
-        file.write_all(self.compile_postscript(postscript).as_bytes())
-            .unknown()?;
-        Ok(())
+        write(
+            self.postscript_path(),
+            self.compile_postscript(postscript).as_bytes(),
+        )
+        .with_context(|_| ErrorDetails::CreatePostscriptError)
     }
 }
 


### PR DESCRIPTION
Closes #304 

Add a `CreatePostscriptError` to represent a failure to create the postscript file when executing `notion activate` or `notion deactivate`