### PR TITLE
Make two small cleanups in package install logic.

### DIFF
--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -362,17 +362,9 @@ impl PackageVersion {
         let image = platform.checkout(session)?;
         // use yarn if it is installed, otherwise default to npm
         let mut install_cmd = if image.yarn.is_some() {
-            install_command_for(
-                Installer::Yarn,
-                &self.image_dir.clone().into_os_string(),
-                &image.path()?,
-            )
+            install_command_for(Installer::Yarn, self.image_dir.as_os_str(), &image.path()?)
         } else {
-            install_command_for(
-                Installer::Npm,
-                &self.image_dir.clone().into_os_string(),
-                &image.path()?,
-            )
+            install_command_for(Installer::Npm, self.image_dir.as_os_str(), &image.path()?)
         };
 
         let output = install_cmd

--- a/crates/notion-core/src/distro/package.rs
+++ b/crates/notion-core/src/distro/package.rs
@@ -361,13 +361,13 @@ impl PackageVersion {
     pub fn install(&self, platform: &PlatformSpec, session: &mut Session) -> Fallible<()> {
         let image = platform.checkout(session)?;
         // use yarn if it is installed, otherwise default to npm
-        let mut install_cmd = if image.yarn.is_some() {
-            install_command_for(Installer::Yarn, self.image_dir.as_os_str(), &image.path()?)
+        let installer = if image.yarn.is_some() {
+            Installer::Yarn
         } else {
-            install_command_for(Installer::Npm, self.image_dir.as_os_str(), &image.path()?)
+            Installer::Npm
         };
 
-        let output = install_cmd
+        let output = install_command_for(installer, self.image_dir.as_os_str(), &image.path()?)
             .output()
             .with_context(|_| ErrorDetails::PackageInstallFailed)?;
 


### PR DESCRIPTION
- Drop an allocation by using `self.image_dir.as_os_str()` instead of `&self.image_dir.clone().into_os_string()`
- Simplify the logic by distinguishing *only* the installer, since the rest of the `install_command_for` invocation is identical.