### PR TITLE
Release script, and script tests in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ jobs:
       vmImage: $(imageName)
     steps:
       - template: ci/install-rust.yml
+      - template: ci/install-bats.yml
       - template: ci/check-formatting.yml
       - template: ci/run-tests.yml
     displayName: Non-Windows OSes

--- a/ci/install-bats.yml
+++ b/ci/install-bats.yml
@@ -5,8 +5,13 @@ steps:
       set -e
       git clone https://github.com/bats-core/bats-core.git "$HOME/bats-core"
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/bats-core/bin"
-      bats --version
     displayName: Install Bats (not Windows)
+    condition: not(eq(variables['Agent.OS'], 'Windows_NT'))
+
+  # after modifying PATH it should be available to downstream steps
+  - script: |
+      bats --version
+    displayName: Log Bats Version (not Windows)
     condition: not(eq(variables['Agent.OS'], 'Windows_NT'))
 
   # no script for Windows because it does not use the Unix shell scripts

--- a/ci/install-bats.yml
+++ b/ci/install-bats.yml
@@ -1,0 +1,12 @@
+steps:
+  # Linux and macOS
+  # Checkout bats-core source and add the bin/ directory to the PATH
+  - script: |
+      set -e
+      git clone https://github.com/bats-core/bats-core.git "$HOME/bats-core"
+      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/bats-core/bin"
+      bats --version
+    displayName: Install Bats (not Windows)
+    condition: not(eq(variables['Agent.OS'], 'Windows_NT'))
+
+  # no script for Windows because it does not use the Unix shell scripts

--- a/ci/run-tests.yml
+++ b/ci/run-tests.yml
@@ -18,3 +18,8 @@ steps:
       NOTION_DEV: 1
       RUST_BACKTRACE: full
     displayName: Smoke Tests
+
+  # shell script tests for Linux & macOS
+  - script: bats dev/unix/tests/
+    displayName: Shell Script Tests (not Windows)
+    condition: not(eq(variables['Agent.OS'], 'Windows_NT'))

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Script to build the binaries and package them up for release.
+# This should be run from the top-level directory.
+
+notion_info() {
+  local ACTION="$1"
+  local DETAILS="$2"
+  command printf '\033[1;32m%12s\033[0m %s\n' "${ACTION}" "${DETAILS}" 1>&2
+}
+
+notion_error() {
+  command printf '\033[1;31mError\033[0m: %s\n' "$1" 1>&2
+}
+
+bold() {
+  command printf '\033[1m%s\033[0m' "$1"
+}
+
+# parse the 'version = "0.3.0"' line from the input text
+parse_version() {
+  local contents="$1"
+
+  while read -r line
+  do
+    if [[ "$line" =~ ^version\ =\ \"(.*)\" ]]
+    then
+      echo "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done <<< "$contents"
+
+  notion_error "Could not determine the current version"
+  return 1
+}
+
+# returns the os name to be used in the packaged release,
+# including the openssl info if necessary
+parse_os_info() {
+  local uname_str="$1"
+  local openssl_version="$2"
+
+  case "$uname_str" in
+    Linux)
+      echo "linux-openssl-$(parse_openssl_version "$openssl_version")"
+      ;;
+    Darwin)
+      echo "macos"
+      ;;
+    *)
+      notion_error "Releases for '$uname_str' are not yet supported. Please modify this script and the install script to support this OS."
+      return 1
+  esac
+  return 0
+}
+
+# parse the OpenSSL version from the input text
+parse_openssl_version() {
+  let version_str="$1"
+
+  if [[ "$version_str" =~ ([^ ]*)\ (\d+).(\d+).(\d+) ]]
+  then
+    echo "matched $version_str" >&2
+    return 0
+  else
+    echo "could NOT match $version_str" >&2
+    return 1
+  fi
+}
+
+### END FUNCTIONS
+
+# read the current version from Cargo.toml
+cargo_toml_contents="$(<Cargo.toml)"
+NOTION_VERSION="$(parse_version "$cargo_toml_contents")"
+# TODO: check exit code
+
+# figure out the OS details
+os="$(uname -s)"
+openssl_version="$(openssl version)"
+NOTION_OS="$(parse_os_info "$os" "$openssl_version")"
+# TODO: check exit code
+
+release_filename="notion-$NOTION_VERSION-$NOTION_OS"
+
+# first make sure the release binaries have been built
+notion_info 'Building' "Notion release $(bold "$release_filename")"
+cargo build --release
+
+# then package up the binaries together
+target_dir="target/release"
+notion_info 'Packaging' "the compiled binaries"
+cd "$target_dir"
+tar -czf "$release_filename.tar.gz" notion shim
+
+notion_info 'Completed' "release in file $(bold "$target_dir/$release_filename.tar.gz")"

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -105,7 +105,9 @@ parse_openssl_version() {
   fi
 }
 
