### PR TITLE
Improve 'NoPlatform' error message

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -707,10 +707,11 @@ Use `volta pin node` to pin Node first, then pin a Yarn version."
             ),
             ErrorDetails::NoPlatform => write!(
                 f,
-                "Could not determine Node version.
+                "Node is not available.
 
-Use `volta pin node` to select a version for a project.
-Use `volta install node` to select a default version."
+To run any Node command, first set a project or default version.
+  - Use `volta pin node` to select a version for a project.
+  - Use `volta install node` to select a default version."
             ),
             ErrorDetails::NoProjectYarn => write!(
                 f,

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -709,9 +709,7 @@ Use `volta pin node` to pin Node first, then pin a Yarn version."
                 f,
                 "Node is not available.
 
-To run any Node command, first set a project or default version.
-  - Use `volta pin node` to select a version for a project.
-  - Use `volta install node` to select a default version."
+To run any Node command, first set a default version using `volta install node`"
             ),
             ErrorDetails::NoProjectYarn => write!(
                 f,


### PR DESCRIPTION
Closes #363 

Updated error message for the `NoPlatform` case (when `node` is not set in either the project nor the user platform) to be less confusing and give a stronger CTA.