### PR TITLE
Don't parse dependencies when locating a local binary

### DIFF
--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -1,7 +1,6 @@
 //! Provides the `Project` type, which represents a Node project tree in
 //! the filesystem.
 
-use std::collections::HashMap;
 use std::env;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -11,8 +10,10 @@ use lazycell::LazyCell;
 use semver::Version;
 
 use crate::distro::node::{load_default_npm_version, NodeVersion};
+use crate::distro::package::BinConfig;
 use crate::error::ErrorDetails;
 use crate::manifest::{serial, Manifest};
+use crate::path;
 use crate::platform::PlatformSpec;
 use volta_fail::{throw, Fallible, ResultExt};
 
@@ -30,24 +31,6 @@ fn is_dependency(dir: &Path) -> bool {
 
 fn is_project_root(dir: &Path) -> bool {
     is_node_root(dir) && !is_dependency(dir)
-}
-
-pub struct LazyDependentBins {
-    bins: LazyCell<HashMap<String, String>>,
-}
-
-impl LazyDependentBins {
-    /// Constructs a new `LazyDependentBins`.
-    pub fn new() -> LazyDependentBins {
-        LazyDependentBins {
-            bins: LazyCell::new(),
-        }
-    }
-
-    /// Forces creating the dependent bins and returns an immutable reference to it.
-    pub fn get(&self, project: &Project) -> Fallible<&HashMap<String, String>> {
-        self.bins.try_borrow_with(|| project.dependent_binaries())
-    }
 }
 
 /// A lazily loaded Project
@@ -74,7 +57,6 @@ impl LazyProject {
 pub struct Project {
     manifest: Manifest,
     project_root: PathBuf,
-    dependent_bins: LazyDependentBins,
 }
 
 impl Project {
@@ -101,7 +83,6 @@ impl Project {
         Ok(Some(Rc::new(Project {
             manifest: Manifest::for_dir(&dir)?,
             project_root: PathBuf::from(dir),
-            dependent_bins: LazyDependentBins::new(),
         })))
     }
 
@@ -133,43 +114,19 @@ impl Project {
 
     /// Returns true if the input binary name is a direct dependency of the input project
     pub fn has_direct_bin(&self, bin_name: &OsStr) -> Fallible<bool> {
-        let dep_bins = self.dependent_bins.get(&self)?;
-        if let Some(bin_name_str) = bin_name.to_str() {
-            if dep_bins.contains_key(bin_name_str) {
-                return Ok(true);
+        if let Some(name) = bin_name.to_str() {
+            let config_path = path::user_tool_bin_config(name)?;
+            if config_path.exists() {
+                let config = BinConfig::from_file(config_path)?;
+                return Ok(self.has_direct_dependency(&config.package));
             }
         }
         Ok(false)
     }
 
-    /// Returns a mapping of the names to paths for all the binaries installed
-    /// by direct dependencies of the current project.
-    fn dependent_binaries(&self) -> Fallible<HashMap<String, String>> {
-        let mut dependent_bins = HashMap::new();
-        let all_deps = Manifest::for_dir(&self.project_root)?.merged_dependencies();
-        let all_dep_paths = all_deps.iter().map(|name| self.get_dependency_path(name));
-
-        // use those project paths to get the "bin" info for each project
-        for pkg_path in all_dep_paths {
-            let pkg_info =
-                Manifest::for_dir(&pkg_path).with_context(|_| ErrorDetails::DepPackageReadError)?;
-            let bin_map = pkg_info.bin;
-            for (name, path) in bin_map.iter() {
-                dependent_bins.insert(name.clone(), path.clone());
-            }
-        }
-        Ok(dependent_bins)
-    }
-
-    /// Convert dependency names to the path to each project.
-    fn get_dependency_path(&self, name: &String) -> PathBuf {
-        // ISSUE(158): Add support for Yarn Plug'n'Play.
-        let mut path = PathBuf::from(&self.project_root);
-
-        path.push("node_modules");
-        path.push(name);
-
-        path
+    pub fn has_direct_dependency(&self, dependency: &str) -> bool {
+        self.manifest.dependencies.contains_key(dependency)
+            || self.manifest.dev_dependencies.contains_key(dependency)
     }
 
     /// Writes the specified version of Node to the `volta.node` key in package.json.
@@ -230,8 +187,6 @@ impl Project {
 
 #[cfg(test)]
 pub mod tests {
-    use std::collections::HashMap;
-    use std::ffi::OsStr;
     use std::path::PathBuf;
 
     use crate::project::Project;
@@ -244,52 +199,21 @@ pub mod tests {
     }
 
     #[test]
-    fn gets_binary_info() {
-        let project_path = fixture_path("basic");
-        let test_project = Project::for_dir(&project_path).unwrap().unwrap();
-
-        let dep_bins = test_project
-            .dependent_binaries()
-            .expect("Could not get dependent binaries");
-        let mut expected_bins = HashMap::new();
-        expected_bins.insert("eslint".to_string(), "./bin/eslint.js".to_string());
-        expected_bins.insert("rsvp".to_string(), "./bin/rsvp.js".to_string());
-        expected_bins.insert("bin-1".to_string(), "./lib/cli.js".to_string());
-        expected_bins.insert("bin-2".to_string(), "./lib/cli.js".to_string());
-        assert_eq!(dep_bins, expected_bins);
-    }
-
-    #[test]
-    fn local_bin_true() {
+    fn direct_dependency_true() {
         let project_path = fixture_path("basic");
         let test_project = Project::for_dir(&project_path).unwrap().unwrap();
         // eslint, rsvp, bin-1, and bin-2 are direct dependencies
-        assert!(test_project.has_direct_bin(&OsStr::new("eslint")).unwrap());
-        assert!(test_project.has_direct_bin(&OsStr::new("rsvp")).unwrap());
-        assert!(test_project.has_direct_bin(&OsStr::new("bin-1")).unwrap());
-        assert!(test_project.has_direct_bin(&OsStr::new("bin-2")).unwrap());
+        assert!(test_project.has_direct_dependency("eslint"));
+        assert!(test_project.has_direct_dependency("rsvp"));
+        assert!(test_project.has_direct_dependency("@namespace/some-dep"));
+        assert!(test_project.has_direct_dependency("@namespaced/something-else"));
     }
 
     #[test]
-    fn local_bin_false() {
+    fn direct_dependency_false() {
         let project_path = fixture_path("basic");
         let test_project = Project::for_dir(&project_path).unwrap().unwrap();
         // tsc and tsserver are installed, but not direct deps
-        assert!(!test_project.has_direct_bin(&OsStr::new("tsc")).unwrap());
-        assert!(!test_project
-            .has_direct_bin(&OsStr::new("tsserver"))
-            .unwrap());
-    }
-
-    #[test]
-    fn maps_dependency_paths() {
-        let project_path = fixture_path("basic");
-        let test_project = Project::for_dir(&project_path).unwrap().unwrap();
-        let mut expected_path = PathBuf::from(project_path);
-
-        expected_path.push("node_modules");
-        expected_path.push("foo");
-
-        assert!(test_project.get_dependency_path(&"foo".to_string()) == expected_path);
+        assert!(!test_project.has_direct_dependency("typescript"));
     }
 }

--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -124,7 +124,7 @@ impl Project {
         Ok(false)
     }
 
-    pub fn has_direct_dependency(&self, dependency: &str) -> bool {
+    fn has_direct_dependency(&self, dependency: &str) -> bool {
         self.manifest.dependencies.contains_key(dependency)
             || self.manifest.dev_dependencies.contains_key(dependency)
     }


### PR DESCRIPTION
Closes #393 

Info
-----
As noted in the issue, we are currently parsing all of the dependency `package.json` files to find which `bins` are local, direct dependencies. However, since we have implemented `volta install <package>`, we have a bin config file that can tell us which package a binary came from.

Changes
-----
* Updated `Project::has_direct_bin` to read the `BinConfig` file and then check that the `package` for that bin is declared in the current project's `dependencies` or `devDependencies`, bypassing the need to parse all of the dependencies directly.
* Removed the `LazyDependentBins` struct and all of the code around generating that HashMap, since we don't use it anymore.