-### END FUNCTIONS
+# if this script is being sourced (for tests) then return at this point
+(return 0 2>/dev/null) && return 0
+
 
 # exit on error
 set -e

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -41,7 +41,7 @@ parse_os_info() {
 
   case "$uname_str" in
     Linux)
-      major_minor="$(parse_openssl_version "$openssl_version")"
+      parsed_version="$(parse_openssl_version "$openssl_version")"
       # if there was an error, return
       exit_code="$?"
       if [ "$exit_code" != 0 ]
@@ -49,7 +49,7 @@ parse_os_info() {
         return "$exit_code"
       fi
 
-      echo "linux-openssl-$major_minor"
+      echo "linux-openssl-$parsed_version"
       ;;
     Darwin)
       echo "macos"
@@ -105,8 +105,8 @@ parse_openssl_version() {
   fi
 }
 
-# if this script is being sourced (for tests) then return at this point
-(return 0 2>/dev/null) && return 0
+# return if sourced (for testing the functions above without running the commands below)
+return 0 2>/dev/null
 
 
 # exit on error

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -144,7 +144,7 @@ case "$1" in
   --dev)
     build_with_release="false"
     ;;
-  --release)
+  ''|--release)
     # not really necessary to set this again
     build_with_release="true"
     ;;

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -183,6 +183,8 @@ notion_info 'Packaging' "the compiled binaries and shell scripts"
 # copy the load.* shell scripts to the target dir, to include them as well
 cp "$shell_script_dir"/load.* "$target_dir/"
 cd "$target_dir"
