### PR TITLE
Implements `VOLTA_FEATURE_YARN=0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,7 +1657,7 @@ dependencies = [
  "volta-core",
  "volta-migrate",
  "which",
- "winreg",
+ "winreg 0.53.0",
 ]
 
 [[package]]
@@ -1701,7 +1701,7 @@ dependencies = [
  "volta-layout",
  "walkdir",
  "which",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2013,6 +2013,16 @@ checksum = "89a47b489f8fc5b949477e89dca4d1617f162c6c53fbcbefde553ab17b342ff9"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/volta-core/src/lib.rs
+++ b/crates/volta-core/src/lib.rs
@@ -1,5 +1,7 @@
 //! The main implementation crate for the core of Volta.
 
+use std::{env, ffi::OsString};
+
 mod command;
 pub mod error;
 pub mod event;
@@ -22,3 +24,8 @@ pub mod toolchain;
 pub mod version;
 
 const VOLTA_FEATURE_PNPM: &str = "VOLTA_FEATURE_PNPM";
+const VOLTA_FEATURE_YARN: &str = "VOLTA_FEATURE_YARN";
+
+pub fn is_yarn_enabled() -> bool {
+    env::var_os(VOLTA_FEATURE_YARN) != Some(OsString::from("0"))
+}

--- a/crates/volta-core/src/platform/image.rs
+++ b/crates/volta-core/src/platform/image.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use super::{build_path_error, Sourced};
 use crate::error::{Context, Fallible};
+use crate::is_yarn_enabled;
 use crate::layout::volta_home;
 use crate::tool::load_default_npm_version;
 use node_semver::Version;
@@ -34,9 +35,11 @@ impl Image {
             bins.push(home.pnpm_image_bin_dir(&pnpm_str));
         }
 
-        if let Some(yarn) = &self.yarn {
-            let yarn_str = yarn.value.to_string();
-            bins.push(home.yarn_image_bin_dir(&yarn_str));
+        if is_yarn_enabled() {
+            if let Some(yarn) = &self.yarn {
+                let yarn_str = yarn.value.to_string();
+                bins.push(home.yarn_image_bin_dir(&yarn_str));
+            }
         }
 
         // Add Node path to the bins last, so that any custom version of npm will be earlier in the PATH

--- a/crates/volta-core/src/platform/mod.rs
+++ b/crates/volta-core/src/platform/mod.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::error::{ErrorKind, Fallible};
 use crate::session::Session;
 use crate::tool::{Node, Npm, Pnpm, Yarn};
-use crate::VOLTA_FEATURE_PNPM;
+use crate::{is_yarn_enabled, VOLTA_FEATURE_PNPM};
 use node_semver::Version;
 
 mod image;
@@ -290,8 +290,10 @@ impl Platform {
             }
         }
 
-        if let Some(Sourced { value: version, .. }) = &self.yarn {
-            Yarn::new(version.clone()).ensure_fetched(session)?;
+        if is_yarn_enabled() {
+            if let Some(Sourced { value: version, .. }) = &self.yarn {
+                Yarn::new(version.clone()).ensure_fetched(session)?;
+            }
         }
 
         Ok(Image {

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -7,7 +7,7 @@ use std::process::ExitStatus;
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{CliPlatform, Image, Sourced};
 use crate::session::Session;
-use crate::VOLTA_FEATURE_PNPM;
+use crate::{is_yarn_enabled, VOLTA_FEATURE_PNPM};
 use log::debug;
 use node_semver::Version;
 
@@ -86,6 +86,7 @@ fn get_executor(
             Some("node") => node::command(args, session),
             Some("npm") => npm::command(args, session),
             Some("npx") => npx::command(args, session),
+
             Some("pnpm") => {
                 // If the pnpm feature flag variable is set, delegate to the pnpm handler
                 // If not, use the binary handler as a fallback (prior to pnpm support, installing
@@ -96,7 +97,17 @@ fn get_executor(
                     binary::command(exe, args, session)
                 }
             }
-            Some("yarn") | Some("yarnpkg") => yarn::command(args, session),
+
+            Some("yarn") | Some("yarnpkg") => {
+                println!("is_yarn_enabled: {:?}", is_yarn_enabled());
+                if is_yarn_enabled() {
+                    yarn::command(args, session)
+                } else {
+                    println!("using binary");
+                    binary::command(exe, args, session)
+                }
+            }
+
             _ => binary::command(exe, args, session),
         }
     }

--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -19,20 +19,18 @@ use crate::session::{ActivityKind, Session};
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
     session.add_event_start(ActivityKind::Yarn);
     // Don't re-evaluate the context or global install interception if this is a recursive call
-
-    let platform = if env::var_os(RECURSION_ENV_VAR).is_some() {
-        None
-    } else if env::var_os("VOLTA_SKIP_YARN") {
-        None
-    } else {
-        if let CommandArg::Global(cmd) = CommandArg::for_yarn(args) {
-            // For globals, only intercept if the default platform exists
-            if let Some(default_platform) = session.default_platform()? {
-                return cmd.executor(default_platform);
+    let platform = match env::var_os(RECURSION_ENV_VAR) {
+        Some(_) => None,
+        None => {
+            if let CommandArg::Global(cmd) = CommandArg::for_yarn(args) {
+                // For globals, only intercept if the default platform exists
+                if let Some(default_platform) = session.default_platform()? {
+                    return cmd.executor(default_platform);
+                }
             }
-        }
 
-        Platform::current(session)?
+            Platform::current(session)?
+        }
     };
 
     Ok(ToolCommand::new("yarn", args, platform, ToolKind::Yarn).into())

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -8,7 +8,7 @@ use crate::session::Session;
 use crate::style::{note_prefix, success_prefix, tool_version};
 use crate::sync::VoltaLock;
 use crate::version::VersionSpec;
-use crate::VOLTA_FEATURE_PNPM;
+use crate::{is_yarn_enabled, VOLTA_FEATURE_PNPM};
 use cfg_if::cfg_if;
 use log::{debug, info};
 
@@ -104,8 +104,13 @@ impl Spec {
                 }
             }
             Spec::Yarn(version) => {
-                let version = yarn::resolve(version, session)?;
-                Ok(Box::new(Yarn::new(version)))
+                if is_yarn_enabled() {
+                    let version = yarn::resolve(version, session)?;
+                    Ok(Box::new(Yarn::new(version)))
+                } else {
+                    let package = Package::new("yarn".to_owned(), version)?;
+                    Ok(Box::new(package))
+                }
             }
             // When using global package install, we allow the package manager to perform the version resolution
             Spec::Package(name, version) => {


### PR DESCRIPTION
I'm implementing a version manager for Yarn, and Volta gets in the way: every call to `node` corrupts the PATH by shadowing the existing `yarn` binary.

In theory Volta should be smarter and only update the PATH for binaries it's sure to own (see https://github.com/volta-cli/volta/issues/2053), but in practice this is likely to be a significant change and I doubt we have the bandwidth to land this kind of change medium term.

Instead, this PR implements a `VOLTA_FEATURE_YARN=0` environment variable that, when set, will prevent Volta from shadowing the Yarn binary.  Any wrapper meant to own the management of Yarn releases can then set this variable.