### PR TITLE
Use 'volta' instead of 'toolchain' for package.json config

### DIFF
--- a/crates/volta-core/fixtures/basic/package.json
+++ b/crates/volta-core/fixtures/basic/package.json
@@ -11,7 +11,7 @@
     "@namespaced/something-else": "^6.3.7",
     "eslint": "~4.8.0"
   },
-  "toolchain": {
+  "volta": {
     "node": "6.11.1",
     "npm": "3.10.10",
     "yarn": "1.2.0"

--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod serial;
 
 /// A Node manifest file.
 pub struct Manifest {
-    /// The platform image specified by the `toolchain` section.
+    /// The platform image specified by the `volta` section.
     pub platform: Option<Rc<PlatformSpec>>,
     /// The `dependencies` section.
     pub dependencies: HashMap<String, String>,
@@ -85,7 +85,7 @@ impl Manifest {
             .and_then(|t| t.yarn.as_ref().map(|yarn| yarn.to_string()))
     }
 
-    /// Writes the input ToolchainManifest to package.json, adding the "toolchain" key if
+    /// Writes the input ToolchainManifest to package.json, adding the "volta" key if
     /// necessary.
     pub fn update_toolchain(
         toolchain: serial::ToolchainSpec,
@@ -105,10 +105,10 @@ impl Manifest {
             // detect indentation in package.json
             let indent = detect_indent::detect_indent(&contents);
 
-            // update the "toolchain" key
+            // update the "volta" key
             let toolchain_value = serde_json::to_value(toolchain)
                 .with_context(|_| ErrorDetails::StringifyToolchainError)?;
-            map.insert("toolchain".to_string(), toolchain_value);
+            map.insert("volta".to_string(), toolchain_value);
 
             // serialize the updated contents back to package.json
             let file = File::create(&package_file)

--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -53,6 +53,7 @@ pub struct Manifest {
     #[serde(rename = "devDependencies")]
     pub dev_dependencies: HashMap<String, String>,
 
+    #[serde(rename = "volta")]
     pub toolchain: Option<ToolchainSpec>,
 
     // the "bin" field can be a map or a string
@@ -255,7 +256,7 @@ pub mod tests {
             "description": "This is a description",
             "dependencies": { "something": "1.2.3" },
             "devDependencies": { "somethingElse": "1.2.3" },
-            "toolchain": {
+            "volta": {
                 "node": "0.10.5",
                 "npm": "1.2.18",
                 "yarn": "1.2.1"
@@ -330,18 +331,18 @@ pub mod tests {
     #[test]
     fn test_package_toolchain() {
         let package_empty_toolchain = r#"{
-            "toolchain": {
+            "volta": {
             }
         }"#;
         let manifest_empty_toolchain =
             serde_json::de::from_str::<Manifest>(package_empty_toolchain);
         assert!(
             manifest_empty_toolchain.is_err(),
-            "Node must be defined in the 'toolchain'"
+            "Node must be defined under the 'volta' key"
         );
 
         let package_node_only = r#"{
-            "toolchain": {
+            "volta": {
                 "node": "0.11.4"
             }
         }"#;
@@ -350,7 +351,7 @@ pub mod tests {
         assert_eq!(manifest_node_only.toolchain.unwrap().node, "0.11.4");
 
         let package_node_npm = r#"{
-            "toolchain": {
+            "volta": {
                 "node": "0.10.5",
                 "npm": "1.2.18"
             }
@@ -364,18 +365,18 @@ pub mod tests {
         assert_eq!(toolchain_node_npm.npm.unwrap(), "1.2.18");
 
         let package_yarn_only = r#"{
-            "toolchain": {
+            "volta": {
                 "yarn": "1.2.1"
             }
         }"#;
         let manifest_yarn_only = serde_json::de::from_str::<Manifest>(package_yarn_only);
         assert!(
             manifest_yarn_only.is_err(),
-            "Node must be defined in the 'toolchain'"
+            "Node must be defined under the 'volta' key"
         );
 
         let package_node_and_yarn = r#"{
-            "toolchain": {
+            "volta": {
                 "node": "0.10.5",
                 "npm": "1.2.18",
                 "yarn": "1.2.1"

--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -172,7 +172,7 @@ impl Project {
         path
     }
 
-    /// Writes the specified version of Node to the `toolchain.node` key in package.json.
+    /// Writes the specified version of Node to the `volta.node` key in package.json.
     pub fn pin_node(&self, node_version: &NodeVersion) -> Fallible<()> {
         // prevent writing the npm version if it is equal to the default version
 
@@ -195,7 +195,7 @@ impl Project {
         Ok(())
     }
 
-    /// Writes the specified version of Yarn to the `toolchain.yarn` key in package.json.
+    /// Writes the specified version of Yarn to the `volta.yarn` key in package.json.
     pub fn pin_yarn(&self, yarn_version: &Version) -> Fallible<()> {
         if let Some(platform) = self.manifest().platform() {
             let toolchain = serial::ToolchainSpec::new(
@@ -210,7 +210,7 @@ impl Project {
         Ok(())
     }
 
-    /// Writes the specified version of Npm to the `toolchain.npm` key in package.json.
+    /// Writes the specified version of Npm to the `volta.npm` key in package.json.
     pub fn pin_npm(&self, npm_version: &Version) -> Fallible<()> {
         if let Some(platform) = self.manifest().platform() {
             let toolchain = serial::ToolchainSpec::new(

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -296,7 +296,7 @@ impl Session {
             .fetch(name, version_spec, hooks.package.as_ref())
     }
 
-    /// Updates toolchain in package.json with the Node version matching the specified semantic
+    /// Updates 'volta' in package.json with the Node version matching the specified semantic
     /// versioning requirements.
     pub fn pin_node(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         if let Some(ref project) = self.project()? {
@@ -314,7 +314,7 @@ impl Session {
         Ok(())
     }
 
-    /// Updates toolchain in package.json with the Yarn version matching the specified semantic
+    /// Updates 'volta' in package.json with the Yarn version matching the specified semantic
     /// versioning requirements.
     pub fn pin_yarn(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         if let Some(ref project) = self.project()? {
@@ -331,7 +331,7 @@ impl Session {
         Ok(())
     }
 
-    /// Updates toolchain in package.json with the Npm version matching the specified semantic
+    /// Updates 'volta' in package.json with the Npm version matching the specified semantic
     /// versioning requirements.
     pub fn pin_npm(&mut self, version_spec: &VersionSpec) -> Fallible<()> {
         if let Some(ref project) = self.project()? {

--- a/dev/package.json
+++ b/dev/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "ember-cli": "2.18.1"
   },
-  "toolchain": {
+  "volta": {
     "node": "6.11.1",
     "yarn": "1.7.0"
   }

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -8,7 +8,7 @@ use volta_fail::ExitCode;
 
 const PACKAGE_JSON: &'static str = r#"{
     "name": "text-package",
-    "toolchain": {
+    "volta": {
         "node": "10.22.123",
         "yarn": "4.55.633"
     }

--- a/tests/acceptance/volta_current.rs
+++ b/tests/acceptance/volta_current.rs
@@ -13,7 +13,7 @@ fn package_json_with_pinned_node(node: &str, npm: &str) -> String {
     format!(
         r#"{{
   "name": "test-package",
-  "toolchain": {{
+  "volta": {{
     "node": "{}",
     "npm": "{}"
   }}

--- a/tests/acceptance/volta_pin.rs
+++ b/tests/acceptance/volta_pin.rs
@@ -13,7 +13,7 @@ fn package_json_with_pinned_node(node: &str) -> String {
     format!(
         r#"{{
   "name": "test-package",
-  "toolchain": {{
+  "volta": {{
     "node": "{}"
   }}
 }}"#,
@@ -25,7 +25,7 @@ fn package_json_with_pinned_node_npm(node: &str, npm: &str) -> String {
     format!(
         r#"{{
   "name": "test-package",
-  "toolchain": {{
+  "volta": {{
     "node": "{}",
     "npm": "{}"
   }}
@@ -38,7 +38,7 @@ fn package_json_with_pinned_node_yarn(node_version: &str, yarn_version: &str) ->
     format!(
         r#"{{
   "name": "test-package",
-  "toolchain": {{
+  "volta": {{
     "node": "{}",
     "yarn": "{}"
   }}
@@ -55,7 +55,7 @@ fn package_json_with_pinned_node_npm_yarn(
     format!(
         r#"{{
   "name": "test-package",
-  "toolchain": {{
+  "volta": {{
     "node": "{}",
     "npm": "{}",
     "yarn": "{}"

--- a/tests/smoke/autodownload.rs
+++ b/tests/smoke/autodownload.rs
@@ -9,7 +9,7 @@ fn package_json_with_pinned_node_npm(version: &str, npm_version: &str) -> String
     format!(
         r#"{{
   "name": "test-package",
-  "toolchain": {{
+  "volta": {{
     "node": "{}",
     "npm": "{}"
   }}
@@ -26,7 +26,7 @@ fn package_json_with_pinned_node_npm_yarn(
     format!(
         r#"{{
   "name": "test-package",
-  "toolchain": {{
+  "volta": {{
     "node": "{}",
     "npm": "{}",
     "yarn": "{}"

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -42,7 +42,7 @@
 
         <Package Id='*'
             Keywords='Installer'
-            Description='The Hassle-Free JavaScript Toolchain Manager'
+            Description='The JavaScript Launcher'
             Manufacturer='The Volta Maintainers'
             InstallerVersion='450'
             Languages='1033'


### PR DESCRIPTION
Closes #412 

Info
-----
* As discussed in the issue, we want to use a more discoverable and tool-specific key `volta` in `package.json` instead of the generic `toolchain`.
* The concept is still the `toolchain` internally, so we only want to change how it is serialized and deserialized, not how the internal code references that value.

Changes
-----
* Added a serde rename attribute to the `toolchain` element in `manifest::serial::Manifest`
* Updated `volta pin` logic to use `volta` instead of `toolchain` as the key.
* Changed comments around `volta pin` methods to refer to the `volta` key.
* Updated all test fixtures to use `volta` in their `package.json` values.

Notes
-----
* I also updated the description in `main.wxs` to match the new slogan "The JavaScript Launcher", discovered when searching through the project for uses of `toolchain`.