### PR TITLE
fix(install script)!: exit with non-zero exit code on error

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -221,15 +221,17 @@ install_version() {
       ;;
   esac
 
-  if [ "$?" == 0 ]
-  then
-      if [ "$should_run_setup" == "true" ]; then
-        info 'Finished' "installation. Updating user profile settings."
-        "$install_dir"/bin/volta setup
-      else
-        "$install_dir"/bin/volta --version &>/dev/null # creates the default shims
-        info 'Finished' "installation. No changes were made to user profile settings."
-      fi
+  local install_status="$?"
+  if [ "$install_status" -ne 0 ]; then
+    return "$install_status"
+  fi
+
+  if [ "$should_run_setup" == "true" ]; then
+    info 'Finished' "installation. Updating user profile settings."
+    "$install_dir"/bin/volta setup
+  else
+    "$install_dir"/bin/volta --version &>/dev/null # creates the default shims
+    info 'Finished' "installation. No changes were made to user profile settings."
   fi
 }
 


### PR DESCRIPTION
The install script should exit with a non-zero exit code when an error occurs during the installation. Otherwise users invoking the script can't handle the error on their end. Currently the script exits with zero exit code even when an error occurs.