### PR TITLE
Tools: better message for intercepted global installs.

### DIFF
--- a/crates/volta-core/src/event.rs
+++ b/crates/volta-core/src/event.rs
@@ -164,7 +164,7 @@ pub mod tests {
         assert_eq!(event_log.events.len(), 3);
         assert_eq!(event_log.events[2].name, "version");
 
-        let error = ErrorDetails::NoGlobalInstalls.into();
+        let error = ErrorDetails::NoGlobalInstalls { package: None }.into();
         event_log.add_event_error(ActivityKind::Install, &error);
         assert_eq!(event_log.events.len(), 4);
         assert_eq!(event_log.events[3].name, "install");

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -34,6 +34,14 @@ lazy_static! {
     static ref HAS_VERSION: Regex = Regex::new(r"^[^\s]+@").expect("regex is valid");
 }
 
+/// Distinguish global `add` commands in npm or yarn from all others.
+enum CommandArg {
+    /// The command is a *global* add command.
+    GlobalAdd(Option<OsString>),
+    /// The command is a local, i.e. non-global, add command.
+    NotGlobalAdd,
+}
+
 /// Specification for a tool and its associated version.
 ///
 /// Since [`Ord`] is implemented for `ToolSpec`, we can use `.sort` on any

--- a/crates/volta-core/src/tool/npm.rs
+++ b/crates/volta-core/src/tool/npm.rs
@@ -1,7 +1,7 @@
 use std::env::args_os;
 use std::ffi::{OsStr, OsString};
 
-use super::{intercept_global_installs, ToolCommand};
+use super::{intercept_global_installs, CommandArg, ToolCommand};
 use crate::error::ErrorDetails;
 use crate::session::{ActivityKind, Session};
 
@@ -15,8 +15,10 @@ where
 
     match session.current_platform()? {
         Some(ref platform) => {
-            if intercept_global_installs() && is_global_npm_install() {
-                throw!(ErrorDetails::NoGlobalInstalls);
+            if intercept_global_installs() {
+                if let CommandArg::GlobalAdd(package) = check_npm_install() {
+                    throw!(ErrorDetails::NoGlobalInstalls { package });
+                }
             }
             let image = platform.checkout(session)?;
             let path = image.path()?;
@@ -26,25 +28,33 @@ where
     }
 }
 
-fn is_global_npm_install() -> bool {
-    let command = args_os()
-        .skip(1)
-        .skip_while(|arg| match arg.to_str() {
-            Some(arg) => arg.starts_with("-"),
-            None => false,
-        })
-        .next();
+fn check_npm_install() -> CommandArg {
+    // npm global installs will have `-g` or `--global` somewhere in the
+    // argument list
+    let is_global =
+        args_os().any(|arg| arg == OsString::from("-g") || arg == OsString::from("--global"));
 
-    // npm global installs will have the command `i`, `install`, `add` or `isntall`
+    // Get the same set of args again to iterate over, this time with the
+    // command itself skipped and all flags excluded entirely. The first item
+    // in that skipped, filter iterator is the command itself.
+    let mut args = args_os().skip(1).filter(|arg| match arg.to_str() {
+        Some(arg) => !arg.starts_with("-"),
+        None => true,
+    });
+    let command = args.next();
+
+    // They will be specified by the command `i`, `install`, `add` or `isntall`.
     // See https://github.com/npm/cli/blob/latest/lib/config/cmd-list.js
-    // Additionally, they will have `-g` or `--global` somewhere in the argument list
-    if command == Some(OsString::from("install"))
+    let is_install = command == Some(OsString::from("install"))
         || command == Some(OsString::from("i"))
         || command == Some(OsString::from("isntall"))
-        || command == Some(OsString::from("add"))
-    {
-        args_os().any(|arg| arg == OsString::from("-g") || arg == OsString::from("--global"))
+        || command == Some(OsString::from("add"));
+
+    if is_global && is_install {
+        // `args` here picks up from where the command lookup left off, so
+        // will be the name of the package passed to the command.
+        CommandArg::GlobalAdd(args.next())
     } else {
-        false
+        CommandArg::NotGlobalAdd
     }
 }

--- a/crates/volta-core/src/tool/npm.rs
+++ b/crates/volta-core/src/tool/npm.rs
@@ -31,8 +31,9 @@ where
 fn check_npm_install() -> CommandArg {
     // npm global installs will have `-g` or `--global` somewhere in the
     // argument list
-    let is_global =
-        args_os().any(|arg| arg == OsString::from("-g") || arg == OsString::from("--global"));
+    if !args_os().any(|arg| arg == OsString::from("-g") || arg == OsString::from("--global")) {
+        return CommandArg::NotGlobalAdd;
+    }
 
     // Get the same set of args again to iterate over, this time with the
     // command itself skipped and all flags excluded entirely. The first item
@@ -45,12 +46,11 @@ fn check_npm_install() -> CommandArg {
 
     // They will be specified by the command `i`, `install`, `add` or `isntall`.
     // See https://github.com/npm/cli/blob/latest/lib/config/cmd-list.js
-    let is_install = command == Some(OsString::from("install"))
+    if command == Some(OsString::from("install"))
         || command == Some(OsString::from("i"))
         || command == Some(OsString::from("isntall"))
-        || command == Some(OsString::from("add"));
-
-    if is_global && is_install {
+        || command == Some(OsString::from("add"))
+    {
         // `args` here picks up from where the command lookup left off, so
         // will be the name of the package passed to the command.
         CommandArg::GlobalAdd(args.next())

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -22,49 +22,49 @@ fn npm_prevents_global_install() {
         s.npm("install ember-cli --global"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.npm("i ember-cli --global"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.npm("install ember-cli -g"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.npm("i -g ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.npm("-g i ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.npm("add ember-cli --global"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.npm("isntall --global ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 }
 
@@ -80,7 +80,7 @@ fn npm_allows_global_install_with_env_variable() {
         s.npm("i -g ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_does_not_contain("[..]Global package installs are not recommended.")
+            .with_stderr_does_not_contain("[..]Global package installs are not supported.")
             .with_stderr_contains("[..]Could not download node version[..]")
     );
 }
@@ -93,21 +93,21 @@ fn yarn_prevents_global_add() {
         s.yarn("global add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.yarn("--verbose global add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 
     assert_that!(
         s.yarn("global --verbose add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_contains("[..]Global package installs are not recommended.")
+            .with_stderr_contains("[..]Global package installs are not supported.")
     );
 }
 
@@ -123,7 +123,7 @@ fn yarn_allows_global_add_with_env_variable() {
         s.yarn("global add ember-cli"),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
-            .with_stderr_does_not_contain("[..]Global package installs are not recommended.")
+            .with_stderr_does_not_contain("[..]Global package installs are not supported.")
             .with_stderr_contains("[..]Could not download node version[..]")
     );
 }


### PR DESCRIPTION
Fixes #360

<details>
<summary>
output for <code>yarn global add</code> and <code>npm -g, --global install</code> (all variations)
</summary>

```
$ yarn global add waffles
Volta error: Global package installs are not supported.

Use `volta install waffles` to add a package to your toolchain (see `volta help install` for more info).

$ yarn global add
Volta error: Global package installs are not supported.

Use `volta install` to add a package to your toolchain (see `volta help install` for more info).

$ npm i -g waffles
Volta error: Global package installs are not supported.

Use `volta install waffles` to add a package to your toolchain (see `volta help install` for more info).

$ npm add -g waffles
Volta error: Global package installs are not supported.

Use `volta install waffles` to add a package to your toolchain (see `volta help install` for more info).

$ npm add waffles --global
Volta error: Global package installs are not supported.

Use `volta install waffles` to add a package to your toolchain (see `volta help install` for more info).

$ npm isntall --global
Volta error: Global package installs are not supported.

Use `volta install` to add a package to your toolchain (see `volta help install` for more info).
```

</details>