### PR TITLE
Add success messages to 'notion pin' and 'notion install'

### DIFF
--- a/crates/notion-core/src/project.rs
+++ b/crates/notion-core/src/project.rs
@@ -192,10 +192,6 @@ impl Project {
             self.manifest().yarn_str().clone(),
         );
         Manifest::update_toolchain(toolchain, self.package_file())?;
-        println!(
-            "Pinned node version {} (with npm {}) in package.json",
-            node_version.runtime, node_version.npm
-        );
         Ok(())
     }
 
@@ -208,7 +204,6 @@ impl Project {
                 Some(yarn_version.to_string()),
             );
             Manifest::update_toolchain(toolchain, self.package_file())?;
-            println!("Pinned yarn version {} in package.json", yarn_version);
         } else {
             throw!(ErrorDetails::NoPinnedNodeVersion);
         }
@@ -224,7 +219,6 @@ impl Project {
                 self.manifest().yarn_str().clone(),
             );
             Manifest::update_toolchain(toolchain, self.package_file())?;
-            println!("Pinned npm version {} in package.json", npm_version);
         } else {
             throw!(ErrorDetails::NoPinnedNodeVersion);
         }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -174,16 +174,30 @@ impl Session {
     /// Fetch and unpack a version of Node matching the input requirements.
     pub fn install_node(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         let node_distro = self.fetch_node(version_spec)?.into_version();
+        let success_message = format!(
+            "Installation successful. Default node version set to {}",
+            &node_distro.runtime
+        );
         let toolchain = self.toolchain.get_mut()?;
+
         toolchain.set_active_node(node_distro)?;
+        println!("{}", success_message);
+
         Ok(())
     }
 
     /// Fetch and unpack a version of Yarn matching the input requirements.
     pub fn install_yarn(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         let yarn_distro = self.fetch_yarn(version_spec)?.into_version();
+        let success_message = format!(
+            "Installation successful. Default yarn version set to {}",
+            &yarn_distro
+        );
         let toolchain = self.toolchain.get_mut()?;
+
         toolchain.set_active_yarn(yarn_distro)?;
+        println!("{}", success_message);
+
         Ok(())
     }
 
@@ -287,6 +301,7 @@ impl Session {
         if let Some(ref project) = self.project()? {
             let node_version = self.fetch_node(version_spec)?.into_version();
             project.pin_node(&node_version)?;
+            println!("Project pinned to use node@{}", node_version.runtime);
         } else {
             throw!(ErrorDetails::NotInPackage);
         }
@@ -299,6 +314,7 @@ impl Session {
         if let Some(ref project) = self.project()? {
             let yarn_version = self.fetch_yarn(version_spec)?.into_version();
             project.pin_yarn(&yarn_version)?;
+            println!("Project pinned to use yarn@{}", yarn_version);
         } else {
             throw!(ErrorDetails::NotInPackage);
         }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -16,6 +16,7 @@ use crate::hook::{HookConfig, LazyHookConfig, Publish};
 use crate::inventory::{FetchResolve, Inventory, LazyInventory};
 use crate::platform::PlatformSpec;
 use crate::project::{LazyProject, Project};
+use crate::style::format_success_message;
 use crate::toolchain::LazyToolchain;
 use crate::version::VersionSpec;
 
@@ -174,14 +175,11 @@ impl Session {
     /// Fetch and unpack a version of Node matching the input requirements.
     pub fn install_node(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         let node_distro = self.fetch_node(version_spec)?.into_version();
-        let success_message = format!(
-            "Installation successful. Default node version set to {}",
-            &node_distro.runtime
-        );
+        let success_message = format!("installed and set node@{} as default", &node_distro.runtime);
         let toolchain = self.toolchain.get_mut()?;
 
         toolchain.set_active_node(node_distro)?;
-        println!("{}", success_message);
+        println!("{}", format_success_message(success_message));
 
         Ok(())
     }
@@ -189,14 +187,11 @@ impl Session {
     /// Fetch and unpack a version of Yarn matching the input requirements.
     pub fn install_yarn(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         let yarn_distro = self.fetch_yarn(version_spec)?.into_version();
-        let success_message = format!(
-            "Installation successful. Default yarn version set to {}",
-            &yarn_distro
-        );
+        let success_message = format!("installed and set yarn@{} as default", &yarn_distro);
         let toolchain = self.toolchain.get_mut()?;
 
         toolchain.set_active_yarn(yarn_distro)?;
-        println!("{}", success_message);
+        println!("{}", format_success_message(success_message));
 
         Ok(())
     }
@@ -301,7 +296,11 @@ impl Session {
         if let Some(ref project) = self.project()? {
             let node_version = self.fetch_node(version_spec)?.into_version();
             project.pin_node(&node_version)?;
-            println!("Project pinned to use node@{}", node_version.runtime);
+            println!(
+                "{}{}",
+                format_success_message("project pinned to use node@"),
+                node_version.runtime
+            );
         } else {
             throw!(ErrorDetails::NotInPackage);
         }
@@ -314,7 +313,11 @@ impl Session {
         if let Some(ref project) = self.project()? {
             let yarn_version = self.fetch_yarn(version_spec)?.into_version();
             project.pin_yarn(&yarn_version)?;
-            println!("Project pinned to use yarn@{}", yarn_version);
+            println!(
+                "{}{}",
+                format_success_message("project pinned to use yarn@"),
+                yarn_version
+            );
         } else {
             throw!(ErrorDetails::NotInPackage);
         }

--- a/crates/notion-core/src/session.rs
+++ b/crates/notion-core/src/session.rs
@@ -16,7 +16,7 @@ use crate::hook::{HookConfig, LazyHookConfig, Publish};
 use crate::inventory::{FetchResolve, Inventory, LazyInventory};
 use crate::platform::PlatformSpec;
 use crate::project::{LazyProject, Project};
-use crate::style::format_success_message;
+use crate::style::{success_prefix, tool_version};
 use crate::toolchain::LazyToolchain;
 use crate::version::VersionSpec;
 
@@ -175,11 +175,14 @@ impl Session {
     /// Fetch and unpack a version of Node matching the input requirements.
     pub fn install_node(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         let node_distro = self.fetch_node(version_spec)?.into_version();
-        let success_message = format!("installed and set node@{} as default", &node_distro.runtime);
+        let success_message = format!(
+            "installed and set {} as default",
+            tool_version("node", &node_distro.runtime)
+        );
         let toolchain = self.toolchain.get_mut()?;
 
         toolchain.set_active_node(node_distro)?;
-        println!("{}", format_success_message(success_message));
+        println!("{} {}", success_prefix(), success_message);
 
         Ok(())
     }
@@ -187,11 +190,14 @@ impl Session {
     /// Fetch and unpack a version of Yarn matching the input requirements.
     pub fn install_yarn(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         let yarn_distro = self.fetch_yarn(version_spec)?.into_version();
-        let success_message = format!("installed and set yarn@{} as default", &yarn_distro);
+        let success_message = format!(
+            "installed and set {} as default",
+            tool_version("yarn", &yarn_distro)
+        );
         let toolchain = self.toolchain.get_mut()?;
 
         toolchain.set_active_yarn(yarn_distro)?;
-        println!("{}", format_success_message(success_message));
+        println!("{} {}", success_prefix(), success_message);
 
         Ok(())
     }
@@ -297,9 +303,10 @@ impl Session {
             let node_version = self.fetch_node(version_spec)?.into_version();
             project.pin_node(&node_version)?;
             println!(
-                "{}{}",
-                format_success_message("project pinned to use node@"),
-                node_version.runtime
+                "{} pinned {} (with {}) in package.json",
+                success_prefix(),
+                tool_version("node", node_version.runtime),
+                tool_version("npm", node_version.npm),
             );
         } else {
             throw!(ErrorDetails::NotInPackage);
@@ -314,9 +321,9 @@ impl Session {
             let yarn_version = self.fetch_yarn(version_spec)?.into_version();
             project.pin_yarn(&yarn_version)?;
             println!(
-                "{}{}",
-                format_success_message("project pinned to use yarn@"),
-                yarn_version
+                "{} pinned {} in package.json",
+                success_prefix(),
+                tool_version("yarn", yarn_version)
             );
         } else {
             throw!(ErrorDetails::NotInPackage);
@@ -335,6 +342,11 @@ impl Session {
                 .resolve("npm", version_spec, hooks.package.as_ref())?
                 .version;
             project.pin_npm(&npm_version)?;
+            println!(
+                "{} pinned {} in package.json",
+                success_prefix(),
+                tool_version("npm", npm_version)
+            );
         } else {
             throw!(ErrorDetails::NotInPackage);
         }

--- a/crates/notion-core/src/style.rs
+++ b/crates/notion-core/src/style.rs
@@ -18,12 +18,9 @@ Please feel free to reach out to us at \x1b[36m\x1b[1m@notionjs\x1b[0m on Twitte
     \x1b[1mhttps://github.com/notion-cli/notion/issues\x1b[0m
 ";
 
-/// Format a success message for output
-pub(crate) fn format_success_message<S>(msg: S) -> String
-where
-    S: AsRef<str>,
-{
-    format!("{} {}", style("success:").green().bold(), msg.as_ref())
+/// Generate the styled prefix for a success message
+pub(crate) fn success_prefix() -> StyledObject<&'static str> {
+    style("success:").green().bold()
 }
 
 /// Format an error for output in the given context

--- a/crates/notion-core/src/style.rs
+++ b/crates/notion-core/src/style.rs
@@ -18,6 +18,14 @@ Please feel free to reach out to us at \x1b[36m\x1b[1m@notionjs\x1b[0m on Twitte
     \x1b[1mhttps://github.com/notion-cli/notion/issues\x1b[0m
 ";
 
+/// Format a success message for output
+pub(crate) fn format_success_message<S>(msg: S) -> String
+where
+    S: AsRef<str>,
+{
+    format!("{} {}", style("success:").green().bold(), msg.as_ref())
+}
+
 /// Format an error for output in the given context
 pub(crate) fn format_error_message(cx: ErrorContext, err: &NotionError) -> String {
     let prefix = error_prefix(cx);

--- a/tests/acceptance/notion_pin.rs
+++ b/tests/acceptance/notion_pin.rs
@@ -205,9 +205,7 @@ fn pin_node() {
         s.notion("pin node 6"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains(
-                "Pinned node version 6.19.62 (with npm 3.10.1066) in package.json"
-            )
+            .with_stdout_contains("[..]pinned node@6.19.62 (with npm@3.10.1066) in package.json")
     );
 
     assert_eq!(
@@ -228,9 +226,7 @@ fn pin_node_latest() {
         s.notion("pin node latest"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains(
-                "Pinned node version 10.99.1040 (with npm 6.2.26) in package.json"
-            )
+            .with_stdout_contains("[..]pinned node@10.99.1040 (with npm@6.2.26) in package.json")
     );
 
     assert_eq!(
@@ -251,9 +247,7 @@ fn pin_node_no_version() {
         s.notion("pin node"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains(
-                "Pinned node version 10.99.1040 (with npm 6.2.26) in package.json"
-            )
+            .with_stdout_contains("[..]pinned node@10.99.1040 (with npm@6.2.26) in package.json")
     );
 
     assert_eq!(
@@ -275,7 +269,7 @@ fn pin_node_removes_npm() {
         s.notion("pin node 8"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("Pinned node version 8.9.10 (with npm 5.6.7) in package.json")
+            .with_stdout_contains("[..]pinned node@8.9.10 (with npm@5.6.7) in package.json")
     );
 
     assert_eq!(
@@ -316,7 +310,7 @@ fn pin_yarn() {
         s.notion("pin yarn 1.4"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("Pinned yarn version 1.4.159 in package.json")
+            .with_stdout_contains("[..]pinned yarn@1.4.159 in package.json")
     );
 
     assert_eq!(
@@ -337,7 +331,7 @@ fn pin_yarn_latest() {
         s.notion("pin yarn latest"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("Pinned yarn version 1.2.42 in package.json")
+            .with_stdout_contains("[..]pinned yarn@1.2.42 in package.json")
     );
 
     assert_eq!(
@@ -358,7 +352,7 @@ fn pin_yarn_no_version() {
         s.notion("pin yarn"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("Pinned yarn version 1.2.42 in package.json")
+            .with_stdout_contains("[..]pinned yarn@1.2.42 in package.json")
     );
 
     assert_eq!(
@@ -399,7 +393,7 @@ fn pin_yarn_leaves_npm() {
         s.notion("pin yarn 1.4"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("Pinned yarn version 1.4.159 in package.json")
+            .with_stdout_contains("[..]pinned yarn@1.4.159 in package.json")
     );
 
     assert_eq!(
@@ -421,7 +415,7 @@ fn pin_npm() {
         s.notion("pin npm 5.10"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("Pinned npm version 5.10.12 in package.json")
+            .with_stdout_contains("pinned npm@5.10.12 in package.json")
     );
 
     assert_eq!(


### PR DESCRIPTION
Closes #357 

Adds a success message to `notion install node`, `notion install yarn`, `notion pin node`, and `notion pin yarn`, so that the user is informed of success, instead of leaving the terminal completely blank.