### PR TITLE
Fix annoying package install errors

### DIFF
--- a/crates/notion-core/src/distro/mod.rs
+++ b/crates/notion-core/src/distro/mod.rs
@@ -14,24 +14,30 @@ use semver::Version;
 /// The result of a requested installation.
 #[derive(Debug)]
 pub enum Fetched<V> {
-    /// Indicates that the given tool was already installed.
+    /// Indicates that the given tool was already fetched and unpacked.
     Already(V),
-    /// Indicates that the given tool was not already installed but has now been installed.
+    /// Indicates that the given tool was not already fetched but has now been fetched and unpacked.
     Now(V),
+    /// Indicates that the given tool is already installed.
+    Installed(V),
 }
 
 impl<V> Fetched<V> {
     /// Consumes this value and produces the installed version.
     pub fn into_version(self) -> V {
         match self {
-            Fetched::Already(version) | Fetched::Now(version) => version,
+            Fetched::Already(version) | Fetched::Now(version) | Fetched::Installed(version) => {
+                version
+            }
         }
     }
 
     /// Produces a reference to the installed version.
     pub fn version(&self) -> &V {
         match self {
-            &Fetched::Already(ref version) | &Fetched::Now(ref version) => version,
+            &Fetched::Already(ref version)
+            | &Fetched::Now(ref version)
+            | &Fetched::Installed(ref version) => version,
         }
     }
 }

