### PR TITLE
Add OpenSSL 3 build to dependencies for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
     needs:
       - centos
       - linux
+      - linux-ssl-3
       - macos
       - macos-aarch64
       - windows


### PR DESCRIPTION
Info
-----
* While waiting for the release job to run, I noticed that the dependencies weren't properly set up.
* The "Publish release" job wasn't set up to require the OpenSSL 3 build to complete.
* Luckily, this didn't cause a problem because the OpenSSL 3 build is faster than any of the other builds, but we should have it set up properly regardless.

Changes
-----
* Added the `linux-ssl-3` job to the list of dependencies for the Publish release job