### PR TITLE
Handle illegal `engines` fields.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations":[
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Cargo test notion core",
+      "cargo": {
+        "args": [
+          "test",
+          "--lib",
+          "--no-run",
+          "--package", "notion-core",
+          "--", "--test-threads", "1",
+        ],
+        "filter": {
+          "kind": "lib",
+          "name": "notion-core"
+        }
+      },
+      "program": "${cargo:program}",
+      "args": [],
+      "sourceLanguages": ["rust"]
+    }
+  ]
+}


### PR DESCRIPTION
- Fixes #388
- Adds a debugger launch config for VS Code, which I found useful (can drop it if people don't want it here)