--- a/crates/notion-core/src/distro/mod.rs
+++ b/crates/notion-core/src/distro/mod.rs
@@ -48,7 +48,7 @@ pub trait Distro: Sized {
 
     /// Provisions a new Distro based on the name, Version and Possible Hooks
     fn new(
-        name: String,
+        name: &str,
         version: Self::ResolvedVersion,
         hooks: Option<&ToolHooks<Self>>,
     ) -> Fallible<Self>;

--- a/crates/notion-core/src/distro/node.rs
+++ b/crates/notion-core/src/distro/node.rs
@@ -151,7 +151,7 @@ impl Distro for NodeDistro {
 
     /// Provisions a new Distro based on the Version and possible Hooks
     fn new(
-        _name: String,
+        _name: &str,
         version: Self::ResolvedVersion,
         hooks: Option<&ToolHooks<Self>>,
     ) -> Fallible<Self> {

--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -130,7 +130,7 @@ impl Distro for PackageDistro {
     type ResolvedVersion = PackageEntry;
 
     fn new(
-        name: String,
+        name: &str,
         entry: Self::ResolvedVersion,
         _hooks: Option<&ToolHooks<Self>>,
     ) -> Fallible<Self> {
@@ -140,9 +140,9 @@ impl Distro for PackageDistro {
             shasum: entry.shasum,
             version: version.clone(),
             tarball_url: entry.tarball,
-            image_dir: path::package_image_dir(&name, &version.to_string())?,
-            distro_file: path::package_distro_file(&name, &version.to_string())?,
-            shasum_file: path::package_distro_shasum(&name, &version.to_string())?,
+            image_dir: path::package_image_dir(name, &version.to_string())?,
+            distro_file: path::package_distro_file(name, &version.to_string())?,
+            shasum_file: path::package_distro_shasum(name, &version.to_string())?,
         })
     }
 

--- a/crates/notion-core/src/distro/yarn.rs
+++ b/crates/notion-core/src/distro/yarn.rs
@@ -103,7 +103,7 @@ impl Distro for YarnDistro {
 
     /// Provisions a new Distro based on the Version and possible Hooks
     fn new(
-        _name: String,
+        _name: &str,
         version: Self::ResolvedVersion,
         hooks: Option<&ToolHooks<Self>>,
     ) -> Fallible<Self> {

--- a/crates/notion-core/src/inventory/mod.rs
+++ b/crates/notion-core/src/inventory/mod.rs
@@ -135,7 +135,7 @@ pub trait FetchResolve<D: Distro> {
     /// Fetch a Distro version matching the specified semantic versioning requirements.
     fn fetch(
         &mut self,
-        name: String, // unused by Node and Yarn, but package install needs this
+        name: &str, // unused by Node and Yarn, but package install needs this
         matching: &VersionSpec,
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<Fetched<Self::FetchedVersion>>;
@@ -143,7 +143,7 @@ pub trait FetchResolve<D: Distro> {
     /// Resolves the specified semantic versioning requirements into a distribution
     fn resolve(
         &self,
-        name: String,
+        name: &str,
         matching: &VersionSpec,
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<D> {
@@ -215,7 +215,7 @@ impl FetchResolve<NodeDistro> for NodeCollection {
 
     fn fetch(
         &mut self,
-        name: String, // not used here, we already know this is "node"
+        name: &str, // not used here, we already know this is "node"
         matching: &VersionSpec,
         hooks: Option<&ToolHooks<NodeDistro>>,
     ) -> Fallible<Fetched<NodeVersion>> {
@@ -321,7 +321,7 @@ impl FetchResolve<YarnDistro> for YarnCollection {
     /// Fetches a Yarn version matching the specified semantic versioning requirements.
     fn fetch(
         &mut self,
-        name: String, // not used here, we already know this is "yarn"
+        name: &str, // not used here, we already know this is "yarn"
         matching: &VersionSpec,
         hooks: Option<&ToolHooks<YarnDistro>>,
     ) -> Fallible<Fetched<Self::FetchedVersion>> {
@@ -425,7 +425,7 @@ impl FetchResolve<PackageDistro> for PackageCollection {
     /// Fetches a package version matching the specified semantic versioning requirements.
     fn fetch(
         &mut self,
-        name: String,
+        name: &str,
         matching: &VersionSpec,
         hooks: Option<&ToolHooks<PackageDistro>>,
     ) -> Fallible<Fetched<Self::FetchedVersion>> {

--- a/crates/notion-core/src/inventory/mod.rs
+++ b/crates/notion-core/src/inventory/mod.rs
@@ -148,14 +148,12 @@ pub trait FetchResolve<D: Distro> {
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<D> {
         let version = match *matching {
-            VersionSpec::Latest => self.resolve_latest(name.clone(), hooks)?,
-            VersionSpec::Lts => self.resolve_lts(name.clone(), hooks)?,
+            VersionSpec::Latest => self.resolve_latest(&name, hooks)?,
+            VersionSpec::Lts => self.resolve_lts(&name, hooks)?,
             VersionSpec::Semver(ref requirement) => {
-                self.resolve_semver(name.clone(), requirement, hooks)?
+                self.resolve_semver(&name, requirement, hooks)?
             }
-            VersionSpec::Exact(ref version) => {
-                self.resolve_exact(name.clone(), version.clone(), hooks)?
-            }
+            VersionSpec::Exact(ref version) => self.resolve_exact(&name, version.clone(), hooks)?,
         };
 
         D::new(name, version, hooks)
@@ -164,14 +162,14 @@ pub trait FetchResolve<D: Distro> {
     /// Resolves the latest version for this tool, using either the `latest` hook or the public registry
     fn resolve_latest(
         &self,
-        name: String,
+        name: &str,
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<D::ResolvedVersion>;
 
     /// Resolves a SemVer version for this tool, using either the `index` hook or the public registry
     fn resolve_semver(
         &self,
-        name: String,
+        name: &str,
         matching: &VersionReq,
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<D::ResolvedVersion>;
@@ -179,7 +177,7 @@ pub trait FetchResolve<D: Distro> {
     /// Resolves an LTS version for this tool
     fn resolve_lts(
         &self,
-        name: String,
+        name: &str,
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<D::ResolvedVersion> {
         return self.resolve_latest(name, hooks);
@@ -188,7 +186,7 @@ pub trait FetchResolve<D: Distro> {
     /// Resolves an exact version of this tool
     fn resolve_exact(
         &self,
-        name: String,
+        name: &str,
         version: Version,
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<D::ResolvedVersion>;
@@ -239,7 +237,7 @@ impl FetchResolve<NodeDistro> for NodeCollection {
 
     fn resolve_latest(
         &self,
-        _name: String,
+        _name: &str,
         hooks: Option<&ToolHooks<NodeDistro>>,
     ) -> Fallible<Version> {
         // NOTE: This assumes the registry always produces a list in sorted order
@@ -265,7 +263,7 @@ impl FetchResolve<NodeDistro> for NodeCollection {
 
     fn resolve_semver(
         &self,
-        _name: String,
+        _name: &str,
         matching: &VersionReq,
         hooks: Option<&ToolHooks<NodeDistro>>,
     ) -> Fallible<Version> {
@@ -290,11 +288,7 @@ impl FetchResolve<NodeDistro> for NodeCollection {
         }
     }
 
-    fn resolve_lts(
-        &self,
-        _name: String,
-        hooks: Option<&ToolHooks<NodeDistro>>,
-    ) -> Fallible<Version> {
+    fn resolve_lts(&self, _name: &str, hooks: Option<&ToolHooks<NodeDistro>>) -> Fallible<Version> {
         let url = match hooks {
             Some(&ToolHooks {
                 index: Some(ref hook),
@@ -315,7 +309,7 @@ impl FetchResolve<NodeDistro> for NodeCollection {
 
     fn resolve_exact(
         &self,
-        _name: String,
+        _name: &str,
         version: Version,
         _hooks: Option<&ToolHooks<NodeDistro>>,
     ) -> Fallible<Version> {
@@ -345,7 +339,7 @@ impl FetchResolve<YarnDistro> for YarnCollection {
 
     fn resolve_latest(
         &self,
-        _name: String,
+        _name: &str,
         hooks: Option<&ToolHooks<YarnDistro>>,
     ) -> Fallible<Version> {
         let url = match hooks {
@@ -362,7 +356,7 @@ impl FetchResolve<YarnDistro> for YarnCollection {
 
     fn resolve_semver(
         &self,
-        _name: String,
+        _name: &str,
         matching: &VersionReq,
         hooks: Option<&ToolHooks<YarnDistro>>,
     ) -> Fallible<Version> {
@@ -394,7 +388,7 @@ impl FetchResolve<YarnDistro> for YarnCollection {
 
     fn resolve_exact(
         &self,
-        _name: String,
+        _name: &str,
         version: Version,
         _hooks: Option<&ToolHooks<YarnDistro>>,
     ) -> Fallible<Version> {
@@ -449,7 +443,7 @@ impl FetchResolve<PackageDistro> for PackageCollection {
 
     fn resolve_latest(
         &self,
-        name: String,
+        name: &str,
         hooks: Option<&ToolHooks<PackageDistro>>,
     ) -> Fallible<PackageEntry> {
         let url = match hooks {
@@ -480,7 +474,7 @@ impl FetchResolve<PackageDistro> for PackageCollection {
 
     fn resolve_semver(
         &self,
-        name: String,
+        name: &str,
         matching: &VersionReq,
         hooks: Option<&ToolHooks<PackageDistro>>,
     ) -> Fallible<PackageEntry> {
@@ -511,7 +505,7 @@ impl FetchResolve<PackageDistro> for PackageCollection {
 
     fn resolve_exact(
         &self,
-        name: String,
+        name: &str,
         exact_version: Version,
         hooks: Option<&ToolHooks<PackageDistro>>,
     ) -> Fallible<PackageEntry> {

--- a/crates/notion-core/src/inventory/mod.rs
+++ b/crates/notion-core/src/inventory/mod.rs
@@ -147,13 +147,11 @@ pub trait FetchResolve<D: Distro> {
         matching: &VersionSpec,
         hooks: Option<&ToolHooks<D>>,
     ) -> Fallible<D> {
-        let version = match *matching {
+        let version = match matching {
             VersionSpec::Latest => self.resolve_latest(&name, hooks)?,
             VersionSpec::Lts => self.resolve_lts(&name, hooks)?,
-            VersionSpec::Semver(ref requirement) => {
-                self.resolve_semver(&name, requirement, hooks)?
-            }
-            VersionSpec::Exact(ref version) => self.resolve_exact(&name, version.clone(), hooks)?,
+            VersionSpec::Semver(requirement) => self.resolve_semver(&name, requirement, hooks)?,
+            VersionSpec::Exact(version) => self.resolve_exact(&name, version.to_owned(), hooks)?,
         };
 
         D::new(name, version, hooks)

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -207,7 +207,6 @@ impl Session {
         let package_version = fetched_package.version();
 
         // if the package is already installed, don't re-install it
-        // TODO: accept --force for this?
         if let Fetched::Installed(pkg_version) = fetched_package {
             let version = pkg_version.version.clone();
             println!(

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -149,11 +149,9 @@ impl Session {
 
         if !inventory.node.contains(version) {
             let hooks = self.hooks.get()?;
-            inventory.node.fetch(
-                "node".to_string(),
-                &VersionSpec::exact(version),
-                hooks.node.as_ref(),
-            )?;
+            inventory
+                .node
+                .fetch("node", &VersionSpec::exact(version), hooks.node.as_ref())?;
         }
 
         Ok(())
@@ -165,11 +163,9 @@ impl Session {
 
         if !inventory.yarn.contains(version) {
             let hooks = self.hooks.get()?;
-            inventory.yarn.fetch(
-                "yarn".to_string(),
-                &VersionSpec::exact(version),
-                hooks.yarn.as_ref(),
-            )?;
+            inventory
+                .yarn
+                .fetch("yarn", &VersionSpec::exact(version), hooks.yarn.as_ref())?;
         }
 
         Ok(())
@@ -203,7 +199,7 @@ impl Session {
     /// Fetch, unpack, and install a package matching the input requirements.
     pub fn install_package(&mut self, name: String, version: &VersionSpec) -> Fallible<Version> {
         // fetches and unpacks package
-        let fetched_package = self.fetch_package(name.clone(), version)?;
+        let fetched_package = self.fetch_package(&name, version)?;
         let package_version = fetched_package.version();
 
         // if the package is already installed, don't re-install it
@@ -251,7 +247,7 @@ impl Session {
         let hooks = self.hooks.get()?;
         inventory
             .node
-            .fetch("node".to_string(), &version_spec, hooks.node.as_ref())
+            .fetch("node", &version_spec, hooks.node.as_ref())
     }
 
     /// Fetches a Yarn version matching the specified semantic versioning requirements.
@@ -260,7 +256,7 @@ impl Session {
         let hooks = self.hooks.get()?;
         inventory
             .yarn
-            .fetch("yarn".to_string(), &version_spec, hooks.yarn.as_ref())
+            .fetch("yarn", &version_spec, hooks.yarn.as_ref())
     }
 
     /// Fetches a Npm version matching the specified semantic versioning requirements.
@@ -269,13 +265,13 @@ impl Session {
         let hooks = self.hooks.get()?;
         inventory
             .packages
-            .fetch("npm".to_string(), version_spec, hooks.package.as_ref())
+            .fetch("npm", version_spec, hooks.package.as_ref())
     }
 
     /// Fetches a Package version matching the specified semantic versioning requirements.
     pub fn fetch_package(
         &mut self,
-        name: String,
+        name: &str,
         version_spec: &VersionSpec,
     ) -> Fallible<Fetched<PackageVersion>> {
         let inventory = self.inventory.get_mut()?;
@@ -317,7 +313,7 @@ impl Session {
             let hooks = self.hooks.get()?;
             let npm_version = inventory
                 .packages
-                .resolve("npm".to_string(), version_spec, hooks.package.as_ref())?
+                .resolve("npm", version_spec, hooks.package.as_ref())?
                 .version;
             project.pin_npm(&npm_version)?;
         } else {

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -203,8 +203,19 @@ impl Session {
     /// Fetch, unpack, and install a package matching the input requirements.
     pub fn install_package(&mut self, name: String, version: &VersionSpec) -> Fallible<Version> {
         // fetches and unpacks package
-        let fetched_package = self.fetch_package(name, version)?;
+        let fetched_package = self.fetch_package(name.clone(), version)?;
         let package_version = fetched_package.version();
+
+        // if the package is already installed, don't re-install it
+        // TODO: accept --force for this?
+        if let Fetched::Installed(pkg_version) = fetched_package {
+            let version = pkg_version.version.clone();
+            println!(
+                "Package `{}` is up-to-date, version {} already installed",
+                name, version
+            );
+            return Ok(version);
+        }
 
         // This uses the "engines" field from package.json to determine the node version to use
         // From https://docs.npmjs.com/files/package.json#engines:

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -35,7 +35,7 @@ impl Command for Fetch {
                 unimplemented!("Fetching npm is not supported yet");
             }
             ToolSpec::Package(name, version) => {
-                session.fetch_package(name.to_string(), &version)?;
+                session.fetch_package(&name, &version)?;
             }
         }
         session.add_event_end(ActivityKind::Fetch, ExitCode::Success);


### PR DESCRIPTION
## Bug Fixes

Closes #352 
Now this doesn't error if the same version has already been installed:

```
$ notion install cowsay
  Unpacking cowsay-v1.4.0  [========================================] 100%
npm notice created a lockfile as package-lock.json. You should commit this file.
added 9 packages from 2 contributors and audited 1535 packages in 3.261s
found 0 vulnerabilities

$ notion install cowsay
Package `cowsay` is up-to-date, version 1.4.0 already installed
```

Closes #353 
Don't fail for a different version of an existing package:

```
$ notion install ember-cli 3.8.1
  Fetching ember-cli-v3.8.1  [========================================] 100%
[lots out output not included]

$ ember --version
WARNING: Node v11.14.0 is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js. See https://git.io/v7S5n for details.
ember-cli: 3.8.1
node: 11.14.0
os: darwin x64

$ notion install ember-cli 3.9
  Fetching ember-cli-v3.9.0  [========================================] 100%
[lots log output not included]

$ ember --version
ember-cli: 3.9.0
node: 11.14.0
os: darwin x64
```

Closes #371
Now this doesn't fail to install if the previous install was cancelled:

```
$ notion install cowsay
  Unpacking cowsay-v1.4.0  [========================================] 100%
^C░░░░░░░░░░░░░░░░░⸩ ⠧ fetchMetadata: sill pacote range manifest for istanbul-reports@^2.2.2 fetched in 146ms
[I hit ^C to cancel the npm install]

$ notion install cowsay
  Unpacking cowsay-v1.4.0  [========================================] 100%
npm notice created a lockfile as package-lock.json. You should commit this file.
added 9 packages from 2 contributors and audited 1535 packages in 4.717s
found 0 vulnerabilities
```

## Other Stuff

* Cleaned up some descriptions in the comments for `distro::Fetched` to be more accurate.