### PR TITLE
Show specific error for nonexistent package

### DIFF
--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -186,6 +186,11 @@ pub enum ErrorDetails {
         from_url: String,
     },
 
+    /// Thrown when a specified package could not be found on the npm registry
+    PackageNotFound {
+        package: String,
+    },
+
     /// Thrown when parsing a package manifest fails
     PackageParseError {
         file: String,
@@ -569,7 +574,7 @@ Please ensure the directory is available."),
             ErrorDetails::NoPackageExecutables => {
                 write!(f, "Package has no executables to install.
 
-Please verify the intended package name.")
+Please verify the requested package name.")
             }
             ErrorDetails::NoPinnedNodeVersion => write!(
                 f,
@@ -620,6 +625,9 @@ from {}
 Please verify your internet connection.",
                 from_url
             ),
+            ErrorDetails::PackageNotFound { package } => write!(f, "Could not find package '{}'
+
+Please verify the requested package name.", package),
             ErrorDetails::PackageParseError { file } => {
                 write!(f, "Could not parse project manifest
 at {}
@@ -866,6 +874,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::NpxNotAvailable { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::PackageInstallFailed => ExitCode::FileSystemError,
             ErrorDetails::PackageMetadataFetchError { .. } => ExitCode::NetworkError,
+            ErrorDetails::PackageNotFound { .. } => ExitCode::InvalidArguments,
             ErrorDetails::PackageParseError { .. } => ExitCode::ConfigurationError,
             ErrorDetails::PackageReadError { .. } => ExitCode::FileSystemError,
             ErrorDetails::PackageUnpackError => ExitCode::ConfigurationError,


### PR DESCRIPTION
Closes #361 

Add a specific error message for the case when a user runs `notion install <package>` with a package name that doesn't exist in the npm registry. Before this change, we were showing a less-accurate `Could not parse package metadata` error, instead of telling the user that the package could not be found.