### PR TITLE
feat: added node nightly version support #1419

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,7 +1657,7 @@ dependencies = [
  "volta-core",
  "volta-migrate",
  "which",
- "winreg",
+ "winreg 0.53.0",
 ]
 
 [[package]]
@@ -1701,7 +1701,7 @@ dependencies = [
  "volta-layout",
  "walkdir",
  "which",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2013,6 +2013,16 @@ checksum = "89a47b489f8fc5b949477e89dca4d1617f162c6c53fbcbefde553ab17b342ff9"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -6,7 +6,7 @@ use crate::command::Command;
 
 #[derive(clap::Args)]
 pub(crate) struct Fetch {
-    /// Tools to fetch, like `node`, `yarn@latest` or `your-package@^14.4.3`.
+    /// Tools to fetch, like `node@nightly`, `yarn@latest` or `your-package@^14.4.3`.
     #[arg(value_name = "tool[@version]", required = true)]
     tools: Vec<String>,
 }

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -6,7 +6,7 @@ use crate::command::Command;
 
 #[derive(clap::Args)]
 pub(crate) struct Install {
-    /// Tools to install, like `node`, `yarn@latest` or `your-package@^14.4.3`.
+    /// Tools to install, like `node@nightly`, `yarn@latest` or `your-package@^14.4.3`.
     #[arg(value_name = "tool[@version]", required = true)]
     tools: Vec<String>,
 }

--- a/src/command/pin.rs
+++ b/src/command/pin.rs
@@ -6,7 +6,7 @@ use crate::command::Command;
 
 #[derive(clap::Args)]
 pub(crate) struct Pin {
-    /// Tools to pin, like `node@lts` or `yarn@^1.14`.
+    /// Tools to pin, like `node@lts`, `node@nightly`, or `yarn@^1.14`.
     #[arg(value_name = "tool[@version]", required = true)]
     tools: Vec<String>,
 }


### PR DESCRIPTION
# Problem

The support for node@nightly version was missing. (as discussed in #1419 )

# Solution

  - Add node@nightly support: resolve against the Node nightly index, error only on unsupported custom
    tags, and download from the nightly base URL.
  - Detect nightly builds via pre-release naming and use /download/nightly for fetches.
  - Allow nightly as a version-like tag in CLI parsing/help text.
  - Cover with unit tests for nightly URL selection and CLI parsing.
