### PR TITLE
Cleanup: remove extraneous `println!()`.

### DIFF
--- a/crates/volta-core/src/inventory/serial.rs
+++ b/crates/volta-core/src/inventory/serial.rs
@@ -166,7 +166,6 @@ impl YarnEntry {
     /// proper release tarball?
     fn is_full_release(&self) -> bool {
         let release_filename = &format!("yarn-v{}.tar.gz", self.tag_name)[..];
-        println!("checking release filename: {}", release_filename);
         self.assets
             .iter()
             .any(|&YarnAsset { ref name }| name == release_filename)


### PR DESCRIPTION
Fixes an issue internal testing at LI identified. (I don't see a good test to write here because it's a *negative* test.)