### PR TITLE
Replace unimplemented macro with ErrorDetails variant

### DIFF
--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -340,6 +340,11 @@ pub enum ErrorDetails {
     /// Thrown when serializing the toolchain to JSON fails
     StringifyToolchainError,
 
+    /// Thrown when a given feature has not yet been implemented
+    Unimplemented {
+        feature: String,
+    },
+
     /// Thrown when unpacking an archive (tarball or zip) fails
     UnpackArchiveError {
         tool: String,
@@ -758,6 +763,7 @@ at {}
             ErrorDetails::StringifyToolchainError => write!(f, "Could not serialize toolchain settings.
 
 {}", REPORT_BUG_CTA),
+            ErrorDetails::Unimplemented { feature } => write!(f, "{} is not supported yet.", feature),
             ErrorDetails::UnpackArchiveError { tool, version } => write!(f, "Could not unpack {} v{}
 
 Please ensure the correct version is specified.", tool, version),
@@ -902,6 +908,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::StringifyPackageConfigError => ExitCode::UnknownError,
             ErrorDetails::StringifyPlatformError => ExitCode::UnknownError,
             ErrorDetails::StringifyToolchainError => ExitCode::UnknownError,
+            ErrorDetails::Unimplemented { .. } => ExitCode::UnknownError,
             ErrorDetails::UnpackArchiveError { .. } => ExitCode::UnknownError,
             ErrorDetails::UnrecognizedShell { .. } => ExitCode::EnvironmentError,
             ErrorDetails::UnspecifiedPostscript => ExitCode::EnvironmentError,

--- a/crates/notion-core/src/event.rs
+++ b/crates/notion-core/src/event.rs
@@ -128,6 +128,7 @@ impl EventLog {
 
     pub fn publish(&mut self, plugin: Option<&Publish>) {
         match plugin {
+            // Note: This call to unimplemented is left in, as it's not a Fallible operation that can use ErrorDetails::Unimplemented
             Some(&Publish::Url(_)) => unimplemented!(),
             Some(&Publish::Bin(ref command)) => {
                 let mut monitor = Monitor::new(command);

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -10,7 +10,7 @@ use std::process::{Command, ExitStatus};
 use lazy_static::lazy_static;
 use regex::Regex;
 
-use notion_fail::{Fallible, ResultExt};
+use notion_fail::{throw, Fallible, ResultExt};
 use validate_npm_package_name::{validate, Validity};
 
 use crate::command::create_command;
@@ -69,21 +69,29 @@ impl ToolSpec {
         match self {
             ToolSpec::Node(version) => session.install_node(&version)?,
             // ISSUE(#292): Implement install for npm
-            ToolSpec::Npm(_version) => unimplemented!("Installing npm is not supported yet"),
+            ToolSpec::Npm(_version) => throw!(ErrorDetails::Unimplemented {
+                feature: "Installing npm".into()
+            }),
             ToolSpec::Yarn(version) => session.install_yarn(&version)?,
             ToolSpec::Package(name, version) => {
                 session.install_package(name.to_string(), &version)?;
             }
-        }
+        };
         Ok(())
     }
 
     pub fn uninstall(&self, session: &mut Session) -> Fallible<()> {
         match self {
-            ToolSpec::Node(_version) => unimplemented!("Uninstalling Node not supported yet"),
+            ToolSpec::Node(_version) => throw!(ErrorDetails::Unimplemented {
+                feature: "Uninstalling node".into()
+            }),
             // ISSUE(#292): Implement install for npm
-            ToolSpec::Npm(_version) => unimplemented!("Uninstalling Npm not supported yet"),
-            ToolSpec::Yarn(_version) => unimplemented!("Uninstalling Yarn not supported yet"),
+            ToolSpec::Npm(_version) => throw!(ErrorDetails::Unimplemented {
+                feature: "Uninstalling npm".into()
+            }),
+            ToolSpec::Yarn(_version) => throw!(ErrorDetails::Unimplemented {
+                feature: "Uninstalling yarn".into()
+            }),
             ToolSpec::Package(name, _version) => {
                 session.uninstall_package(name.to_string())?;
             }

--- a/src/command/activate.rs
+++ b/src/command/activate.rs
@@ -1,5 +1,6 @@
 use structopt::StructOpt;
 
+use notion_core::error::ErrorDetails;
 use notion_core::platform::System;
 use notion_core::session::{ActivityKind, Session};
 use notion_core::shell::{CurrentShell, Postscript, Shell};
@@ -15,10 +16,13 @@ impl Command for Activate {
         session.add_event_start(ActivityKind::Activate);
         let shell = CurrentShell::detect()?;
 
-        let postscript = match System::enabled_path()?.into_string() {
-            Ok(path) => Postscript::Activate(path),
-            Err(_) => unimplemented!(),
-        };
+        let path =
+            System::enabled_path()?
+                .into_string()
+                .map_err(|_| ErrorDetails::Unimplemented {
+                    feature: "notion activate".into(),
+                })?;
+        let postscript = Postscript::Activate(path);
 
         shell.save_postscript(&postscript)?;
         session.add_event_end(ActivityKind::Activate, ExitCode::Success);

--- a/src/command/deactivate.rs
+++ b/src/command/deactivate.rs
@@ -1,5 +1,6 @@
 use structopt::StructOpt;
 
+use notion_core::error::ErrorDetails;
 use notion_core::platform::System;
 use notion_core::session::{ActivityKind, Session};
 use notion_core::shell::{CurrentShell, Postscript, Shell};
@@ -15,10 +16,12 @@ impl Command for Deactivate {
         session.add_event_start(ActivityKind::Deactivate);
         let shell = CurrentShell::detect()?;
 
-        let postscript = match System::path()?.into_string() {
-            Ok(path) => Postscript::Deactivate(path),
-            Err(_) => unimplemented!(),
-        };
+        let path = System::path()?
+            .into_string()
+            .map_err(|_| ErrorDetails::Unimplemented {
+                feature: "notion deactivate".into(),
+            })?;
+        let postscript = Postscript::Deactivate(path);
 
         shell.save_postscript(&postscript)?;
         session.add_event_end(ActivityKind::Deactivate, ExitCode::Success);

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -1,8 +1,9 @@
 use structopt::StructOpt;
 
+use notion_core::error::ErrorDetails;
 use notion_core::session::{ActivityKind, Session};
 use notion_core::tool::ToolSpec;
-use notion_fail::{ExitCode, Fallible};
+use notion_fail::{throw, ExitCode, Fallible};
 
 use crate::command::Command;
 
@@ -33,7 +34,9 @@ impl Command for Fetch {
                 }
                 ToolSpec::Npm(_version) => {
                     // ISSUE(#292): Implement install for npm
-                    unimplemented!("Fetching npm is not supported yet");
+                    throw!(ErrorDetails::Unimplemented {
+                        feature: "Fetching npm".into()
+                    });
                 }
                 ToolSpec::Package(name, version) => {
                     session.fetch_package(&name, &version)?;

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -29,7 +29,9 @@ impl Command for Pin {
                 ToolSpec::Node(version) => session.pin_node(&version)?,
                 ToolSpec::Yarn(version) => session.pin_yarn(&version)?,
                 // ISSUE(#292): Implement install for npm
-                ToolSpec::Npm(_version) => unimplemented!("Pinning npm is not supported yet"),
+                ToolSpec::Npm(_version) => throw!(ErrorDetails::Unimplemented {
+                    feature: "Pinning npm".into()
+                }),
                 ToolSpec::Package(name, _version) => {
                     throw!(ErrorDetails::CannotPinPackage { package: name })
                 }


### PR DESCRIPTION
Closes #359 

Replace uses of the `unimplemented!` macro with returning an `ErrorDetails::Unimplemented` error. The macro causes a panic, which is a jarring experience for the user, compared with our usual well-formatted errors. Instead of panicking in most cases, we can instead return an error that displays the same message using our existing error reporting mechanisms.

There are two cases where `unimplemented!` is still being used: Inside of `event.rs`, where it is part of an operation that isn't `Fallible` (and also isn't currently used), and inside of `windows.rs`, where it is simply a placeholder for when we compile with `universal-docs` and won't ever actually be run.