### PR TITLE
fix: filter lines with VOLTA_HOME during setup

### DIFF
--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -183,7 +183,7 @@ If you run into problems running Volta, create {} and run `volta setup` again.",
         reader
             .lines()
             .filter(|line_result| match line_result {
-                Ok(line) if !line.contains("VOLTA") => true,
+                Ok(line) if !line.contains("VOLTA_HOME") => true,
                 Ok(_) => false,
                 Err(_) => true,
             })


### PR DESCRIPTION
If `$VOLTA_HOME` is not set or `$VOLTA_HOME/bin` is not in `$PATH`, Volta removes lines containing `VOLTA` from shell profile script. But `VOLTA` is too generic and it filters lines that shouldn't have been removed.

This PR uses the less generic `VOLTA_HOME` to avoid removing unwanted lines.