### PR TITLE
Suppress misleading messages from npm on package install

### DIFF
--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -560,7 +560,13 @@ impl Installer {
         match self {
             Installer::Npm => {
                 let mut command = create_command("npm");
-                command.args(&["install", "--only=production"]);
+                command.args(&[
+                    "install",
+                    "--only=production",
+                    "-q",
+                    "--no-update-notifier",
+                    "--no-audit",
+                ]);
                 command
             }
             Installer::Yarn => {

--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -563,7 +563,7 @@ impl Installer {
                 command.args(&[
                     "install",
                     "--only=production",
-                    "-q",
+                    "--loglevel=warn",
                     "--no-update-notifier",
                     "--no-audit",
                 ]);


### PR DESCRIPTION
Closes #369 
Closes #374 

Add the following flags when executing `npm install` to install dependencies on a `notion install <package>`:

* `-q`: Sets output to quiet mode, meaning only warnings and errors are shown, but not notices.
* `--no-update-notifier`: Remove the message about a new version of `npm` being available.
* `--no-audit`: Remove the package auditing, which can result in a CTA saying `run npm audit fix`, which won't work and is misleading.