### PR TITLE
Remove unnecessary use statements

### DIFF
--- a/crates/volta-core/src/shim.rs
+++ b/crates/volta-core/src/shim.rs
@@ -119,11 +119,10 @@ pub fn delete(shim_name: &str) -> Fallible<ShimResult> {
 /// This bash script simply calls the shim using `cmd.exe`, so that it is resolved correctly
 #[cfg(windows)]
 mod windows {
-    use crate::error::{Context, ErrorKind, Fallible, VoltaError};
+    use crate::error::{Context, ErrorKind, Fallible};
     use crate::fs::remove_file_if_exists;
     use crate::layout::volta_home;
-    use std::fs::{remove_file, write};
-    use std::io;
+    use std::fs::write;
 
     const BASH_SCRIPT: &str = r#"cmd //C $0 "$@""#;
 


### PR DESCRIPTION
Windows builds were showing warnings for unused imports. Removing the now-unnecessary imports from the Windows side to remove those warnings.