### PR TITLE
which: look up user tools, including in projects.

### DIFF
--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -53,7 +53,7 @@ impl Command for Which {
         // Treat any error with obtaining the current platform image as if the image doesn't exist
         // However, errors in obtaining the current working directory or the System path should
         // still be treated as errors.
-        let mut default_path = match session
+        let path = match session
             .current_platform()
             .unwrap_or(None)
             .and_then(|platform| platform.checkout(session).ok())
@@ -61,14 +61,6 @@ impl Command for Which {
         {
             Some(path) => path,
             None => System::path()?,
-        };
-
-        let path = match tool_path {
-            Some(tool_path) => {
-                default_path.push(tool_path.as_os_str());
-                default_path
-            }
-            None => default_path,
         };
 
         let cwd = env::current_dir().with_context(|_| ErrorDetails::CurrentDirError)?;

--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -23,7 +23,6 @@ impl Command for Which {
         // Treat any error with obtaining the current platform image as if the image doesn't exist
         // However, errors in obtaining the current working directory or the System path should
         // still be treated as errors.
-        let cwd = env::current_dir().with_context(|_| ErrorDetails::CurrentDirError)?;
         let path = match session
             .current_platform()
             .unwrap_or(None)
@@ -34,20 +33,21 @@ impl Command for Which {
             None => System::path()?,
         };
 
-        match which_in(&self.binary, Some(path), cwd) {
+        let cwd = env::current_dir().with_context(|_| ErrorDetails::CurrentDirError)?;
+        let exit_code = match which_in(&self.binary, Some(path), cwd) {
             Ok(result) => {
                 println!("{}", result.to_string_lossy());
-                session.add_event_end(ActivityKind::Which, ExitCode::Success);
-
-                Ok(ExitCode::Success)
+                ExitCode::Success
             }
             Err(_) => {
                 // `which_in` Will return an Err if it can't find the binary in the path
                 // In that case, we don't want to print anything out, but we want to return
                 // Exit Code 1 (ExitCode::UnknownError)
-                session.add_event_end(ActivityKind::Which, ExitCode::UnknownError);
-                Ok(ExitCode::UnknownError)
+                ExitCode::UnknownError
             }
-        }
+        };
+
+        session.add_event_end(ActivityKind::Which, exit_code);
+        Ok(exit_code)
     }
 }

--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -37,7 +37,7 @@ impl Command for Which {
                 });
 
         let tool_path = match (user_tool, project_bin_path) {
-            (Some(_), Some(project_path)) => Some(project_path),
+            (Some(_), Some(project_bin_dir)) => Some(project_bin_dir.join(&bin)),
             (Some(tool), _) => Some(tool.bin_path),
             _ => None,
         };

--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsString;
 
 use structopt::StructOpt;
 use which::which_in;
@@ -17,13 +18,42 @@ pub(crate) struct Which {
 }
 
 impl Command for Which {
+    // 1. Start by checking if the user has a tool installed in the project or
+    //    as a user default. If so, we're done.
+    // 2. Otherwise, use the platform image and/or the system environment to
+    //    determine a lookup path to run `which` in.
     fn run(self, session: &mut Session) -> Fallible<ExitCode> {
         session.add_event_start(ActivityKind::Which);
+
+        let bin = OsString::from(self.binary.as_str());
+
+        let user_tool = session.get_user_tool(&bin)?;
+        let project_bin_path =
+            session
+                .project()?
+                .and_then(|project| match project.has_direct_bin(&bin) {
+                    Ok(true) => Some(project.local_bin_dir()),
+                    _ => None,
+                });
+
+        let tool_path = match (user_tool, project_bin_path) {
+            (Some(_), Some(project_path)) => Some(project_path),
+            (Some(tool), _) => Some(tool.bin_path),
+            _ => None,
+        };
+
+        if let Some(path) = tool_path {
+            println!("{}", path.to_string_lossy());
+
+            let exit_code = ExitCode::Success;
+            session.add_event_end(ActivityKind::Which, exit_code);
+            return Ok(exit_code);
+        }
 
         // Treat any error with obtaining the current platform image as if the image doesn't exist
         // However, errors in obtaining the current working directory or the System path should
         // still be treated as errors.
-        let path = match session
+        let mut default_path = match session
             .current_platform()
             .unwrap_or(None)
             .and_then(|platform| platform.checkout(session).ok())
@@ -33,8 +63,16 @@ impl Command for Which {
             None => System::path()?,
         };
 
+        let path = match tool_path {
+            Some(tool_path) => {
+                default_path.push(tool_path.as_os_str());
+                default_path
+            }
+            None => default_path,
+        };
+
         let cwd = env::current_dir().with_context(|_| ErrorDetails::CurrentDirError)?;
-        let exit_code = match which_in(&self.binary, Some(path), cwd) {
+        let exit_code = match which_in(&bin, Some(path), cwd) {
             Ok(result) => {
                 println!("{}", result.to_string_lossy());
                 ExitCode::Success


### PR DESCRIPTION
- Fixes #391.
- Includes some cleanup of the existing `which` code.