### PR TITLE
Provide informative error for `notion <action> <tool> <version-like>`.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
         }
       },
       "program": "${cargo:program}",
-      "args": ["fetch", "2bar"],
+      "args": [],
       "sourceLanguages": ["rust"]
     },
     {

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -549,7 +549,7 @@ Please ensure that the command output is valid UTF-8 text.", command),
                 );
 
                 let call_to_action = format!(
-"To install '{name}' version '{version}', please run `notion {action} {formatted}`. \
+"To {action} '{name}' version '{version}', please run `notion {action} {formatted}`. \
 To {action} the packages '{name}' and '{version}', please {action} them in separate commands, or with explicit versions.",
                     action=action,
                     name=name,

--- a/crates/notion-core/src/error/details.rs
+++ b/crates/notion-core/src/error/details.rs
@@ -5,7 +5,7 @@ use textwrap::{fill, indent};
 
 use notion_fail::{ExitCode, NotionFail};
 
-use crate::style::display_width;
+use crate::style::{text_width, tool_version};
 use crate::tool::ToolSpec;
 
 const REPORT_BUG_CTA: &'static str =
@@ -16,7 +16,7 @@ an issue at https://github.com/notion-cli/notion/issues with the details!";
 const PERMISSIONS_CTA: &'static str =
     "Please ensure you have correct permissions to the Notion directory.";
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Fail, PartialEq)]
 pub enum ErrorDetails {
     /// Thrown when package tries to install a binary that is already installed.
     BinaryAlreadyInstalled {
@@ -127,6 +127,14 @@ pub enum ErrorDetails {
     /// Thrown when output from a hook command could not be read
     InvalidHookOutput {
         command: String,
+    },
+
+    /// Thrown when a user does e.g. `notion install node 12` instead of
+    /// `notion install node@12`.
+    InvalidInvocation {
+        action: String,
+        name: String,
+        version: String,
     },
 
     /// Thrown when a tool name is invalid per npm's rules.
@@ -531,9 +539,30 @@ Please ensure that the correct command is specified.", command),
             ErrorDetails::InvalidHookOutput { command } => write!(f, "Could not read output from hook command: '{}'
 
 Please ensure that the command output is valid UTF-8 text.", command),
+
+            ErrorDetails::InvalidInvocation { action, name, version } => {
+                let error = format!(
+                    "`notion {action} {name} {version}` is not supported.",
+                    action=action,
+                    name=name,
+                    version=version
+                );
+
+                let call_to_action = format!(
+"To install '{name}' version '{version}', please run `notion {action} {formatted}`. \
+To {action} the packages '{name}' and '{version}', please {action} them in separate commands, or with explicit versions.",
+                    action=action,
+                    name=name,
+                    version=version,
+                    formatted=tool_version(name, version)
+                );
+
+                write!(f, "{}\n\n{}", error, fill(&call_to_action, text_width()))
+            },
+
             ErrorDetails::InvalidToolName { name, errors } => {
                 let indentation = "    ";
-                let wrapped = &fill(&errors.join("\n"), display_width() - indentation.len());
+                let wrapped = &fill(&errors.join("\n"), text_width() - indentation.len());
                 let formatted_errs = indent(&wrapped, indentation);
 
                 let call_to_action = if errors.len() > 1 {
@@ -542,11 +571,9 @@ Please ensure that the command output is valid UTF-8 text.", command),
                     "Please fix the following error:"
                 };
 
-                write!(f, "Invalid tool name `{}`
-
-{}
-{}", name, call_to_action, formatted_errs)
+                write!(f, "Invalid tool name `{}`\n\n{}\n{}", name, call_to_action, formatted_errs)
             },
+
             ErrorDetails::NoBinPlatform { binary } => {
                 write!(f, "Platform info for executable `{}` is missing
 
@@ -863,6 +890,7 @@ impl NotionFail for ErrorDetails {
             ErrorDetails::HookNoFieldsSpecified => ExitCode::ConfigurationError,
             ErrorDetails::InvalidHookCommand { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::InvalidHookOutput { .. } => ExitCode::ExecutionFailure,
+            ErrorDetails::InvalidInvocation { .. } => ExitCode::InvalidArguments,
             ErrorDetails::InvalidToolName { .. } => ExitCode::InvalidArguments,
             ErrorDetails::NoBinPlatform { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::NodeVersionNotFound { .. } => ExitCode::NoVersionMatch,

--- a/crates/notion-core/src/style.rs
+++ b/crates/notion-core/src/style.rs
@@ -82,6 +82,10 @@ pub fn display_width() -> usize {
     term_size::dimensions().map(|(w, _)| w).unwrap_or(80)
 }
 
+pub fn text_width() -> usize {
+    display_width().min(80)
+}
+
 /// Constructs a command-line progress bar based on the specified Origin enum
 /// (e.g., `Origin::Remote`), details string (e.g., `"v1.23.4"`), and logical
 /// length (i.e., the number of logical progress steps in the process being

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -160,9 +160,6 @@ impl ToolSpec {
     }
 
     /// Check the args for the bad pattern of `notion install <tool> <number>`.
-    ///
-    /// Requires you to pass *all* args. Should only be called from commands
-    /// like `notion install`, `notion fetch`, or `notion pin`.
     fn check_args<T>(args: &mut [T], action: &str) -> Fallible<()>
     where
         T: AsRef<str>,

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -531,34 +531,47 @@ mod tests {
         #[test]
         fn leaves_other_scenarios_alone() {
             let mut empty: Vec<&str> = Vec::new();
-            assert!(
-                ToolSpec::from_strings(&mut empty, PIN).is_ok(),
+            assert_eq!(
+                ToolSpec::from_strings(&mut empty, PIN)
+                    .expect("is ok")
+                    .len(),
+                empty.len(),
                 "when there are no args"
             );
 
-            assert!(
-                ToolSpec::from_strings(&mut ["node".to_owned()], PIN).is_ok(),
+            let mut only_one = ["node".to_owned()];
+            assert_eq!(
+                ToolSpec::from_strings(&mut only_one, PIN)
+                    .expect("is ok")
+                    .len(),
+                only_one.len(),
                 "when there is only one arg"
             );
 
-            assert!(
-                ToolSpec::from_strings(&mut ["12".to_owned(), "node".to_owned()], PIN.into())
-                    .is_ok(),
+            let mut two_but_unmistakable = ["12".to_owned(), "node".to_owned()];
+            assert_eq!(
+                ToolSpec::from_strings(&mut two_but_unmistakable, PIN.into())
+                    .expect("is ok")
+                    .len(),
+                two_but_unmistakable.len(),
                 "when there are two args but the order is not likely to be a mistake"
             );
 
-            assert!(
-                ToolSpec::from_strings(&mut ["node@lts".to_owned(), "12".to_owned()], PIN.into())
-                    .is_ok(),
+            let mut two_but_valid_first = ["node@lts".to_owned(), "12".to_owned()];
+            assert_eq!(
+                ToolSpec::from_strings(&mut two_but_valid_first, PIN.into())
+                    .expect("is ok")
+                    .len(),
+                two_but_valid_first.len(),
                 "when there are two args but the first is a valid tool spec"
             );
 
-            assert!(
-                ToolSpec::from_strings(
-                    &mut ["node".to_owned(), "12".to_owned(), "yarn".to_owned(),],
-                    PIN.into()
-                )
-                .is_ok(),
+            let mut more_than_two_tools = ["node".to_owned(), "12".to_owned(), "yarn".to_owned()];
+            assert_eq!(
+                ToolSpec::from_strings(&mut more_than_two_tools, PIN.into())
+                    .expect("is ok")
+                    .len(),
+                more_than_two_tools.len(),
                 "when there are more than two args"
             );
         }

--- a/crates/notion-core/src/tool/mod.rs
+++ b/crates/notion-core/src/tool/mod.rs
@@ -553,7 +553,7 @@ mod tests {
             assert!(
                 ToolSpec::from_strings(&mut ["node@lts".to_owned(), "12".to_owned()], PIN.into())
                     .is_ok(),
-                "when the there are two args but the first is a valid tool spec"
+                "when there are two args but the first is a valid tool spec"
             );
 
             assert!(
@@ -562,7 +562,7 @@ mod tests {
                     PIN.into()
                 )
                 .is_ok(),
-                "when the there are more than two args"
+                "when there are more than two args"
             );
         }
     }

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -22,6 +22,7 @@ pub(crate) struct Fetch {
 impl Command for Fetch {
     fn run(mut self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Fetch);
+        ToolSpec::check_args(std::env::args(), "fetch".into())?;
 
         self.tools.sort();
         for tool in self.tools {

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -10,22 +10,15 @@ use crate::command::Command;
 #[derive(StructOpt)]
 pub(crate) struct Fetch {
     /// Tools to fetch, like `node`, `yarn@latest` or `your-package@^14.4.3`.
-    #[structopt(
-        name = "tool[@version]",
-        required = true,
-        min_values = 1,
-        parse(try_from_str = "ToolSpec::try_from_str")
-    )]
-    tools: Vec<ToolSpec>,
+    #[structopt(name = "tool[@version]", required = true, min_values = 1)]
+    tools: Vec<String>,
 }
 
 impl Command for Fetch {
     fn run(mut self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Fetch);
-        ToolSpec::check_args(std::env::args(), "fetch".into())?;
 
-        self.tools.sort();
-        for tool in self.tools {
+        for tool in ToolSpec::from_strings(&mut self.tools, "fetch")? {
             match tool {
                 ToolSpec::Node(version) => {
                     session.fetch_node(&version)?;

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -21,6 +21,7 @@ pub(crate) struct Install {
 impl Command for Install {
     fn run(mut self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Install);
+        ToolSpec::check_args(std::env::args(), "install".into())?;
 
         self.tools.sort();
         for tool in self.tools {

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -9,22 +9,15 @@ use crate::command::Command;
 #[derive(StructOpt)]
 pub(crate) struct Install {
     /// Tools to install, like `node`, `yarn@latest` or `your-package@^14.4.3`.
-    #[structopt(
-        name = "tool[@version]",
-        required = true,
-        min_values = 1,
-        parse(try_from_str = "ToolSpec::try_from_str")
-    )]
-    tools: Vec<ToolSpec>,
+    #[structopt(name = "tool[@version]", required = true, min_values = 1)]
+    tools: Vec<String>,
 }
 
 impl Command for Install {
     fn run(mut self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Install);
-        ToolSpec::check_args(std::env::args(), "install".into())?;
 
-        self.tools.sort();
-        for tool in self.tools {
+        for tool in ToolSpec::from_strings(&mut self.tools, "install")? {
             tool.install(session)?;
         }
 

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -22,6 +22,7 @@ pub(crate) struct Pin {
 impl Command for Pin {
     fn run(mut self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Pin);
+        ToolSpec::check_args(std::env::args(), "pin".into())?;
 
         self.tools.sort();
         for tool in self.tools {

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -10,22 +10,15 @@ use crate::command::Command;
 #[derive(StructOpt)]
 pub(crate) struct Pin {
     /// Tools to pin, like `node@lts` or `yarn@^1.14`.
-    #[structopt(
-        name = "tool[@version]",
-        required = true,
-        min_values = 1,
-        parse(try_from_str = "ToolSpec::try_from_str")
-    )]
-    tools: Vec<ToolSpec>,
+    #[structopt(name = "tool[@version]", required = true, min_values = 1)]
+    tools: Vec<String>,
 }
 
 impl Command for Pin {
     fn run(mut self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Pin);
-        ToolSpec::check_args(std::env::args(), "pin".into())?;
 
-        self.tools.sort();
-        for tool in self.tools {
+        for tool in ToolSpec::from_strings(&mut self.tools, "pin")? {
             match tool {
                 ToolSpec::Node(version) => session.pin_node(&version)?,
                 ToolSpec::Yarn(version) => session.pin_yarn(&version)?,


### PR DESCRIPTION
Users coming from tools like `nvm` or `nodenv` or other ecosystems may expect `notion install node 10` to install Node v10. Since it will instead install `node@lts` and `10@latest` -- and the package `10` [does indeed exist!][10] -- provide an error message when Notion detects that this scenario has occurred.

[10]: https://www.npmjs.com/package/10