-tar -czvf "$release_filename.tar.gz" notion shim load.*
+# using COPYFILE_DISABLE to avoid storing extended attribute files when run on OSX
+# (see https://superuser.com/q/61185)
+COPYFILE_DISABLE=1 tar -czvf "$release_filename.tar.gz" notion shim load.*
 
 notion_info 'Completed' "release in file $(bold "$target_dir/$release_filename.tar.gz")"

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -85,7 +85,9 @@ parse_openssl_version() {
   # would be nice to use a bash 4.x associative array, but bash 3.x is the default on OSX
   SUPPORTED_SSL_LIBS=( 'OpenSSL' )
 
-  if [[ "$version_str" =~ ^([^\ ]*)\ ([0-9]+\.[0-9]+) ]]
+  # use regex to get the library name and version
+  # typical version string looks like 'OpenSSL 1.0.1e-fips 11 Feb 2013'
+  if [[ "$version_str" =~ ^([^\ ]*)\ ([0-9]+\.[0-9]+\.[0-9]+) ]]
   then
     # check that the lib is supported
     libname="${BASH_REMATCH[1]}"

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -55,7 +55,7 @@ parse_os_info() {
       echo "macos"
       ;;
     *)
-      notion_error "Releases for '$uname_str' are not yet supported. You will need to modify this script and the install script to support this OS."
+      notion_error "Releases for '$uname_str' are not yet supported. You will need to add another OS case to this script, and to the install script to support this OS."
       return 1
   esac
   return 0
@@ -65,18 +65,22 @@ parse_os_info() {
 parse_openssl_version() {
   local version_str="$1"
 
+  # associative array containing the SSL libraries that are supported
+  declare -A SUPPORTED_SSL_LIBS
+  SUPPORTED_SSL_LIBS['OpenSSL']='true'
+
   if [[ "$version_str" =~ ^([^\ ]*)\ ([0-9]+\.[0-9]+) ]]
   then
     # check that lib name is 'OpenSSL'
     libname="${BASH_REMATCH[1]}"
-    if [[ "$libname" != "OpenSSL" ]]; then
-      notion_error "Releases for '$libname' not currently supported"
+    if [[ "${SUPPORTED_SSL_LIBS["$libname"]}" != "true" ]]; then
+      notion_error "Releases for '$libname' not currently supported. Supported libraries are: ${!SUPPORTED_SSL_LIBS[@]}."
       return 1
     fi
     echo "${BASH_REMATCH[2]}"
     return 0
   else
-    notion_error "Could not determine OpenSSL version for '$version_str'"
+    notion_error "Could not determine OpenSSL version for '$version_str'. You probably need to update the regex to handle this output."
     return 1
   fi
 }

--- a/dev/unix/release.sh
+++ b/dev/unix/release.sh
@@ -101,10 +101,13 @@ release_filename="notion-$NOTION_VERSION-$NOTION_OS"
 notion_info 'Building' "Notion release $(bold "$release_filename")"
 cargo build --release
 
-# then package up the binaries together
+# then package the binaries and shell scripts together
 target_dir="target/release"
-notion_info 'Packaging' "the compiled binaries"
+shell_script_dir="shell/unix"
+notion_info 'Packaging' "the compiled binaries and shell scripts"
+# copy the load.* shell scripts to the target dir, to include them as well
+cp "$shell_script_dir"/load.* "$target_dir/"
 cd "$target_dir"
-tar -czf "$release_filename.tar.gz" notion shim
+tar -czvf "$release_filename.tar.gz" notion shim load.*
 
 notion_info 'Completed' "release in file $(bold "$target_dir/$release_filename.tar.gz")"

--- a/dev/unix/tests/release-script.bats
+++ b/dev/unix/tests/release-script.bats
@@ -1,0 +1,109 @@
+# test the release.sh script
+
+# load the functions from the script
+# (everything before the '### END FUNCTIONS' line)
+eval "$(cat dev/unix/release.sh | sed '/### END FUNCTIONS/q')"
+
+# happy path test to parse the version from Cargo.toml
+@test "parse_version - normal Cargo.toml" {
+  input=$(cat <<'END_CARGO_TOML'
+[package]
+name = "notion"
+version = "0.7.38"
+authors = ["David Herman <david.herman@gmail.com>"]
+license = "BSD-2-Clause"
+END_CARGO_TOML
+)
+
+  expected_output="0.7.38"
+
+  run parse_version "$input"
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+# it doesn't parse the version from other dependencies
+@test "parse_version - error" {
+  input=$(cat <<'END_CARGO_TOML'
+[dependencies]
+notion-core = { path = "crates/notion-core" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.37"
+console = "0.6.1"
+END_CARGO_TOML
+)
+
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine the current version")
+
+  run parse_version "$input"
+  [ "$status" -eq 1 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+
+# macos
+@test "parse_os_info - macos" {
+  expected_output="macos"
+
+  run parse_os_info "Darwin" "this is ignored"
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+# linux - supported OpenSSL
+@test "parse_os_info - linux with supported OpenSSL" {
+  expected_output="linux-openssl-1.2"
+
+  run parse_os_info "Linux" "OpenSSL 1.2.3a whatever else"
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+# linux - unsupported OpenSSL
+@test "parse_os_info - linux with unsupported OpenSSL" {
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'SomeSSL' not currently supported")
+
+  run parse_os_info "Linux" "SomeSSL 1.2.3a whatever else"
+  [ "$status" -eq 1 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+# linux - unexpected OpenSSL version format
+@test "parse_os_info - linux with unexpected OpenSSL format" {
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine OpenSSL version for 'Some SSL 1.2.4'")
+
+  run parse_os_info "Linux" "Some SSL 1.2.4"
+  [ "$status" -eq 1 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+
+# parsing valid OpenSSL version strings
+@test "parse_openssl_version - valid versions" {
+  expected_output="0.9"
+  run parse_openssl_version "OpenSSL 0.9.5a 1 Apr 2000"
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") <(echo "$expected_output")
+
+  expected_output="1.0"
+  run parse_openssl_version "OpenSSL 1.0.1e-fips 11 Feb 2013"
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+# unsupported OpenSSL library
+@test "parse_openssl_version - unsupported library" {
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'LibreSSL' not currently supported")
+  run parse_openssl_version "LibreSSL 2.6.5"
+  [ "$status" -eq 1 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+# version string with unexpected format
+@test "parse_openssl_version - unexpected format" {
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine OpenSSL version for 'Some Weird Version 1.2.3'")
+  run parse_openssl_version "Some Weird Version 1.2.3"
+  [ "$status" -eq 1 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+

--- a/dev/unix/tests/release-script.bats
+++ b/dev/unix/tests/release-script.bats
@@ -1,8 +1,7 @@
 # test the release.sh script
 
 # load the functions from the script
-# (everything before the '### END FUNCTIONS' line)
-eval "$(cat dev/unix/release.sh | sed '/### END FUNCTIONS/q')"
+source dev/unix/release.sh
 
 # happy path test to parse the version from Cargo.toml
 @test "parse_version - normal Cargo.toml" {

--- a/dev/unix/tests/release-script.bats
+++ b/dev/unix/tests/release-script.bats
@@ -61,7 +61,7 @@ END_CARGO_TOML
 
 # linux - unsupported OpenSSL
 @test "parse_os_info - linux with unsupported OpenSSL" {
-  expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'SomeSSL' not currently supported")
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'SomeSSL' not currently supported. Supported libraries are: OpenSSL.")
 
   run parse_os_info "Linux" "SomeSSL 1.2.3a whatever else"
   [ "$status" -eq 1 ]
@@ -70,9 +70,18 @@ END_CARGO_TOML
 
 # linux - unexpected OpenSSL version format
 @test "parse_os_info - linux with unexpected OpenSSL format" {
-  expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine OpenSSL version for 'Some SSL 1.2.4'")
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine OpenSSL version for 'Some SSL 1.2.4'. You probably need to update the regex to handle this output.")
 
   run parse_os_info "Linux" "Some SSL 1.2.4"
+  [ "$status" -eq 1 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+# unsupported OS
+@test "parse_os_info - unsupported OS" {
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'DOS' are not yet supported. You will need to add another OS case to this script, and to the install script to support this OS.")
+
+  run parse_os_info "DOS" "doesn't matter"
   [ "$status" -eq 1 ]
   diff <(echo "$output") <(echo "$expected_output")
 }
@@ -93,7 +102,7 @@ END_CARGO_TOML
 
 # unsupported OpenSSL library
 @test "parse_openssl_version - unsupported library" {
-  expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'LibreSSL' not currently supported")
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'LibreSSL' not currently supported. Supported libraries are: OpenSSL.")
   run parse_openssl_version "LibreSSL 2.6.5"
   [ "$status" -eq 1 ]
   diff <(echo "$output") <(echo "$expected_output")
@@ -101,7 +110,7 @@ END_CARGO_TOML
 
 # version string with unexpected format
 @test "parse_openssl_version - unexpected format" {
-  expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine OpenSSL version for 'Some Weird Version 1.2.3'")
+  expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine OpenSSL version for 'Some Weird Version 1.2.3'. You probably need to update the regex to handle this output.")
   run parse_openssl_version "Some Weird Version 1.2.3"
   [ "$status" -eq 1 ]
   diff <(echo "$output") <(echo "$expected_output")

--- a/dev/unix/tests/release-script.bats
+++ b/dev/unix/tests/release-script.bats
@@ -116,3 +116,20 @@ END_CARGO_TOML
   diff <(echo "$output") <(echo "$expected_output")
 }
 
+
+# test element_in helper function
+@test "element_in works correctly" {
+  run element_in "foo" "foo" "bar" "baz"
+  [ "$status" -eq 0 ]
+
+  array=( "foo" "bar" "baz" )
+  run element_in "foo" "${array[@]}"
+  [ "$status" -eq 0 ]
+  run element_in "bar" "${array[@]}"
+  [ "$status" -eq 0 ]
+  run element_in "baz" "${array[@]}"
+  [ "$status" -eq 0 ]
+
+  run element_in "fob" "${array[@]}"
+  [ "$status" -eq 1 ]
+}

--- a/dev/unix/tests/release-script.bats
+++ b/dev/unix/tests/release-script.bats
@@ -52,7 +52,7 @@ END_CARGO_TOML
 
 # linux - supported OpenSSL
 @test "parse_os_info - linux with supported OpenSSL" {
-  expected_output="linux-openssl-1.2"
+  expected_output="linux-openssl-1.2.3"
 
   run parse_os_info "Linux" "OpenSSL 1.2.3a whatever else"
   [ "$status" -eq 0 ]
@@ -89,12 +89,12 @@ END_CARGO_TOML
 
 # parsing valid OpenSSL version strings
 @test "parse_openssl_version - valid versions" {
-  expected_output="0.9"
+  expected_output="0.9.5"
   run parse_openssl_version "OpenSSL 0.9.5a 1 Apr 2000"
   [ "$status" -eq 0 ]
   diff <(echo "$output") <(echo "$expected_output")
 
-  expected_output="1.0"
+  expected_output="1.0.1"
   run parse_openssl_version "OpenSSL 1.0.1e-fips 11 Feb 2013"
   [ "$status" -eq 0 ]
   diff <(echo "$output") <(echo "$expected_output")


### PR DESCRIPTION
Start to implement #151 by packaging the compiled binaries and shell scripts for release.

```
$ ./dev/unix/release.sh
    Building Notion for notion-0.3.0-macos
    Finished release [optimized] target(s) in 0.69s
   Packaging the compiled binaries and shell scripts
a notion
a shim
a load.fish
a load.sh
   Completed release in file target/release/notion-0.3.0-macos.tar.gz
```

```
$ ./dev/unix/release.sh --dev
    Building Notion for notion-0.3.0-macos
    Finished dev [unoptimized + debuginfo] target(s) in 0.43s
   Packaging the compiled binaries and shell scripts
a notion
a shim
a load.fish
a load.sh
   Completed release in file target/debug/notion-0.3.0-macos.tar.gz
```

```
$ ./dev/unix/release.sh -h
release.sh

Compile and package a release for Notion

USAGE:
    ./dev/unix/release.sh [FLAGS] [OPTIONS]

FLAGS:
    -h, --help          Prints this help info

OPTIONS:
        --release       Build artifacts in release mode, with optimizations (default)
        --dev           Build artifacts in dev mode, without optimizations
```

Also, this uses [bats](https://github.com/bats-core/bats-core) to test this script in CI.